### PR TITLE
Bug/548 - Prevent button text from wrapping

### DIFF
--- a/packages/odyssey/src/scss/components/_button.scss
+++ b/packages/odyssey/src/scss/components/_button.scss
@@ -29,6 +29,7 @@
   font-size: ms(0);
   font-weight: 600;
   line-height: $base-line-height;
+  white-space: nowrap;
 
   &:hover,
   &.is-ods-button-hover {


### PR DESCRIPTION
Small fix to prevent Button copy from wrapping - most common in tables.

<img width="786" alt="Screenshot 2020-07-08 10 51 10" src="https://user-images.githubusercontent.com/36284167/86953465-54375400-c109-11ea-8718-6ecde14333c9.png">

<img width="780" alt="Screenshot 2020-07-08 10 51 16" src="https://user-images.githubusercontent.com/36284167/86953461-539ebd80-c109-11ea-8b94-ceef382aba61.png">

Closes https://github.com/okta/odyssey/issues/548