### PR TITLE
bugfix: disable automatic outbound link manipulation

### DIFF
--- a/packages/docs/.vuepress/config.js
+++ b/packages/docs/.vuepress/config.js
@@ -18,6 +18,12 @@ module.exports = {
     require('./plugins/plugin-choices/index.js'),
     require('./plugins/plugin-micromodal/index.js')
   ],
+  markdown: {
+    externalLinks: {
+      target: '',
+      rel: ''
+    }
+  },
   themeConfig: {
     nav: [
       {


### PR DESCRIPTION
Currently, VuePress turns all outbound links into open-external links and adds an SVG to indicate this.

we want neither of these things to happen, so let's disable both!

Before:

<img width="556" alt="4681bf8a-ac09-4301-b463-088aa380807e" src="https://user-images.githubusercontent.com/36284167/93531859-bf18be80-f8f4-11ea-9ead-86ac597a0d07.png">

After:

<img width="556" alt="Screen Shot 2020-09-17 at 2 47 06 PM" src="https://user-images.githubusercontent.com/36284167/93531868-c4760900-f8f4-11ea-949e-36fc5f969cb0.png">

Confirmed our styles and behaviors are unaffected by this change - this merely removes the additional processing VuePress was doing:

<img width="129" alt="Screen Shot 2020-09-17 at 2 47 10 PM" src="https://user-images.githubusercontent.com/36284167/93531906-d5bf1580-f8f4-11ea-9124-ae284112ed97.png">

Closes #669 