### PR TITLE
Rebrand: Colors

### DIFF
--- a/packages/docs/source/base/color.md
+++ b/packages/docs/source/base/color.md
@@ -9,25 +9,25 @@ These foundations are only available in the draft spec.
 
 <section class="sample--colors-wrap">
   <ul class="sample--color-list">
-    <li class="sample--color is-sample-success-lightest"></li>
+    <li class="sample--color is-sample-success-light"></li>
     <li class="sample--color is-sample-success-base"></li>
     <li class="sample--color is-sample-success-dark"></li>
   </ul>
 
   <ul class="sample--color-list">
-    <li class="sample--color is-sample-action-lightest"></li>
+    <li class="sample--color is-sample-action-light"></li>
     <li class="sample--color is-sample-action-base"></li>
     <li class="sample--color is-sample-action-dark"></li>
   </ul>
 
   <ul class="sample--color-list">
-    <li class="sample--color is-sample-danger-lightest"></li>
+    <li class="sample--color is-sample-danger-light"></li>
     <li class="sample--color is-sample-danger-base"></li>
     <li class="sample--color is-sample-danger-dark"></li>
   </ul>
 </section>
 
-The current palette is constrained to three shades per hue. Use <strong>lightest</strong> variants to highlight specific states in typically-white backgrounds (e.g. a Text Input might have a `cv('danger', 'lightest')` background during an error state. The <strong>base</strong> variant can be treated as a safe default. <strong>Dark</strong> shades should be used for `:hover`-esque  states or to increase contrast.
+The current palette is constrained to three shades per hue. Use <strong>light</strong> variants to highlight specific states in typically-white backgrounds (e.g. a Text Input might have a `cv('danger', 'light')` background during an error state. The <strong>base</strong> variant can be treated as a safe default. <strong>Dark</strong> shades should be used for `:hover`-esque  states or to increase contrast.
 
 ## Semantic hues
 
@@ -51,25 +51,19 @@ It should never be used as a text color, as it is not AA compliant.
 
 <ul class="sample--color-list">
   <li class="sample--color is-sample-gray-000"></li>
-  <li class="sample--color is-sample-gray-100"></li>
   <li class="sample--color is-sample-gray-200"></li>
-  <li class="sample--color is-sample-gray-300"></li>
   <li class="sample--color is-sample-gray-400"></li>
-  <li class="sample--color is-sample-gray-500"></li>
   <li class="sample--color is-sample-gray-600"></li>
-  <li class="sample--color is-sample-gray-700"></li>
   <li class="sample--color is-sample-gray-800"></li>
-  <li class="sample--color is-sample-gray-900"></li>
 </ul>
 
 We have a large selection of grays available for use. We've currently standardized around a few shades:
 
 ```scss
-$text-body: cv('gray', '900');
-$text-heading: cv('gray', '900');
-$text-sub: cv('gray', '500');
-
-$base-border-color: cv('gray', '300');
+$brand: cv('action', 'dark');
+$text-body: cv('gray', '800');
+$text-heading: $black;
+$text-sub: cv('gray', '600');
 ```
 
 </div>

--- a/packages/docs/themes/nimatron/source/css/_prism-ext.scss
+++ b/packages/docs/themes/nimatron/source/css/_prism-ext.scss
@@ -1,8 +1,8 @@
 /* stylelint-disable selector-no-qualifying-type */
 
 code:not([class]) {
+  color: cv('lilac', 'base');
   font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-  color: cv('magenta', 'base');
   font-size: ms(-1);
 }
 
@@ -44,14 +44,11 @@ pre[class*='language-'] {
   }
 }
 
-:not(pre) > code[class*='language-'] {
-  background: $white;
-}
-
 /* Inline code */
 :not(pre) > code[class*='language-'] {
   padding: $tiny-spacing;
   border-radius: $base-border-radius;
+  background: $white;
   white-space: normal;
 }
 
@@ -77,7 +74,7 @@ pre[class*='language-'] {
 .token.constant,
 .token.symbol,
 .token.deleted {
-  color: cv('violet', 'base');
+  color: cv('lilac', 'base');
 }
 
 .token.selector,
@@ -95,7 +92,7 @@ pre[class*='language-'] {
 .language-css .token.string,
 .style .token.string {
   background: hsla(0, 0%, 100%, $less-opaque);
-  color: cv('warning', 'dark');
+  color: cv('caution', 'dark');
 }
 
 .token.atrule,
@@ -112,7 +109,7 @@ pre[class*='language-'] {
 .token.regex,
 .token.important,
 .token.variable {
-  color: cv('warning', 'base');
+  color: cv('caution', 'base');
 }
 
 .token.important,

--- a/packages/docs/themes/nimatron/source/css/_samples.scss
+++ b/packages/docs/themes/nimatron/source/css/_samples.scss
@@ -13,7 +13,7 @@
 .modal--form {
   position: relative;
   border-radius: 0 0 $base-border-radius $base-border-radius;
-  box-shadow: 0 0 20px rgba(cv('gray', '900'), 0.1);
+  box-shadow: 0 0 20px rgba(cv('gray', '800'), 0.1);
 
   &::before {
     content: '';
@@ -161,7 +161,7 @@ $spacing-units: (
     width: $value;
     height: $value;
     margin: 0 0 $base-spacing 0;
-    border: 1px solid cv('gray', '900');
+    border: 1px solid cv('gray', '800');
   }
 }
 
@@ -232,7 +232,7 @@ $spacing-units: (
 }
 
 .is-link-visited {
-  color: cv('violet', 'dark');
+  color: cv('lilac', 'dark');
 }
 
 .sample--external-link-icon {

--- a/packages/docs/themes/nimatron/source/css/nimatron.scss
+++ b/packages/docs/themes/nimatron/source/css/nimatron.scss
@@ -113,7 +113,7 @@
       top: 0;
       left: -$big-spacing;
       width: calc(100% + #{$big-spacing} + #{$big-spacing});
-      border-top: 1px solid cv('gray', '100');
+      border-top: 1px solid cv('gray', '200');
     }
   }
 }
@@ -130,7 +130,7 @@
 
   @media only screen and (min-width: 125ch) {
     display: block;
-    border-left: 1px solid cv('gray', '100');
+    border-left: 1px solid cv('gray', '200');
   }
 }
 

--- a/packages/odyssey/CHANGELOG.md
+++ b/packages/odyssey/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rebrand type and color changes
 - [Breaking Change] Removed documentation and Sass styles for unapproved components: Banner, Callout, Card, Dropdown, Meter, Navigation, Switch, Toast, Top Bar
 - Removed all other unused/unapproved documentation
+- [Breaking Change] Removed `fauxpacity` function, preferring "light" color variants
+- [Breaking Change] Renamed "warning" to "orange, renamed "violet" to "lilac"
+- [Breaking Change] Removed grays 100, 300, 500, 700, 900
+- [Breaking Change] Removed "magenta"
 
 ## [0.2.0] - 2020-04-30
 

--- a/packages/odyssey/src/scss/abstracts/_colors.scss
+++ b/packages/odyssey/src/scss/abstracts/_colors.scss
@@ -18,57 +18,50 @@
 
 $colors: (
   'success': (
-    'lightest': #e5fff6,
-    'base': #00d1b3,
-    'dark': #00a08e,
+    'light': #a0dcc3,
+    'base': #00b478,
+    'dark': #1e5046,
   ),
   'action': (
-    'lightest': #e5edfb,
+    'light': #92bcff,
     'base': #1662dd,
-    'dark': #124a94,
+    'dark': #00297a,
   ),
   'caution': (
-    'lightest': #fcf9e1,
-    'base': #ebd551,
-    'dark': #bc960f,
-  ),
-  'warning': (
-    'lightest': #feefe2,
-    'base': #f47c25,
-    'dark': #cb5500,
+    'light': #fae496,
+    'base': #ffc61c,
+    'dark': #9d6612,
   ),
   'danger': (
-    'lightest': #fee6ea,
-    'base': #dd0744,
-    'dark': #b80047,
+    'light': #faafa3,
+    'base': #da372c,
+    'dark': #892100,
+  ),
+  'orange': (
+    'light': #f0bf87,
+    'base': #e97107,
+    'dark': #873800,
+  ),
+  'lilac': (
+    'light': #bf9daf,
+    'base': #8d6e97,
+    'dark': #3c2b57,
   ),
   'cyan': (
-    'lightest': #c6fafa,
-    'base': #007f9c,
-    'dark': #004d6b,
-  ),
-  'violet': (
-    'lightest': #f3eafe,
-    'base': #963fe6,
-    'dark': #5a13b4,
-  ),
-  'magenta': (
-    'base': #c72c86,
+    'light': #abd5d6,
+    'base': #2d8c9e,
+    'dark': #095661,
   ),
   'gray': (
-    '000': #fafafa,
-    '100': #e4e5e7,
-    '200': #cdd1d3,
-    '300': #b7bcc0,
-    '400': #a0a7ac,
-    '500': #899298,
-    '600': #737d85,
-    '700': #5c6971,
-    '800': #46545e,
-    '900': #2f3f4a,
+    '000': #f5f5f6,
+    '200': #d7d7dc,
+    '400': #aaaab4,
+    '600': #6e6e78,
+    '800': #41414b,
   ),
 );
 
+$black: #000000;
 $white: #ffffff;
 
 /**
@@ -92,6 +85,7 @@ $white: #ffffff;
 
 $box-shadow-default: 0 2px 0 rgba(175, 175, 175, 0.12);
 
-$text-body: cv('gray', '900');
-$text-heading: cv('gray', '900');
-$text-sub: cv('gray', '500');
+$brand: cv('action', 'dark');
+$text-body: cv('gray', '800');
+$text-heading: $black;
+$text-sub: cv('gray', '600');

--- a/packages/odyssey/src/scss/abstracts/_functions.scss
+++ b/packages/odyssey/src/scss/abstracts/_functions.scss
@@ -56,12 +56,6 @@
   @return $map;
 }
 
-@function fauxpacity($color) {
-  $value: mix($color, $white, 40%);
-
-  @return $value;
-}
-
 /**
  * Retrieves and encodes icons for use in CSS
  * Works down to IE9

--- a/packages/odyssey/src/scss/abstracts/_mixins.scss
+++ b/packages/odyssey/src/scss/abstracts/_mixins.scss
@@ -25,7 +25,7 @@
 
 @mixin outline($outlineColor: 'action', $radius: 4px) {
   outline: 0;
-  box-shadow: 0 0 0 $radius fauxpacity(cv($outlineColor, 'base'));
+  box-shadow: 0 0 0 $radius cv($outlineColor, 'light');
 }
 
 @mixin input-baseline {
@@ -41,7 +41,7 @@
   border: 1px solid $base-border-color;
   border-radius: $base-border-radius;
   background-color: $white;
-  box-shadow: 0 0 0 0 fauxpacity(cv('action', 'base'));
+  box-shadow: 0 0 0 0 cv('action', 'light');
   color: $text-body;
   font-family: $body-font-family;
   font-size: ms(0);
@@ -64,11 +64,11 @@
 
   &:disabled,
   &[readonly] {
-    border-color: cv('gray', '200');
+    border-color: $disabled-border-color;
     background-color: cv('gray', '000');
 
     &:hover {
-      border-color: cv('gray', '200');
+      border-color: $disabled-border-color;
     }
   }
 

--- a/packages/odyssey/src/scss/abstracts/_variables.scss
+++ b/packages/odyssey/src/scss/abstracts/_variables.scss
@@ -14,7 +14,7 @@
 
 // Establish Type Scale
 
-$body-font-family: 'Proxima Nova', '-apple-system',  'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
+$body-font-family: 'Whyte', '-apple-system',  'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
 $mono-font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
 $base-font-size: 16px;
@@ -43,7 +43,8 @@ $base-timing: linear;
 
 // Borders
 
-$base-border-color: cv('gray', '300');
+$base-border-color: cv('gray', '400');
+$disabled-border-color: cv('gray', '200');
 $base-border-radius: 4px;
 $border-default: 1px solid $base-border-color;
 

--- a/packages/odyssey/src/scss/base/_typography-link.scss
+++ b/packages/odyssey/src/scss/base/_typography-link.scss
@@ -20,7 +20,7 @@ a {
   }
 
   &:visited {
-    color: cv('violet', 'dark');
+    color: cv('lilac', 'dark');
   }
 
   /* stylelint-disable selector-no-qualifying-type */

--- a/packages/odyssey/src/scss/base/_typography-text.scss
+++ b/packages/odyssey/src/scss/base/_typography-text.scss
@@ -66,7 +66,7 @@ cite {
 
 del {
   display: inline-block;
-  background: cv('danger', 'lightest');
+  background: cv('danger', 'light');
 }
 
 del::before,
@@ -84,7 +84,7 @@ del::after {
 
 ins {
   display: inline-block;
-  background: cv('success', 'lightest');
+  background: cv('success', 'light');
 }
 
 ins::before,
@@ -101,7 +101,7 @@ ins::after {
 }
 
 mark {
-  background: cv('warning', 'lightest');
+  background: cv('caution', 'light');
 }
 
 s {
@@ -130,7 +130,7 @@ hr {
 }
 
 code {
-  color: cv('magenta', 'base');
+  color: cv('cyan', 'dark');
   font-family: $mono-font-family;
 }
 

--- a/packages/odyssey/src/scss/components/_button.scss
+++ b/packages/odyssey/src/scss/components/_button.scss
@@ -23,7 +23,7 @@
   border: 1px solid transparent;
   border-radius: $base-border-radius;
   background-color: cv('action');
-  box-shadow: 0 0 0 0 fauxpacity(cv('action', 'base'));
+  box-shadow: 0 0 0 0 cv('action', 'light');
   color: $white;
   font-family: $body-font-family;
   font-size: ms(0);
@@ -45,7 +45,7 @@
 
   &:disabled {
     border-color: transparent;
-    background-color: fauxpacity(cv('action', 'base'));
+    background-color: cv('action', 'light');
     cursor: not-allowed;
   }
 }
@@ -57,22 +57,22 @@
 
   &:hover,
   &.is-ods-button-hover {
-    border-color: cv('action', 'dark');
-    background-color: cv('action', 'lightest');
-    color: cv('action', 'dark');
+    border-color: cv('action', 'base');
+    background-color: cv('action', 'base');
+    color: $white;
   }
 
   &:focus,
   &.is-ods-button-focus {
-    border-color: cv('action', 'dark');
-    background-color: cv('action', 'lightest');
-    color: cv('action', 'dark');
+    border-color: cv('action', 'base');
+    background-color: $white;
+    color: cv('action', 'base');
   }
 
   &:disabled {
-    border-color: fauxpacity(cv('action', 'base'));
+    border-color: cv('action', 'light');
     background-color: $white;
-    color: fauxpacity(cv('action', 'base'));
+    color: cv('action', 'light');
   }
 }
 
@@ -93,7 +93,7 @@
   }
 
   &:disabled {
-    background-color: fauxpacity(cv('danger', 'base'));
+    background-color: cv('danger', 'light');
   }
 
   &.is-ods-button-secondary {
@@ -104,14 +104,14 @@
     &:focus,
     &.is-ods-button-focus {
       border-color: cv('danger', 'dark');
-      background-color: cv('danger', 'lightest');
+      background-color: cv('danger', 'light');
       color: cv('danger', 'dark');
     }
 
     &:disabled {
-      border-color: fauxpacity(cv('danger', 'base'));
+      border-color: cv('danger', 'light');
       background-color: $white;
-      color: fauxpacity(cv('danger', 'base'));
+      color: cv('danger', 'light');
     }
   }
 }
@@ -128,14 +128,14 @@
 
   &:focus,
   &.is-ods-button-focus {
-    @include outline;
-
-    background-color: cv('gray', '000');
+    outline: 0;
+    background-color: $white;
+    box-shadow: 0 0 0 $base-border-radius cv('action');
   }
 
   &:disabled {
-    opacity: $more-opaque;
     background-color: $white;
+    color: cv('gray', '400');
   }
 }
 
@@ -146,19 +146,19 @@
   &:hover,
   &.is-ods-button-hover {
     border-color: transparent;
-    background-color: cv('action', 'lightest');
+    background-color: cv('action', 'light');
     color: cv('action', 'dark');
   }
 
   &:focus,
   &.is-ods-button-focus {
-    background-color: cv('action', 'lightest');
-    color: cv('action', 'dark');
+    background-color: $white;
+    color: cv('action', 'base');
   }
 
   &:disabled {
     background-color: transparent;
-    color: fauxpacity(cv('action', 'base'));
+    color: cv('action', 'light');
   }
 }
 

