### PR TITLE
:package: Increment version to deploy design-docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,8 +9,8 @@
 # Resources
 #  - [CODEOWNERS] https://help.github.com/articles/about-codeowners
 
-*       @okta/design-system
+*       @okta/eng-uicore
 
-# Require UI Core reviews for scripts
-*.js    @okta/eng-uicore
-*.sh    @okta/eng-uicore
+*.md    @okta/design-system
+*.scss  @okta/design-system
+*.html  @okta/design-system

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.1",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "docs": "yarn --cwd packages/docs start",
-    "lerna-version": "lerna version --no-git-tag-version",
+    "lerna-version": "lerna version --no-git-tag-version --force-publish",
     "prelerna-publish": "lerna run build",
     "lerna-publish": "lerna publish from-package --no-push --force-publish --no-verify-access --no-verify-registry"
   },

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okta/design-docs",
   "description": "Design System Docs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "hexo": {
     "version": "3.9.0"
   },
@@ -21,7 +21,7 @@
     "last 2 versions"
   ],
   "devDependencies": {
-    "@okta/odyssey": "^0.1.0",
+    "@okta/odyssey": "^0.1.1",
     "choices.js": "^9.0.1",
     "hexo": "^3.2.0",
     "hexo-autoprefixer": "^2.0.0",

--- a/packages/odyssey/package.json
+++ b/packages/odyssey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/odyssey",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Okta's design system",
   "author": "Okta, Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Description

- Increments version to`0.1.1` to deploy new design-docs package.
- Updates CODEOWNERS to require DS review on `scss`, `html`, and `md` files.
    - Require `eng-uicore` review on everything else (`js`, `json`, `sh`)