### PR TITLE
Fix bug where placeholder text was styled differently in chrome vs firefox

### DIFF
--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -67,6 +67,7 @@
   }
 
   &::placeholder {
-    color: $text-sub;
+    opacity: 1;
+    color: cv('gray', '500');
   }
 }


### PR DESCRIPTION
See https://github.com/twbs/bootstrap/issues/7589 and https://github.com/twbs/bootstrap/pull/11526 for an explanation.