--- a/packages/odyssey/src/scss/components/_checkbox.scss
+++ b/packages/odyssey/src/scss/components/_checkbox.scss
@@ -52,8 +52,12 @@
       cursor: not-allowed;
 
       &::before {
-        border-color: cv('gray', '200');
+        border-color: $disabled-border-color;
         background-color: cv('gray', '000');
+      }
+
+      &::after {
+        background-image: get-icon('check', cv('gray', '000'));
       }
     }
 
@@ -61,8 +65,8 @@
     &:indeterminate {
       + .ods-checkbox--label {
         &::before {
-          border-color: fauxpacity(cv('action', 'base'));
-          background-color: fauxpacity(cv('action', 'base'));
+          border-color: cv('action', 'light');
+          background-color: cv('action', 'light');
         }
       }
     }
@@ -99,7 +103,7 @@
         color: $text-sub;
 
         &::before {
-          border-color: fauxpacity(cv('danger', 'base'));
+          border-color: cv('danger', 'light');
         }
       }
 
@@ -107,8 +111,8 @@
       &:indeterminate {
         + .ods-checkbox--label {
           &::before {
-            border-color: fauxpacity(cv('danger', 'base'));
-            background-color: fauxpacity(cv('danger', 'base'));
+            border-color: cv('danger', 'light');
+            background-color: cv('danger', 'light');
           }
         }
       }
