### PR TITLE
Fast Follow: update component docs for icon a11y

### DIFF
--- a/packages/docs/components/button.md
+++ b/packages/docs/components/button.md
@@ -104,21 +104,45 @@ They also pair well with Primary and Secondary buttons.
 
 ### Button with icon
 
-Icons can be added to any of our button variants to increase clarity or add flair.
+Icons can be added to any of our button variants to increase clarity or add flair. To ensure proper layout, please wrap any visual labels with `.ods-button--label` as below.
 
 <figure class="nimatron--example">
   <div class="nimatron--rendered">
-    <button class="ods-button is-ods-button-primary"><svg viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="ods-icon"><path fill-rule="evenodd" clip-rule="evenodd" d="M6 12C6 12.5523 6.44772 13 7 13C7.55228 13 8 12.5523 8 12V8L12 8C12.5523 8 13 7.55228 13 7C13 6.44772 12.5523 6 12 6L8 6V2C8 1.44772 7.55228 1 7 1C6.44772 1 6 1.44772 6 2V6L2 6C1.44772 6 1 6.44771 1 7C1 7.55228 1.44772 8 2 8L6 8V12Z" fill="currentColor"/></svg></svg>Add User</button>
-    <button class="ods-button is-ods-button-secondary"><svg viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="ods-icon"><path fill-rule="evenodd" clip-rule="evenodd" d="M6 12C6 12.5523 6.44772 13 7 13C7.55228 13 8 12.5523 8 12V8L12 8C12.5523 8 13 7.55228 13 7C13 6.44772 12.5523 6 12 6L8 6V2C8 1.44772 7.55228 1 7 1C6.44772 1 6 1.44772 6 2V6L2 6C1.44772 6 1 6.44771 1 7C1 7.55228 1.44772 8 2 8L6 8V12Z" fill="currentColor"/></svg></svg>Add User</button>
-    <button class="ods-button is-ods-button-danger"><svg viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="ods-icon"><path fill-rule="evenodd" clip-rule="evenodd" d="M6 12C6 12.5523 6.44772 13 7 13C7.55228 13 8 12.5523 8 12V8L12 8C12.5523 8 13 7.55228 13 7C13 6.44772 12.5523 6 12 6L8 6V2C8 1.44772 7.55228 1 7 1C6.44772 1 6 1.44772 6 2V6L2 6C1.44772 6 1 6.44771 1 7C1 7.55228 1.44772 8 2 8L6 8V12Z" fill="currentColor"/></svg></svg>Add User</button>
-    <button class="ods-button is-ods-button-clear"><svg viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="ods-icon"><path fill-rule="evenodd" clip-rule="evenodd" d="M6 12C6 12.5523 6.44772 13 7 13C7.55228 13 8 12.5523 8 12V8L12 8C12.5523 8 13 7.55228 13 7C13 6.44772 12.5523 6 12 6L8 6V2C8 1.44772 7.55228 1 7 1C6.44772 1 6 1.44772 6 2V6L2 6C1.44772 6 1 6.44771 1 7C1 7.55228 1.44772 8 2 8L6 8V12Z" fill="currentColor"/></svg></svg>Add User</button>
+    <button class="ods-button is-ods-button-primary" aria-label="Add User"><svg aria-hidden="true" focusable="false" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="ods-icon"><path fill-rule="evenodd" clip-rule="evenodd" d="M6 12C6 12.5523 6.44772 13 7 13C7.55228 13 8 12.5523 8 12V8L12 8C12.5523 8 13 7.55228 13 7C13 6.44772 12.5523 6 12 6L8 6V2C8 1.44772 7.55228 1 7 1C6.44772 1 6 1.44772 6 2V6L2 6C1.44772 6 1 6.44771 1 7C1 7.55228 1.44772 8 2 8L6 8V12Z" fill="currentColor"/></svg></button>
+    <button class="ods-button is-ods-button-secondary" aria-label="Add User"><svg aria-hidden="true" focusable="false" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="ods-icon"><path fill-rule="evenodd" clip-rule="evenodd" d="M6 12C6 12.5523 6.44772 13 7 13C7.55228 13 8 12.5523 8 12V8L12 8C12.5523 8 13 7.55228 13 7C13 6.44772 12.5523 6 12 6L8 6V2C8 1.44772 7.55228 1 7 1C6.44772 1 6 1.44772 6 2V6L2 6C1.44772 6 1 6.44771 1 7C1 7.55228 1.44772 8 2 8L6 8V12Z" fill="currentColor"/></svg><span class="ods-button--label">Add User</span></button>
+    <button class="ods-button is-ods-button-danger" aria-label="Add User"><svg aria-hidden="true" focusable="false" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="ods-icon"><path fill-rule="evenodd" clip-rule="evenodd" d="M6 12C6 12.5523 6.44772 13 7 13C7.55228 13 8 12.5523 8 12V8L12 8C12.5523 8 13 7.55228 13 7C13 6.44772 12.5523 6 12 6L8 6V2C8 1.44772 7.55228 1 7 1C6.44772 1 6 1.44772 6 2V6L2 6C1.44772 6 1 6.44771 1 7C1 7.55228 1.44772 8 2 8L6 8V12Z" fill="currentColor"/></svg></button>
+    <button class="ods-button is-ods-button-clear" aria-label="Add User"><svg aria-hidden="true" focusable="false" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="ods-icon"><path fill-rule="evenodd" clip-rule="evenodd" d="M6 12C6 12.5523 6.44772 13 7 13C7.55228 13 8 12.5523 8 12V8L12 8C12.5523 8 13 7.55228 13 7C13 6.44772 12.5523 6 12 6L8 6V2C8 1.44772 7.55228 1 7 1C6.44772 1 6 1.44772 6 2V6L2 6C1.44772 6 1 6.44771 1 7C1 7.55228 1.44772 8 2 8L6 8V12Z" fill="currentColor"/></svg><span class="ods-button--label">Add User</span></button>
   </div>
 
   ```html
-  <button class="ods-button is-ods-button-clear">Clear</button>
-  <button class="ods-button is-ods-button-clear" disabled>Clear</button>
+  <button class="ods-button is-ods-button-primary" aria-label="Add User">
+    <svg aria-hidden="true" focusable="false" viewBox="0 0 14 14" fill="none" class="ods-icon">...</svg>
+  </button>
+  <button class="ods-button is-ods-button-secondary" aria-label="Add User">
+    <svg aria-hidden="true" focusable="false" viewBox="0 0 14 14" fill="none" class="ods-icon">...</svg>
+    <span class="ods-button--label">Add User</span>
+  </button>
+  <button class="ods-button is-ods-button-danger" aria-label="Add User">
+    <svg aria-hidden="true" focusable="false" viewBox="0 0 14 14" fill="none" class="ods-icon">...</svg>
+  </button>
+  <button class="ods-button is-ods-button-clear" aria-label="Add User">
+    <svg aria-hidden="true" focusable="false" viewBox="0 0 14 14" fill="none" class="ods-icon">...</svg>
+    <span class="ods-button--label">Add User</span>
+  </button>
   ```
 </figure>
