### PR TITLE
Tab color element fix

### DIFF
--- a/packages/odyssey/src/scss/components/_tab.scss
+++ b/packages/odyssey/src/scss/components/_tab.scss
@@ -40,6 +40,7 @@
   padding: $small-spacing $base-spacing;
   border: 0;
   background: none;
+  color: $text-body;
   font-family: inherit;
   font-size: ms(0);
   font-weight: 600;


### PR DESCRIPTION
Explicitly adds text color css rule to `.ods-tabs--tab button`