### PR TITLE
Fixes setup script being called from an external source

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,7 +14,7 @@ else
   echo "Yarn installation failed!"
 fi
 
-cd ${OKTA_HOME}/${REPO}
+cd ${OKTA_HOME}/odyssey
 
 if ! yarn install; then
   echo "yarn install command failed! Exiting..."


### PR DESCRIPTION
### Description

- Fixes an issue when the external publish script is triggered, resulting in an incorrect `{REPO}` value.