### PR TITLE
Bugfix: title attribute

### DIFF
--- a/packages/docs/.vuepress/config.js
+++ b/packages/docs/.vuepress/config.js
@@ -2,6 +2,7 @@
 module.exports = {
   theme: '@okta/vuepress-theme-nimatron',
   dest: 'dist',
+  title: 'Odyssey Design System',
   head: [
     [
       'meta', { 


### PR DESCRIPTION
Title no longer reads as "VuePress" 😂 😭 

<img width="426" alt="Screen Shot 2020-09-17 at 1 33 16 PM" src="https://user-images.githubusercontent.com/36284167/93525824-6b55a780-f8eb-11ea-9866-a8187d97c2d8.png">

Closes #658 