@@ -145,7 +149,7 @@
   &::before {
     transform: translateY(-50%);
     border-color: $base-border-color;
-    box-shadow: 0 0 0 0 fauxpacity(cv('action', 'base'));
+    box-shadow: 0 0 0 0 cv('action', 'light');
   }
 
   // Check

--- a/packages/odyssey/src/scss/components/_modal.scss
+++ b/packages/odyssey/src/scss/components/_modal.scss
@@ -22,7 +22,7 @@
   left: 0;
   align-items: center;
   justify-content: center;
-  background: rgba(cv('gray', '900'), 0.9);
+  background: rgba(cv('gray', '800'), 0.75);
 }
 
 .ods-modal--dialog {
@@ -48,7 +48,7 @@
   padding: 0;
   border: 0;
   background-color: transparent;
-  background-image: get-icon('close', cv('gray', '900'));
+  background-image: get-icon('close', $text-body);
   background-repeat: no-repeat;
   background-position: center;
 }

--- a/packages/odyssey/src/scss/components/_radio-button.scss
+++ b/packages/odyssey/src/scss/components/_radio-button.scss
@@ -42,7 +42,11 @@
       cursor: not-allowed;
 
       &::before {
-        border-color: cv('gray', '200');
+        border-color: $disabled-border-color;
+        background-color: cv('gray', '000');
+      }
+
+      &::after {
         background-color: cv('gray', '000');
       }
     }
