### PR TITLE
Styled Element: Links + Icons

### DIFF
--- a/packages/docs/components/link.md
+++ b/packages/docs/components/link.md
@@ -2,20 +2,35 @@
 
 # Link
 
-Links are navigation elements displayed as text. A link can open another page or jump to a section of a page.
+Links are navigation elements displayed as text. A link can can be used to bring a user to another page or initiate a download.
 
 <figure class="nimatron--example">
   <div class="nimatron--rendered">
-    <p>If you need more info, <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link" class="is-link-default">view the spec on MDN</a>.</p>
+    <p>If you need more info, <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link">view the spec on MDN</a>.</p>
   </div>
 
   ```html
-  If you need more info, <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link" class="is-link-default">view the spec on MDN</a>.
+  If you need more info, <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link">view the spec on MDN</a>.
   ```
 
 </figure>
 
 ## Specialty cases
+
+### Icons
+
+Icons may be included in standalone links, but are not supported within paragraph content or longer copy. Add the `.ods-link--has-icon` class to ensure proper layout.
+
+<figure class="nimatron--example">
+  <div class="nimatron--rendered">
+    <a href="#icons" class="ods-link--has-icon"><svg aria-hidden viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="ods-icon"><path fill-rule="evenodd" clip-rule="evenodd" d="M7 13C10.3137 13 13 10.3137 13 7C13 3.68629 10.3137 1 7 1C3.68629 1 1 3.68629 1 7C1 10.3137 3.68629 13 7 13ZM8 4C8 4.55228 7.55228 5 7 5C6.44772 5 6 4.55228 6 4C6 3.44772 6.44772 3 7 3C7.55228 3 8 3.44772 8 4ZM8 6V11H6V6H8Z" fill="currentColor"/></svg>Visit our Link docs</a>
+  </div>
+
+  ```html
+  <a href="#icons" class="ods-link--has-icon"><svg aria-hidden>...</svg>Visit our Link docs</a>
+  ```
+
+</figure>
 
 ### Mailto
 

--- a/packages/odyssey/src/scss/base/_iconography.scss
+++ b/packages/odyssey/src/scss/base/_iconography.scss
@@ -4,4 +4,9 @@
   width: 1em;
   height: 1em;
   vertical-align: middle;
+
+  // Prelim RTL styles
+  .ods-rtl & {
+    order: 1;
+  }
 }

--- a/packages/odyssey/src/scss/base/_typography-link.scss
+++ b/packages/odyssey/src/scss/base/_typography-link.scss
@@ -39,3 +39,11 @@ a {
 
   /* stylelint-enable */
 }
+
+.ods-link--has-icon {
+  display: inline-grid;
+  grid-auto-columns: minmax(min-content, max-content);
+  grid-auto-flow: column;
+  grid-gap: $spacing-xs;
+  align-items: center;
+}


### PR DESCRIPTION
Adds guidance and catch-all styling for using Icons as Link content.

This adds an addition `.ods-link--has-icon` style for standalone links with Icons. Grid will treat the text leaf as an independent cell and lay things out automatically (also provides RTL support).

Closes https://github.com/okta/odyssey/issues/682