### PR TITLE
Component: Status

### DIFF
--- a/packages/docs/source/_data/nav.yml
+++ b/packages/docs/source/_data/nav.yml
@@ -26,6 +26,7 @@
   #'navigation': '/components/navigation.html'
   'radio button': '/components/radio-button.html'
   'select': '/components/select.html'
+  'status': '/components/status.html'
   #'switch': '/components/switch.html'
   'table': '/components/table.html'
   'tab': '/components/tab.html'

--- a/packages/docs/source/components/status.md
+++ b/packages/docs/source/components/status.md
@@ -1,0 +1,213 @@
+# Status
+
+Status is used to keep users informed, by providing appropriate feedback on particular concepts or entities. For Okta, status can be used to display overall operational status all the way down to very granular concepts, like user status.
+
+## Usage
+
+Status should be used to communicate the state of a discrete item, such as a server or individual process. Both labeled and unlabeled variants are acceptable, but should follow the associated guidelines below.
+
+<figure class="nimatron--example">
+  <div class="nimatron--rendered">
+    <dl class="ods-status is-ods-status-success">
+      <dt class="ods-status--label">
+        Server status
+      </dt>
+      <dd class="ods-status--value">
+        System operational
+      </dd>
+    </dl>
+  </div>
+
+  ```html
+  <dl class="ods-status is-ods-status-success">
+    <dt class="ods-status--label">
+      Server status
+    </dt>
+    <dd class="ods-status--value">
+      System operational
+    </dd>
+  </dl>
+  ```
+</figure>
+
+Labels may be hidden by applying the `.is-ods-status-label-hidden` class. If a label is not visually present, ensure that appropriate context is communicated by the Status itself and close proximity to the content that it’s supporting.
+
+Even if the label is hidden, it must be populated to ensure appropriate context for users of assistive technology.
+
+<figure class="nimatron--example">
+  <div class="nimatron--rendered">
+    <dl class="ods-status is-ods-status-success is-ods-status-label-hidden">
+      <dt class="ods-status--label">
+        Server status
+      </dt>
+      <dd class="ods-status--value">
+        System operational
+      </dd>
+    </dl>
+  </div>
+
+  ```html
+  <dl class="ods-status is-ods-status-success is-ods-status-label-hidden">
+    <dt class="ods-status--label">
+      Server status
+    </dt>
+    <dd class="ods-status--value">
+      System operational
+    </dd>
+  </dl>
+  ```
+</figure>
+
+## Variants
+
+There are four variants of Status available: Neutral, Success, Caution, and Danger.
+
+### Neutral
+
+Neutral Statuses are gray and should be used to indicate states like Paused, Not started, or Queued.
+
+This variant is our default.
+
+<figure class="nimatron--example">
+  <div class="nimatron--rendered">
+    <dl class="ods-status">
+      <dt class="ods-status--label">
+        Server status
+      </dt>
+      <dd class="ods-status--value">
+        System inactive
+      </dd>
+    </dl>
+  </div>
+
+  ```html
+  <dl class="ods-status">
+    <dt class="ods-status--label">
+      Server status
+    </dt>
+    <dd class="ods-status--value">
+      System inactive
+    </dd>
+  </dl>
+  ```
+</figure>
+
+### Success
+
+Success Statuses are green and should be used to indicate states like Complete, Active, Available, Service operational.
+
+<figure class="nimatron--example">
+  <div class="nimatron--rendered">
+    <dl class="ods-status is-ods-status-success">
+      <dt class="ods-status--label">
+        Server status
+      </dt>
+      <dd class="ods-status--value">
+        System operational
+      </dd>
+    </dl>
+  </div>
+
+  ```html
+  <dl class="ods-status is-ods-status-success">
+    <dt class="ods-status--label">
+      Server status
+    </dt>
+    <dd class="ods-status--value">
+      System operational
+    </dd>
+  </dl>
+  ```
+</figure>
+
+### Caution
+
+Caution Statuses are yellow and should be used to indicate states like Attention suggested or Service degradation.
+
+<figure class="nimatron--example">
+  <div class="nimatron--rendered">
+    <dl class="ods-status is-ods-status-caution">
+      <dt class="ods-status--label">
+        Server status
+      </dt>
+      <dd class="ods-status--value">
+        Service degradation
+      </dd>
+    </dl>
+  </div>
+
+  ```html
+  <dl class="ods-status is-ods-status-caution">
+    <dt class="ods-status--label">
+      Server status
+    </dt>
+    <dd class="ods-status--value">
+      Service degradation
+    </dd>
+  </dl>
+  ```
+</figure>
+
+### Danger
+
+Danger Statuses are red and should be used to indicate states like Error, Failure, or Service disruption.
+
+<figure class="nimatron--example">
+  <div class="nimatron--rendered">
+    <dl class="ods-status is-ods-status-danger">
+      <dt class="ods-status--label">
+        Server status
+      </dt>
+      <dd class="ods-status--value">
+        Service disruption
+      </dd>
+    </dl>
+  </div>
+
+  ```html
+  <dl class="ods-status is-ods-status-danger">
+    <dt class="ods-status--label">
+      Server status
+    </dt>
+    <dd class="ods-status--value">
+      Service disruption
+    </dd>
+  </dl>
+  ```
+</figure>
+
+## Content guidelines
+
+Status is intended to be both succinct and easily understood; limit label and description to one to two words. As with other components, use sentence casing for both.
+
+## Accessibility
+
+In addition to including copy for assistive technologies, consider whether your Status may change while the user is on the page.
+
+If the current state of Status may change asynchronously while a user is visiting the page, utilize the `role="status"` attribute to ensure that assistive technologies correctly indicate this change.
+
+<strong>Note:</strong> This attribute must be present <em>before</em> the change occurs.
+
+<figure class="nimatron--example">
+  <div class="nimatron--rendered">
+    <dl class="ods-status is-ods-status-danger" role="status">
+      <dt class="ods-status--label">
+        Server status
+      </dt>
+      <dd class="ods-status--value">
+        Service Disruption
+      </dd>
+    </dl>
+  </div>
+
+  ```html
+  <dl class="ods-status is-ods-status-danger" role="status">
+    <dt class="ods-status--label">
+      Server status
+    </dt>
+    <dd class="ods-status--value">
+      Service Disruption
+    </dd>
+  </dl>
+  ```
+</figure>