@@ -50,8 +54,8 @@
     &:checked {
       + .ods-radio--label {
         &::before {
-          border-color: fauxpacity(cv('action', 'base'));
-          background-color: fauxpacity(cv('action', 'base'));
+          border-color: cv('action', 'light');
+          background-color: cv('action', 'light');
         }
       }
     }
@@ -87,15 +91,15 @@
         color: $text-sub;
 
         &::before {
-          border-color: fauxpacity(cv('danger', 'base'));
+          border-color: cv('danger', 'light');
         }
       }
 
       &:checked {
         + .ods-radio--label {
           &::before {
-            border-color: fauxpacity(cv('danger', 'base'));
-            background-color: fauxpacity(cv('danger', 'base'));
+            border-color: cv('danger', 'light');
+            background-color: cv('danger', 'light');
           }
         }
       }
@@ -132,7 +136,7 @@
   &::before {
     transform: translateY(-50%);
     border-color: $base-border-color;
-    box-shadow: 0 0 0 0 fauxpacity(cv('action', 'base'));
+    box-shadow: 0 0 0 0 cv('action', 'light');
   }
 
   // Check

--- a/packages/odyssey/src/scss/components/_status.scss
+++ b/packages/odyssey/src/scss/components/_status.scss
@@ -34,7 +34,7 @@
     margin-right: $tiny-spacing;
     transform: translateY(-50%);
     border-radius: 1em;
