### PR TITLE
Don't override order for form inputs/labels/hints/errors.

### DIFF
--- a/src/scss/components/_forms.scss
+++ b/src/scss/components/_forms.scss
@@ -98,31 +98,6 @@
   display: flex;
   flex-direction: column;
   max-width: $max-line-length;
-
-  .label,
-  .input-legend {
-    order: 1;
-  }
-
-  .number-input,
-  .text-input,
-  .select-input,
-  .input--unavailable,
-  .fieldset--pair {
-    order: 3;
-  }
-
-  .input--unavailable {
-    margin: 0;
-  }
-
-  .field--hint {
-    order: 2;
-  }
-
-  .field--error {
-    order: 4;
-  }
 }
 
 .group-legend {


### PR DESCRIPTION
These order directives made it very hard to gradually adopt nim. For example: It caused labels to be put after checkboxes unless you also changed all your checkboxes to use the new styling. It also meant that hints came before inputs, which didn't make much sense for most of our hints (which are sometimes a paragraph long).