+
+#### Accessibility
+
+When using icons within a button, be sure to add `focusable="false"` to the `svg`; this will prevent browsers (IE, specifically) from incorrectly focusing on the icon instead of the button. Similarly, the `aria-hidden` attribute will ensure screen readers do not unnecessarily announce iconography.
+
+Whether your button has a visual label or not, be sure to use the `aria-label` attribute to ensure screen readers will correctly identify your button, rather than extraneous content inside of it. Remember, if your button does contain a visual label, the text within `aria-label` should match exactly. This is a <a href="https://www.w3.org/WAI/WCAG21/quickref/#label-in-name">WCAG 2.1</a> requirement and will ensure that sighted users of screen readers are not confused by a mismatch.
+
+This enables decorative icons to be ignored by screen readers without compromising the accessibility of informative icons - all with the same markup.
+
+#### Icon-only usability
+
+We recommend pairing icon-only buttons with our <a href="/components/tooltip/">Tooltip</a>. While this is not required, it will increase clarity for sighted users.
 
 ## Guidelines
 
@@ -182,5 +206,20 @@ Semantic states can be combined to produce Secondary Danger styles.
     </tbody>
   </table>
 </figure>
+
+## Further reading
+
+<ul>
+  <li>
+    <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button">
+      MDN - &lt;button&gt;
+    </a>
+  </li>
+  <li>
+    <a href="https://www.sarasoueidan.com/blog/accessible-icon-buttons/">
+      Sara Soueidan - Accessible Icon Buttons
+    </a>
+  </li>
+</ul>
 
 :::