-    background-color: cv('gray', '700');
+    background-color: cv('gray', '600');
   }
 }
 

--- a/packages/odyssey/src/scss/components/_table.scss
+++ b/packages/odyssey/src/scss/components/_table.scss
@@ -52,13 +52,13 @@
 
   tbody {
     [rowspan] {
-      border-bottom: 1px solid cv('gray', '100');
+      border-bottom: 1px solid cv('gray', '200');
     }
 
     tr {
       td,
       th {
-        border-bottom: 1px solid cv('gray', '100');
+        border-bottom: 1px solid cv('gray', '200');
       }
 
       &:first-child {

--- a/packages/odyssey/src/scss/components/_tag.scss
+++ b/packages/odyssey/src/scss/components/_tag.scss
@@ -17,7 +17,7 @@
   margin: 0 $tiny-spacing $tiny-spacing 0;
   padding: 0 $em-tiny-spacing;
   border-radius: $base-border-radius;
-  background: cv('gray', '100');
+  background: cv('gray', '200');
   color: $text-body;
 }
 

--- a/packages/odyssey/src/scss/components/_tooltip.scss
+++ b/packages/odyssey/src/scss/components/_tooltip.scss
@@ -22,10 +22,10 @@
   z-index: 1;
   padding: $tiny-spacing $small-spacing;
   transition: opacity $base-duration $base-timing 1s;
-  border: 1px solid cv('gray', '900');
+  border: 1px solid cv('gray', '800');
   border-radius: $base-border-radius;
   opacity: 0;
-  background: cv('gray', '900');
+  background: cv('gray', '800');
   color: cv('gray', '000');
   font-size: ms(-1);
   font-weight: 600;
@@ -71,11 +71,11 @@
   }
 
   &::after {
-    border-top-color: cv('gray', '900');
+    border-top-color: cv('gray', '800');
   }
 
   &::before {
-    border-top-color: cv('gray', '900');
+    border-top-color: cv('gray', '800');
   }
 }
 