--- a/packages/docs/source/components/table.md
+++ b/packages/docs/source/components/table.md
@@ -410,15 +410,21 @@ If the data in a column consists primarily of figures or numerical data, you can
 
 When presenting numerical data, be sure to leave off any units and incorporate them into the column's header.
 
-#### Dates
+#### Date
 
 To maintain ease of reading, dates should not be line-broken. To preserve their white space, you can utilize the <code>.is-ods-table-date</code> class throughout their column.
 
-#### Buttons
+#### Button
 
 No extra styling is required when adding Buttons to your table. Buttons will automatically resize to their "Small" variant and align to the baseline of other type in the row.
 
 Please follow normal Button variant guidelines within tables.
+
+#### Status
+
+No extra styling is required when adding Statuses to your table. However, the label should be hidden, and they require their own column with an appropriate heading.
+
+Please follow all other Status guidelines as normal.
 
 #### Checkboxes
 

--- a/packages/odyssey/src/scss/abstracts/_colors.scss
+++ b/packages/odyssey/src/scss/abstracts/_colors.scss
@@ -27,7 +27,7 @@ $colors: (
     'base': #1662dd,
     'dark': #124a94,
   ),
-  'yellow': (
+  'caution': (
     'lightest': #fcf9e1,
     'base': #ebd551,
     'dark': #bc960f,

--- a/packages/odyssey/src/scss/components/_banner.scss
+++ b/packages/odyssey/src/scss/components/_banner.scss
@@ -160,8 +160,8 @@
   }
 }
 
-.is-ods-banner-yellow {
-  background: cv('yellow', 'base');
+.is-ods-banner-caution {
+  background: cv('caution', 'base');
   color: $text-heading;
 
   .ods-banner--title {
@@ -174,7 +174,7 @@
     }
 
     .icon--stroke {
-      fill: cv('yellow', 'base');
+      fill: cv('caution', 'base');
     }
   }
 

--- a/packages/odyssey/src/scss/components/_callout.scss
+++ b/packages/odyssey/src/scss/components/_callout.scss
@@ -31,7 +31,7 @@
     left: -1px;
     width: 3px;
     border-radius: $base-border-radius 0 0 $base-border-radius;
-    background-color: cv('yellow', 'base');
+    background-color: cv('caution', 'base');
   }
 }
 