--- a/packages/docs/components/tooltip.md
+++ b/packages/docs/components/tooltip.md
@@ -18,11 +18,13 @@ Tooltips should be employed for all controls that rely solely on iconography for
 
 This is especially important for distinguishing between visually or contextually similar elements, or when employing rarely-used features or features with variant interpretations.
 
+Our <a href="/components/button/">Button</a> component offers more guidance if needed.
+
 <figure class="nimatron--example">
   <div class="nimatron--rendered">
     <span class="has-ods-tooltip">
       <button class="ods-button" aria-describedby="edit-label">
-        &#9998;
+        <svg aria-hidden="true" focusable="false" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="ods-icon"><path fill-rule="evenodd" clip-rule="evenodd" d="M12.8008 2.78969L11.2103 1.19923C10.9447 0.933589 10.5121 0.933589 10.2465 1.19923L9 2.44572L11.5543 5L12.8007 3.75351C13.0664 3.48787 13.0664 3.05533 12.8008 2.78969ZM3.5 13L10.5 6L8 3.5L1 10.5V13L3.5 13Z" fill="currentColor"/></svg>
       </button>
       <aside id="edit-label" class="ods-tooltip is-ods-tooltip-top" role="tooltip">
         Edit
@@ -33,7 +35,7 @@ This is especially important for distinguishing between visually or contextually
   ```html
   <span class="has-ods-tooltip">
     <button class="ods-button" aria-describedby="edit-label">
-      <svg>...</svg>
+      <svg aria-hidden="true" focusable="false" viewBox="0 0 14 14" fill="none" class="ods-icon">...</svg>
     </button>
     <aside id="edit-label" class="ods-tooltip is-ods-tooltip-top" role="tooltip">
       Edit
@@ -271,19 +273,21 @@ When possible, provide inline text that becomes visible on touchscreen devices. 
 
 ## Accessibility
 
-* The paired element should utilize `aria-describedby` to create a hard association with the tooltip.
-* The tooltip itself should utilize the `role='tooltip'` attribute to distinguish it from other popups.
-* Per <a href="https://www.w3.org/TR/wai-aria-1.1/#tooltip">ARIA guidelines</a>, our tooltips triggered by :hover and :focus employ a short delay (1s) before animating.
+Tooltip use cases may require slightly different markup. In both cases below, the tooltip itself should utilize the `role='tooltip'` attribute to distinguish it from other popups.
+
+Per <a href="https://www.w3.org/TR/wai-aria-1.1/#tooltip">ARIA guidelines</a>, our tooltips triggered by :hover and :focus employ a short delay (1s) before animating.
 
 ### Tooltip as a label
 
-When using tooltips as a label, no further considerations are necessary. Assistive technologies will read the following as "Edit".
+When using tooltips as a label, use the `aria-labelledby` attribute to create an association between the button and tooltip. 
+
+Assistive technologies will read the following as "Edit".
 
 <figure class="nimatron--example">
   <div class="nimatron--rendered">
     <span class="has-ods-tooltip">
-      <button class="ods-button" aria-describedby="access-edit-label">
-        &#9998;
+      <button class="ods-button" aria-labelledby="access-edit-label">
+        <svg aria-hidden="true" focusable="false" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="ods-icon"><path fill-rule="evenodd" clip-rule="evenodd" d="M12.8008 2.78969L11.2103 1.19923C10.9447 0.933589 10.5121 0.933589 10.2465 1.19923L9 2.44572L11.5543 5L12.8007 3.75351C13.0664 3.48787 13.0664 3.05533 12.8008 2.78969ZM3.5 13L10.5 6L8 3.5L1 10.5V13L3.5 13Z" fill="currentColor"/></svg>
       </button>
       <aside id="access-edit-label" class="ods-tooltip is-ods-tooltip-top" role="tooltip">
         Edit
@@ -293,26 +297,29 @@ When using tooltips as a label, no further considerations are necessary. Assisti
 
   ```html
   <span class="has-ods-tooltip">