@@ -92,11 +92,11 @@
   }
 
   &::after {
-    border-right-color: cv('gray', '900');
+    border-right-color: cv('gray', '800');
   }
 
   &::before {
-    border-right-color: cv('gray', '900');
+    border-right-color: cv('gray', '800');
   }
 }
 
@@ -113,11 +113,11 @@
   }
 
   &::after {
-    border-bottom-color: cv('gray', '900');
+    border-bottom-color: cv('gray', '800');
   }
 
   &::before {
-    border-bottom-color: cv('gray', '900');
+    border-bottom-color: cv('gray', '800');
   }
 }
 
@@ -134,11 +134,11 @@
   }
 
   &::after {
-    border-left-color: cv('gray', '900');
+    border-left-color: cv('gray', '800');
   }
 
   &::before {
-    border-left-color: cv('gray', '900');
+    border-left-color: cv('gray', '800');
   }
 }
 

--- a/packages/odyssey/src/scss/vendors-ext/_choices-ext.scss
+++ b/packages/odyssey/src/scss/vendors-ext/_choices-ext.scss
@@ -15,13 +15,13 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   &.is-ods-select-focused {
     border-radius: $base-border-radius;
     outline: none;
-    box-shadow: 0 0 0 4px fauxpacity(cv('action', 'base'));
+    box-shadow: 0 0 0 4px cv('action', 'light');
 
     &.is-ods-select-open {
-      box-shadow: 0 0 0 4px fauxpacity(cv('action', 'base')), 0 2px 0 4px fauxpacity(cv('action', 'base'));
+      box-shadow: 0 0 0 4px cv('action', 'light'), 0 2px 0 4px cv('action', 'light');
 
       &.is-ods-select-flipped {
-        box-shadow: 0 0 0 4px fauxpacity(cv('action', 'base')), 0 -2px 0 4px fauxpacity(cv('action', 'base'));
+        box-shadow: 0 0 0 4px cv('action', 'light'), 0 -2px 0 4px cv('action', 'light');
       }
     }
   }
