### PR TITLE
Use independent versioning

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,8 +9,8 @@
 # Resources
 #  - [CODEOWNERS] https://help.github.com/articles/about-codeowners
 
-*       @okta/design-system
+*       @okta/eng-uicore
 
-# Require UI Core reviews for scripts
-*.js    @okta/eng-uicore
-*.sh    @okta/eng-uicore
+*.md    @okta/design-system
+*.scss  @okta/design-system
+*.html  @okta/design-system

--- a/README.md
+++ b/README.md
@@ -73,19 +73,13 @@ Before publishing a new version, ensure the following steps are performed:
 
 2. Increment the package versions following [Semantic Versioning](https://semver.org/).
 
-    ```bash
-    yarn lerna-version
-
-    # Console output will appear similar to:
-    ? Select a new version (currently 0.0.1) (Use arrow keys)
-    ❯ Patch (0.0.2)
-      Minor (0.1.0)
-      Major (1.0.0)
-      Prepatch (0.0.2-alpha.0)
-      Preminor (0.1.0-alpha.0)
-      Premajor (1.0.0-alpha.0)
-      Custom Prerelease
-      Custom Version
+    ```diff
+    {
+      "name": "@okta/odyssey",
+    -  "version": "0.1.0",
+    +  "version": "0.2.0",
+      ...
+    }
     ```
 
 3. Commit your changes and submit the `CHANGELOG` for approval. Once approved, merge into `master`.

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "independent",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "scripts": {
     "docs": "yarn --cwd packages/docs start",
-    "lerna-version": "lerna version --no-git-tag-version",
     "prelerna-publish": "lerna run build",
     "lerna-publish": "lerna publish from-package --no-push --force-publish --no-verify-access --no-verify-registry"
   },

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okta/design-docs",
   "description": "Design System Docs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "hexo": {
     "version": "3.9.0"
   },


### PR DESCRIPTION
### Description

- Updates CODEOWNERS to require DS review on `scss`, `html`, and `md` files.
    - Require `eng-uicore` review on everything else (`js`, `json`, `sh`)
- Use **independent** versioning to allow packages to publish independently.