### PR TITLE
Clean up docs scripts

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -9,13 +9,11 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn vendor && yarn micromodal && yarn choices && yarn prism && hexo g",
-    "vendor": "mkdir -p themes/nimatron/source/js/vendor && mkdir -p themes/nimatron/source/css/vendor/",
-    "micromodal": "cp ../../node_modules/micromodal/dist/micromodal.min.js themes/nimatron/source/js/vendor/micromodal.min.js",
-    "choices": "cp ../../node_modules/choices.js/public/assets/scripts/choices.min.js themes/nimatron/source/js/vendor/choices.min.js",
-    "prism": "cp ../../node_modules/prismjs/prism.js themes/nimatron/source/js/vendor/prism.js && cp ../../node_modules/prismjs/components/prism-scss.js themes/nimatron/source/js/vendor/prism-scss.js",
-    "start": "yarn build && hexo s",
-    "test": "echo \"Tests have not been implemented for ${npm_package_name}\" && exit 0"
+    "prebuild": "./package_scripts/prebuild",
+    "build": "./package_scripts/build",
+    "prestart": "./package_scripts/prestart",
+    "start": "./package_scripts/start",
+    "test": "./package_scripts/test"
   },
   "browserslist": [
     "last 2 versions"

--- a/packages/docs/package_scripts/build
+++ b/packages/docs/package_scripts/build
@@ -1,0 +1,1 @@
+./node_modules/.bin/hexo g

--- a/packages/docs/package_scripts/prebuild
+++ b/packages/docs/package_scripts/prebuild
@@ -1,0 +1,4 @@
+mkdir -p ./themes/nimatron/source/js/vendor && mkdir -p ./themes/nimatron/source/css/vendor/;
+cp ../../node_modules/micromodal/dist/micromodal.min.js themes/nimatron/source/js/vendor/micromodal.min.js;
+cp ../../node_modules/choices.js/public/assets/scripts/choices.min.js themes/nimatron/source/js/vendor/choices.min.js;
+cp ../../node_modules/prismjs/prism.js themes/nimatron/source/js/vendor/prism.js && cp ../../node_modules/prismjs/components/prism-scss.js themes/nimatron/source/js/vendor/prism-scss.js;

--- a/packages/docs/package_scripts/prestart
+++ b/packages/docs/package_scripts/prestart
@@ -1,0 +1,1 @@
+./package_scripts/build;

--- a/packages/docs/package_scripts/start
+++ b/packages/docs/package_scripts/start
@@ -1,0 +1,1 @@
+./node_modules/.bin/hexo s

--- a/packages/docs/package_scripts/test
+++ b/packages/docs/package_scripts/test
@@ -1,0 +1,1 @@
+echo \"Tests have not been implemented for ${npm_package_name}\" && exit 0

--- a/packages/odyssey/package.json
+++ b/packages/odyssey/package.json
@@ -11,10 +11,10 @@
   "main": "src/scss/odyssey.scss",
   "style": "src/scss/odyssey.scss",
   "scripts": {
-    "prepare": "yarn build",
-    "build": "node-sass src/scss/odyssey.scss dist/odyssey.css",
-    "lint": "stylelint src/",
-    "test": "yarn lint"
+    "prepare": "./scripts/prepare",
+    "build": "./scripts/build",
+    "lint": "./scripts/prepare",
+    "test": "./scripts/test"
   },
   "devDependencies": {
     "node-sass": "^4.9.4",

--- a/packages/odyssey/scripts/build
+++ b/packages/odyssey/scripts/build
@@ -1,0 +1,1 @@
+./node_modules/.bin/node-sass src/scss/odyssey.scss dist/odyssey.css

--- a/packages/odyssey/scripts/lint
+++ b/packages/odyssey/scripts/lint
@@ -1,0 +1,1 @@
+./node_modules/.bin/stylelint src

--- a/packages/odyssey/scripts/prepare
+++ b/packages/odyssey/scripts/prepare
@@ -1,0 +1,1 @@
+./scripts/build

--- a/packages/odyssey/scripts/test
+++ b/packages/odyssey/scripts/test
@@ -1,0 +1,1 @@
+./scripts/lint


### PR DESCRIPTION
Fixes #442 

Cleans up `docs` and `odyssey` package scripts. 

**Note:** Usually I would put the scripts inside of a `scripts` directory, but unfortunately hexo reserves that directory for its own purposes. Using `package_scripts` within `packages/docs` instead.