### PR TITLE
Don't reset styles for lists and dl/dt.

### DIFF
--- a/src/scss/base/_reset.scss
+++ b/src/scss/base/_reset.scss
@@ -72,12 +72,6 @@ b,
 u,
 i,
 center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
 fieldset,
 form,
 label,
@@ -135,11 +129,6 @@ section {
 }
 
 // Element Specific Resets
-
-ol,
-ul {
-  list-style: none;
-}
 
 blockquote,
 q {


### PR DESCRIPTION
Nim doesn't have full styling for these elements yet, so li/ul/dl/dt were all unstyled.