@@ -68,21 +68,21 @@
 
 .is-ods-callout-pending {
   &::before {
-    background-color: cv('yellow', 'base');
+    background-color: cv('caution', 'base');
   }
 
   .icon--fill {
-    fill: cv('yellow', 'base');
+    fill: cv('caution', 'base');
   }
 }
 
 .is-ods-callout-warning {
   &::before {
-    background-color: cv('yellow', 'base');
+    background-color: cv('caution', 'base');
   }
 
   .icon--fill {
-    fill: cv('yellow', 'base');
+    fill: cv('caution', 'base');
   }
 }
 

--- a/packages/odyssey/src/scss/components/_meter.scss
+++ b/packages/odyssey/src/scss/components/_meter.scss
@@ -44,7 +44,7 @@ $meter-border-radius: $tiny-spacing/3;
 }
 
 .ods-meter::-webkit-meter-suboptimum-value {
-  background: cv('yellow', 'base');
+  background: cv('caution', 'base');
 }
 
 .ods-meter::-webkit-meter-even-less-good-value {
@@ -62,7 +62,7 @@ $meter-border-radius: $tiny-spacing/3;
 }
 
 .ods-meter:-moz-meter-sub-optimum::-moz-meter-bar {
-  background: cv('yellow', 'base');
+  background: cv('caution', 'base');
 }
 
 .ods-meter:-moz-meter-sub-sub-optimum::-moz-meter-bar {
@@ -100,7 +100,7 @@ $meter-border-radius: $tiny-spacing/3;
 }
 
 .ods-meter--suboptimum-value {
-  background: cv('yellow', 'base');
+  background: cv('caution', 'base');
 }
 
 .ods-meter--subsuboptimum-value {

--- a/packages/odyssey/src/scss/components/_status-layout.scss
+++ b/packages/odyssey/src/scss/components/_status-layout.scss
@@ -1,0 +1,7 @@
+.ods-status {
+  margin-bottom: $base-spacing;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}

--- a/packages/odyssey/src/scss/components/_status.scss
+++ b/packages/odyssey/src/scss/components/_status.scss
@@ -1,0 +1,55 @@
+.ods-status--label {
+  display: block;
+  margin-bottom: $tiny-spacing;
+  font-weight: 600;
+}
+
+.ods-status--value {
+  position: relative;
+  padding-left: 0.5em + $em-small-spacing;
+  background-color: transparent;
+  color: $text-body;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 0;
+    width: 0.5em;
+    height: 0.5em;
+    margin-right: $tiny-spacing;
+    transform: translateY(-50%);
+    border-radius: 1em;
+    background-color: cv('gray', '700');
+  }
+}
+
+.is-ods-status-label-hidden {
+  .ods-status--label {
+    @include is-visually-hidden;
+  }
+}
+
+.is-ods-status-success {
+  .ods-status--value {
+    &::before {
+      background-color: cv('success', 'base');
+    }
+  }
+}
+
+.is-ods-status-caution {
+  .ods-status--value {
+    &::before {
+      background-color: cv('caution', 'base');
+    }
+  }
+}
+
+.is-ods-status-danger {
+  .ods-status--value {
+    &::before {
+      background-color: cv('danger', 'base');
+    }
+  }
+}

--- a/packages/odyssey/src/scss/odyssey.scss
+++ b/packages/odyssey/src/scss/odyssey.scss
@@ -49,6 +49,8 @@
 @import 'components/radio-button';
 @import 'components/radio-button-layout';
 @import 'components/select';
+@import 'components/status';
+@import 'components/status-layout';
 @import 'components/switch';
 @import 'components/table';
 @import 'components/tab';


### PR DESCRIPTION
# Status

Status is used to keep users informed, by providing appropriate feedback on particular concepts or entities. For Okta, status can be used to display overall operational status all the way down to very granular concepts, like user status.

## Variants

We provide semantic variants for Neutral, Success, Caution, and Danger, distinguished by applying a class to the root.

## Usage

We provide both labeled and unlabeled Statuses, distinguished by applying a class to the root.

## a11y

Most a11y concerns are met by utilizing the intended markup. For async statuses, the `role="status"` attribute should be used.

![Screenshot_2020-04-28 Odyssey(1)](https://user-images.githubusercontent.com/36284167/80539347-32c52980-895c-11ea-9256-4af5f46839c0.png)
