### PR TITLE
Allow users to override font family and default text colors.

### DIFF
--- a/src/scss/abstracts/_colors.scss
+++ b/src/scss/abstracts/_colors.scss
@@ -90,6 +90,6 @@ $white: #ffffff;
 
 $box-shadow-default: 0 2px 0 rgba(175, 175, 175, 0.12);
 
-$text-body: cv('gray', '700');
-$text-heading: cv('gray', '900');
-$text-sub: cv('gray', '500');
+$text-body: cv('gray', '700') !default;
+$text-heading: cv('gray', '900') !default;
+$text-sub: cv('gray', '500') !default;

--- a/src/scss/abstracts/_variables.scss
+++ b/src/scss/abstracts/_variables.scss
@@ -14,7 +14,7 @@
 
 // Establish Type Scale
 
-$body-font-family: 'Proxima Nova', '-apple-system',  'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
+$body-font-family: 'Proxima Nova', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif !default;
 
 $base-font-size: 16px;
 $scale-ratio: 1.1429;


### PR DESCRIPTION
ScaleFT uses darker text for body/heading/sub. For a while we had a different font family, but now we've coalesced.

I don't think Okta products should be overriding these, but allowing overrides makes this library much more useful for 3rd parties.