### PR TITLE
Add Changelog

### DIFF
--- a/packages/docs/.gitignore
+++ b/packages/docs/.gitignore
@@ -7,3 +7,4 @@ public/
 dist/
 .deploy*/
 vendor/
+source/getting-started/changelog.md

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -9,13 +9,15 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn vendor && yarn micromodal && yarn choices && yarn prism && hexo g",
+    "prebuild": "yarn changelog && yarn vendor && yarn micromodal && yarn choices && yarn prism",
+    "build": "hexo g",
+    "start": "yarn build && hexo s",
+    "test": "echo \"Tests have not been implemented for ${npm_package_name}\" && exit 0",
     "vendor": "mkdir -p themes/nimatron/source/js/vendor && mkdir -p themes/nimatron/source/css/vendor/",
     "micromodal": "cp ../../node_modules/micromodal/dist/micromodal.min.js themes/nimatron/source/js/vendor/micromodal.min.js",
     "choices": "cp ../../node_modules/choices.js/public/assets/scripts/choices.min.js themes/nimatron/source/js/vendor/choices.min.js",
     "prism": "cp ../../node_modules/prismjs/prism.js themes/nimatron/source/js/vendor/prism.js && cp ../../node_modules/prismjs/components/prism-scss.js themes/nimatron/source/js/vendor/prism-scss.js",
-    "start": "yarn build && hexo s",
-    "test": "echo \"Tests have not been implemented for ${npm_package_name}\" && exit 0"
+    "changelog": "cp ../odyssey/CHANGELOG.md ./source/getting-started/changelog.md"
   },
   "browserslist": [
     "last 2 versions"

--- a/packages/docs/source/_data/nav.yml
+++ b/packages/docs/source/_data/nav.yml
@@ -3,6 +3,7 @@
 
 'getting started':
   'UI status': '/getting-started/status.html'
+  'Changelog': '/getting-started/changelog.html'
 
 'building blocks':
   'color': '/building-blocks/color.html'

--- a/packages/docs/source/getting-started/status.md
+++ b/packages/docs/source/getting-started/status.md
@@ -127,10 +127,10 @@
           Select
         </th>
         <td>
-          In Progress
+          Beta
         </td>
         <td>
-          In Progress
+          Beta
         </td>
         <td>
           -
@@ -144,10 +144,10 @@
           Table
         </th>
         <td>
-          In Progress
+          Beta
         </td>
         <td>
-          In Progress
+          Beta
         </td>
         <td>
           -

--- a/packages/odyssey/CHANGELOG.md
+++ b/packages/odyssey/CHANGELOG.md
@@ -1,17 +1,35 @@
-<!-- CHANGELOG Example
+# Changelog
 
-# 0.0.1
+All notable changes to this project will be documented in this file.
 
-### Features
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-- [`somePullRequest`](https://github.com/okta/odyssey/pulls/) - Description of the new feature.
+## [Unreleased]
 
-### Fixes
+- Rebrand type and color changes
 
-- [`somePullRequest`](https://github.com/okta/odyssey/pulls/) - Description of the problem here and how it was solved.
+## [0.1.1] - 2020-04-01
 
-### Other
+### Added
 
-- [`somePullRequest`](https://github.com/okta/odyssey/pulls/) - Description of non feature/bug changes.
+- Table: styling and documentation for default table behavior, sorting, and various content types
+- Select: support for default select input behavior via plain HTML and Choices.js
+- Styled Element Glossary: blockquote, cite, del, em, ins, mark, s, small, sub, sup, strong
+- Component Status Page
+- Code of Conduct
 
--->
+### Changed
+
+- <mark><strong>[Breaking Change]</strong></mark> All classes are now prefixed with `.ods-`
+- Standard borders are now set to 1px (from 2px)
+- Input and Button now share the same height math
+
+### Removed
+
+- Removed documentation for multiple items not yet ready for public use: Banner, Callout, Card, Dropdown, Iconography, Meter, Navigation, Switch, Toast, Top Bar, Layouts
+
+## [0.0.1] - 2019-10-10
+
+### Added/Changed/Removed
+- Migrated former "Nim" repo into Odyssey


### PR DESCRIPTION
Adds up to date changelog for `0.1.1`.

@jmelberg-okta, @arnoldsandoval-okta's set this up to copy the repo changelog into the docs, so we have a web visible version as well. Won't get detected by Hexo's hot reload, but I figure we can find a more elegant solution when we swap frameworks if we need to.