-    <button class="ods-button" aria-describedby="access-edit-label">
-      <svg>...</svg>
-    </button>
-    <aside id="access-edit-label" class="ods-tooltip is-ods-tooltip-top" role="tooltip">
-      Edit
-    </aside>
-  </span>
+      <button class="ods-button" aria-labelledby="access-edit-label">
+        <svg aria-hidden="true" focusable="false" viewBox="0 0 14 14" fill="none" class="ods-icon">...s</svg>
+      </button>
+      <aside id="access-edit-label" class="ods-tooltip is-ods-tooltip-top" role="tooltip">
+        Edit
+      </aside>
+    </span>
   ```
 </figure>
 
 ### Tooltip as a description
 
-When using tooltips to provide additional information, ensure that the element also includes a visually hidden, accessible label. Assistive technologies will read the following as "Edit. View and manage this profile."
+When using tooltips to provide additional information, you'll need multiple attributes. 
+
+First, make sure the element itself has an accessible label. In the example below, we utilize the `aria-label` attribute to ensure the button is labeled. Next, use `aria-describedby` to create an association with the tooltip for additional context.
+
+Assistive technologies will read the following as "Edit. View and manage this profile."
 
 <figure class="nimatron--example">
   <div class="nimatron--rendered">
     <span class="has-ods-tooltip">
-      <button class="ods-button" aria-describedby="edit-description">
-        &#9998;
-        <span class="u-visually-hidden">Edit</span>
+      <button class="ods-button" aria-label="Edit" aria-describedby="edit-description">
+        <svg aria-hidden="true" focusable="false" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="ods-icon"><path fill-rule="evenodd" clip-rule="evenodd" d="M12.8008 2.78969L11.2103 1.19923C10.9447 0.933589 10.5121 0.933589 10.2465 1.19923L9 2.44572L11.5543 5L12.8007 3.75351C13.0664 3.48787 13.0664 3.05533 12.8008 2.78969ZM3.5 13L10.5 6L8 3.5L1 10.5V13L3.5 13Z" fill="currentColor"/></svg>
       </button>
       <aside id="edit-description" class="ods-tooltip is-ods-tooltip-top" role="tooltip">
         View and manage this profile.
@@ -322,11 +329,8 @@ When using tooltips to provide additional information, ensure that the element a
 
   ```html
   <span class="has-ods-tooltip">
-    <button class="ods-button" aria-describedby="edit-description">
-      <svg>...</svg>
-      <span class="u-visually-hidden">
-        Edit
-      </span>
+    <button class="ods-button" aria-label="Edit" aria-describedby="edit-description">
+      <svg aria-hidden="true" focusable="false" viewBox="0 0 14 14" fill="none" class="ods-icon">...</svg>
     </button>
     <aside id="edit-description" class="ods-tooltip is-ods-tooltip-top" role="tooltip">
       View and manage this profile.

--- a/packages/odyssey/src/scss/base/_iconography.scss
+++ b/packages/odyssey/src/scss/base/_iconography.scss
@@ -5,9 +5,3 @@
   height: 1em;
   vertical-align: middle;
 }
-
-.ods-button {
-  .ods-icon {
-    margin-right: $spacing-xs;
-  }
-}

--- a/packages/odyssey/src/scss/components/_button.scss
+++ b/packages/odyssey/src/scss/components/_button.scss
@@ -51,6 +51,12 @@
   }
 }
 
+.ods-button--label {
+  &:not(:only-child) {
+    margin-left: $spacing-xs;
+  }
+}
+
 .is-ods-button-secondary {
   border-color: $color-primary-base;
   background-color: $white;

--- a/packages/odyssey/src/scss/components/_tooltip.scss
+++ b/packages/odyssey/src/scss/components/_tooltip.scss
@@ -145,10 +145,6 @@
 .has-ods-tooltip {
   display: inline-block;
   position: relative;
-
-  svg {
-    display: block;
-  }
 }
 
 @media only screen and (max-width: 40rem) {


### PR DESCRIPTION
This updates the Button and Tooltip docs to provide accessibility guidance for Iconography. 

This includes documenting the use of `aria-` attributes as well as best practices for icon-only buttons.