### PR TITLE
bugfix: display type token samples as text, not swatch

### DIFF
--- a/packages/docs/base/tokens.md
+++ b/packages/docs/base/tokens.md
@@ -91,22 +91,22 @@
     <tbody>
       <tr>
         <td><code>$text-body</code></td>
-        <td><span class="sample-token sample-token--text-body">Aa</span></td>
+        <td><span class="sample-token--text-body">Aa</span></td>
         <td>gray, 900</td>
       </tr>
       <tr>
         <td><code>$text-danger</code></td>
-        <td><span class="sample-token sample-token--text-danger">Aa</span></td>
+        <td><span class="sample-token--text-danger">Aa</span></td>
         <td>red, 500</td>
       </tr>
       <tr>
         <td><code>$text-heading</code></td>
-        <td><span class="sample-token sample-token--text-heading">Aa</span></td>
+        <td><span class="sample-token--text-heading">Aa</span></td>
         <td>gray, 900</td>
       </tr>
       <tr>
         <td><code>$text-sub</code></td>
-        <td><span class="sample-token sample-token--text-sub">Aa</span></td>
+        <td><span class="sample-token--text-sub">Aa</span></td>
         <td>gray, 600</td>
       </tr>
     </tbody>


### PR DESCRIPTION
Type samples were previously using one of the swatches intended to display token swatches, leading to some table layout weirdness.

Before:

<img width="846" alt="012d1b1d-ea93-4304-a484-ac1c7aba604b" src="https://user-images.githubusercontent.com/36284167/93532645-4b77b100-f8f6-11ea-89f6-74e76b7187c1.png">

After:

<img width="333" alt="Screen Shot 2020-09-17 at 2 59 01 PM" src="https://user-images.githubusercontent.com/36284167/93532696-60ecdb00-f8f6-11ea-9adc-e7aab00ffcac.png">

Closes: #670 