### PR TITLE
Bugfix: table overflow

### DIFF
--- a/packages/odyssey/CHANGELOG.md
+++ b/packages/odyssey/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Rebrand type and color changes
+- bugfix/ee-463 - fixes table cell overflow by wrapping long strings
 
 ## [0.1.2] - 2020-04-06
 

--- a/packages/odyssey/src/scss/components/_table.scss
+++ b/packages/odyssey/src/scss/components/_table.scss
@@ -35,6 +35,7 @@
     padding: $small-spacing $base-spacing;
     text-align: left;
     vertical-align: baseline;
+    overflow-wrap: break-word;
   }
 
   th {


### PR DESCRIPTION
Fixes Table cell overflow by adding `overflow-wrap: break-word`.

Fixes #463