@@ -63,13 +63,13 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
     &.is-ods-select-focused {
       border-radius: $base-border-radius;
       outline: none;
-      box-shadow: 0 0 0 4px fauxpacity(cv('danger', 'base'));
+      box-shadow: 0 0 0 4px cv('danger', 'light');
 
       &.is-ods-select-open {
-        box-shadow: 0 0 0 4px fauxpacity(cv('danger', 'base')), 0 2px 0 4px fauxpacity(cv('danger', 'base'));
+        box-shadow: 0 0 0 4px cv('danger', 'light'), 0 2px 0 4px cv('danger', 'light');
 
         &.is-ods-select-flipped {
-          box-shadow: 0 0 0 4px fauxpacity(cv('danger', 'base')), 0 -2px 0 4px fauxpacity(cv('danger', 'base'));
+          box-shadow: 0 0 0 4px cv('danger', 'light'), 0 -2px 0 4px cv('danger', 'light');
         }
       }
     }
@@ -202,7 +202,7 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   border: 1px solid $base-border-color;
   border-radius: $base-border-radius;
   background-color: $white;
-  box-shadow: 0 0 0 0 fauxpacity(cv('action', 'base'));
+  box-shadow: 0 0 0 0 cv('action', 'light');
   color: $text-body;
   font-family: $body-font-family;
   font-size: ms(0);
@@ -307,7 +307,7 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   }
 
   .is-ods-select-focused & {
-    box-shadow: 0 0 0 4px fauxpacity(cv('action', 'base'));
+    box-shadow: 0 0 0 4px cv('action', 'light');
     clip-path: inset(0 -4px -4px -4px);
   }
 
@@ -376,7 +376,7 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
     }
 
     &.is-ods-select-highlighted {
-      background-color: cv('action', 'lightest');
+      background-color: cv('gray', '000');
 
       &::after {
         opacity: 0.5;
@@ -385,7 +385,7 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   }
 
   [data-invalid] .is-ods-select-focused & {
-    box-shadow: 0 0 0 4px fauxpacity(cv('danger', 'base'));
+    box-shadow: 0 0 0 4px cv('danger', 'light');
   }
 
   [data-invalid] .is-ods-select-open & {


### PR DESCRIPTION
- Sets Odyssey palette to match Rebrand Proposal
- Removes odd-numbered Gray values for a smaller, higher contrast selection
- Replaces "Proxima Nova" declaration with "Whyte" in the font stack
- Removes "Magenta" as a neutral hue
- Minor updates to docs and some element styling to reflect the above