### PR TITLE
Only hide inputs with a checkbox class, not anything with a checkbox class.

### DIFF
--- a/src/scss/components/_checkbox.scss
+++ b/src/scss/components/_checkbox.scss
@@ -14,7 +14,7 @@
 
 /* stylelint-disable no-descending-specificity, max-nesting-depth */
 
-.checkbox {
+input.checkbox {
   @include is-visually-hidden;
 
   &:checked {


### PR DESCRIPTION
"checkbox" is a pretty common class name, even for non-inputs. Sometimes people have markup that looks like:

```
<div class="checkbox">
  <input type="checkbox" checked />
</div>
```

The more general rule makes it harder to adopt nim incrementally.