### PR TITLE
Docs content: Inputs

### DIFF
--- a/packages/docs/components/button.md
+++ b/packages/docs/components/button.md
@@ -11,9 +11,6 @@ tabs:
     id: 'html-scss'
 links:
   - icon: github
-    label: Legacy docs
-    href: https://github.com/okta/odyssey/blob/master/packages/docs/components/button.md
-  - icon: github
     label: View source
     href: https://github.com/okta/odyssey/blob/master/packages/odyssey/src/scss/components/_button.scss
   - icon: figma
@@ -124,7 +121,7 @@ Use Overlay Buttons when Primary or Secondary variants aren't visually suitable.
 
 <Description>
 
-Odyssey provides visual affordances for all standard button states.
+Odyssey provides visual affordances these states: Enabled, Focus, Hover, and Disabled.
 
 </Description>
 

--- a/packages/docs/components/checkbox.md
+++ b/packages/docs/components/checkbox.md
@@ -2,8 +2,8 @@
 template: component
 id: component-checkbox
 title: Checkbox
-description: Radio Buttons appear as a ring shaped UI accompanied by a caption that allows the user to choose only one option at a time.
-lead: Radio Buttons appear as a ring shaped UI accompanied by a caption that allows the user to choose only one option at a time.
+description: Checkboxes appear as a square shaped UI accompanied by a caption.
+lead: Checkboxes appear as a square shaped UI accompanied by a caption. Checkboxes can be found in tables, forms, or in and around text inputs.
 tabs:
   - label: 'Overview'
     id: 'overview'
@@ -38,14 +38,14 @@ Users can click a Checkbox to make a choice and click it again to deselect an op
 
   <fieldset class="ods-fieldset">
     <legend class="ods-input-legend">Payload includes</legend>
-    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-2" value="example-2" checked>
-    <label class="ods-checkbox--label" for="example-2">Tungsten rods</label>
-    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-3" value="example-3" checked>
-    <label class="ods-checkbox--label" for="example-3">Oxygen filters</label>
-    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-3" value="example-3">
-    <label class="ods-checkbox--label" for="example-3">Liquid fuel</label>
-    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-3" value="example-3">
-    <label class="ods-checkbox--label" for="example-3">Replacement crew</label>
+    <input class="ods-checkbox" type="checkbox" name="overview-behavior[]" id="overview-behavior-1" value="tungsten" checked>
+    <label class="ods-checkbox--label" for="overview-behavior-1">Tungsten rods</label>
+    <input class="ods-checkbox" type="checkbox" name="overview-behavior[]" id="overview-behavior-2" value="filters" checked>
+    <label class="ods-checkbox--label" for="overview-behavior-2">Oxygen filters</label>
+    <input class="ods-checkbox" type="checkbox" name="overview-behavior[]" id="overview-behavior-3" value="fuel">
+    <label class="ods-checkbox--label" for="overview-behavior-3">Liquid fuel</label>
+    <input class="ods-checkbox" type="checkbox" name="overview-behavior[]" id="overview-behavior-4" value="crew">
+    <label class="ods-checkbox--label" for="overview-behavior-4">Replacement crew</label>
   </fieldset>
 
 </Visual>
@@ -68,8 +68,8 @@ Checkboxes in their "unchecked" state are considered enabled. They are ready for
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-1" value="example-1">
-    <label class="ods-checkbox--label" for="example-1">Enable auto-docking</label>
+    <input class="ods-checkbox" type="checkbox" name="overview-enabled" id="overview-enabled" value="overview-enabled">
+    <label class="ods-checkbox--label" for="overview-enabled">Enable auto-docking</label>
   </fieldset>
 </Visual>
 
@@ -83,8 +83,8 @@ Hover states are activated when the user pauses their pointer over the input.
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-1" value="example-1">
-    <label class="ods-checkbox--label is-ods-checkbox-hover" for="example-1">Enable auto-docking</label>
+    <input class="ods-checkbox" type="checkbox" name="overview-hover" id="overview-hover" value="overview-hover">
+    <label class="ods-checkbox--label is-ods-checkbox-hover" for="overview-hover">Enable auto-docking</label>
   </fieldset>
 </Visual>
 
@@ -98,8 +98,8 @@ The focus state is a visual affordance that the user has highlighted the input w
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <input class="ods-checkbox is-ods-checkbox-focus" type="checkbox" name="checkbox" id="example-1" value="example-1">
-    <label class="ods-checkbox--label is-ods-checkbox-focus" for="example-1">Enable auto-docking</label>
+    <input class="ods-checkbox is-ods-checkbox-focus" type="checkbox" name="overview-focus" id="overview-focus" value="overview-focus">
+    <label class="ods-checkbox--label is-ods-checkbox-focus" for="overview-focus">Enable auto-docking</label>
   </fieldset>
 </Visual>
 
@@ -113,8 +113,8 @@ Checked Checkboxes, sometimes referred to as "ticked", display a check to indica
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <input checked class="ods-checkbox" type="checkbox" name="checkbox" id="example-1" value="example-1">
-    <label class="ods-checkbox--label" for="example-1">Enable auto-docking</label>
+    <input checked class="ods-checkbox" type="checkbox" name="overview-checked" id="overview-checked" value="overview-checked">
+    <label class="ods-checkbox--label" for="overview-checked">Enable auto-docking</label>
   </fieldset>
 </Visual>
 
@@ -130,8 +130,8 @@ Checkboxes are disabled individually. The values of disabled inputs will not be 
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-1" value="example-1" disabled>
-    <label class="ods-checkbox--label" for="example-1">Enable auto-docking</label>
+    <input class="ods-checkbox" type="checkbox" name="checkbox" id="overview-disabled" value="overview-disabled" disabled>
+    <label class="ods-checkbox--label" for="overview-disabled">Enable auto-docking</label>
   </fieldset>
 </Visual>
 
@@ -150,13 +150,13 @@ Unlike Radio Buttons, Checkboxes validate individually, not as a group.
 <Visual>
   <fieldset class="ods-fieldset">
     <legend class="ods-input-legend">Undocking Procedure</legend>
-    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-0" value="example-0" checked>
-    <label class="ods-checkbox--label" for="example-0">Cycle airlock</label>
-    <input checked class="ods-checkbox" type="checkbox" name="checkbox" id="example-1" value="example-1">
-    <label class="ods-checkbox--label" for="example-1">Disengage maglock</label>
-    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-1" value="example-1" data-invalid checked>
-    <label class="ods-checkbox--label" for="example-1">Open the pod bay doors</label>
-    <aside class="ods-field--error" id="checkbox-invalid-error">
+    <input class="ods-checkbox" type="checkbox" name="overview-invalid[]" id="overview-invalid-1" value="overview-invalid-1" checked>
+    <label class="ods-checkbox--label" for="overview-invalid-1">Cycle airlock</label>
+    <input checked class="ods-checkbox" type="checkbox" name="overview-invalid[]" id="overview-invalid-2" value="overview-invalid-2">
+    <label class="ods-checkbox--label" for="overview-invalid-2">Disengage maglock</label>
+    <input class="ods-checkbox" type="checkbox" name="overview-invalid[]" id="overview-invalid-3" value="overview-invalid-3" aria-describedby="overview-invalid-3-error" data-invalid checked>
+    <label class="ods-checkbox--label" for="overview-invalid-3">Open the pod bay doors</label>
+    <aside class="ods-field--error" id="overview-invalid-3-error">
       <span class="u-visually-hidden">Error:</span> I'm afraid I can't do that, Dave.
     </aside>
   </fieldset>
@@ -174,8 +174,8 @@ Individual checkboxes can be set to required. This is useful when a user confirm
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <input class="ods-checkbox" type="checkbox" name="checkbox-required" id="checkbox-required" value="terms-accepted" checked required>
-    <label class="ods-checkbox--label" for="checkbox-required">I understand the risks of space travel.</label>
+    <input class="ods-checkbox" type="checkbox" name="overview-required" id="overview-required" value="terms-accepted" checked required>
+    <label class="ods-checkbox--label" for="overview-required">I understand the risks of space travel.</label>
   </fieldset>
 </Visual>
 

--- a/packages/docs/components/checkbox.md
+++ b/packages/docs/components/checkbox.md
@@ -54,7 +54,7 @@ Users can click a Checkbox to make a choice and click it again to deselect an op
 
 <Description>
 
-Checkboxex support several states: enabled, hover, focus, disabled, invalid, required, and indeterminate.
+Checkboxes support several states: enabled, hover, focus, disabled, invalid, required, and indeterminate.
 
 </Description>
 

--- a/packages/docs/components/checkbox.md
+++ b/packages/docs/components/checkbox.md
@@ -2,8 +2,8 @@
 template: component
 id: component-checkbox
 title: Checkbox
-description: Typically shown in sets, Checkboxes appear as a square shaped UI accompanied by a caption.
-lead: Typically shown in sets, Checkboxes appear as a square shaped UI accompanied by a caption. Checkboxes can be found in tables, forms, or in and around text inputs.
+description: Radio Buttons appear as a ring shaped UI accompanied by a caption that allows the user to choose only one option at a time.
+lead: Radio Buttons appear as a ring shaped UI accompanied by a caption that allows the user to choose only one option at a time.
 tabs:
   - label: 'Overview'
     id: 'overview'
@@ -54,9 +54,54 @@ Users can click a Checkbox to make a choice and click it again to deselect an op
 
 <Description>
 
-There are six Checkbox states: Checked, unchecked, disabled, invalid, optional/required, and indeterminate.
+Checkboxex support several states: enabled, hover, focus, disabled, invalid, required, and indeterminate.
 
 </Description>
+
+### Enabled
+
+<Description>
+
+Checkboxes in their "unchecked" state are considered enabled. They are ready for user interaction.
+
+</Description>
+
+<Visual>
+  <fieldset class="ods-fieldset">
+    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-1" value="example-1">
+    <label class="ods-checkbox--label" for="example-1">Enable auto-docking</label>
+  </fieldset>
+</Visual>
+
+### Hover
+
+<Description>
+
+Hover states are activated when the user pauses their pointer over the input.
+
+</Description>
+
+<Visual>
+  <fieldset class="ods-fieldset">
+    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-1" value="example-1">
+    <label class="ods-checkbox--label is-ods-checkbox-hover" for="example-1">Enable auto-docking</label>
+  </fieldset>
+</Visual>
+
+### Focus
+
+<Description>
+
+The focus state is a visual affordance that the user has highlighted the input with a pointer, keyboard, or voice.
+
+</Description>
+
+<Visual>
+  <fieldset class="ods-fieldset">
+    <input class="ods-checkbox is-ods-checkbox-focus" type="checkbox" name="checkbox" id="example-1" value="example-1">
+    <label class="ods-checkbox--label is-ods-checkbox-focus" for="example-1">Enable auto-docking</label>
+  </fieldset>
+</Visual>
 
 ### Checked
 
@@ -73,21 +118,6 @@ Checked Checkboxes, sometimes referred to as "ticked", display a check to indica
   </fieldset>
 </Visual>
 
-### Unchecked
-
-<Description>
-
-Unchecked Checkboxes appear as stated above as a rounded rectangle with white fill. This indicates that the Checkbox is not selected.
-
-</Description>
-
-<Visual>
-  <fieldset class="ods-fieldset">
-    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-1" value="example-1">
-    <label class="ods-checkbox--label" for="example-1">Allow low-oxygen mix</label>
-  </fieldset>
-</Visual>
-
 ### Disabled
 
 <Description>
@@ -100,8 +130,8 @@ Checkboxes are disabled individually. The values of disabled inputs will not be 
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-0" value="example-0" disabled>
-    <label class="ods-checkbox--label" for="example-0">Open pod bay doors</label>
+    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-1" value="example-1" disabled>
+    <label class="ods-checkbox--label" for="example-1">Enable auto-docking</label>
   </fieldset>
 </Visual>
 
@@ -109,11 +139,11 @@ Checkboxes are disabled individually. The values of disabled inputs will not be 
 
 <Description>
 
-Checkboxes present as invalid when a required input is left unchecked or some other criteria isn’t met.
+Checkboxes present as invalid when a required input is left unchecked or an incompatible choice has been made.
+
+When indicating a validation error, please use a Field Error label to indicate the nature of the error. Color alone is not an accessible way to signify that something has gone wrong.
 
 Unlike Radio Buttons, Checkboxes validate individually, not as a group.
-
-Visually, they appear in an error red color.
 
 </Description>
 
@@ -125,8 +155,10 @@ Visually, they appear in an error red color.
     <input checked class="ods-checkbox" type="checkbox" name="checkbox" id="example-1" value="example-1">
     <label class="ods-checkbox--label" for="example-1">Disengage maglock</label>
     <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-1" value="example-1" data-invalid checked>
-    <label class="ods-checkbox--label" for="example-1">Release docking clamps</label>
-    <aside class="ods-field--error" id="checkbox-invalid-error">Clamp C is still engaged.</aside>
+    <label class="ods-checkbox--label" for="example-1">Open the pod bay doors</label>
+    <aside class="ods-field--error" id="checkbox-invalid-error">
+      <span class="u-visually-hidden">Error:</span> I'm afraid I can't do that, Dave.
+    </aside>
   </fieldset>
 </Visual>
 
@@ -184,7 +216,7 @@ Note that this state is visual-only and will be submitted as either "checked" or
               <span class="u-visually-hidden">Select this row</span>
             </label>
           </td>
-          <td>Hermetic seals</td>
+          <td>Tribbles</td>
           <td class="is-ods-table-num">8,514,877</td>
         </tr>
         <tr>

--- a/packages/docs/components/checkbox.md
+++ b/packages/docs/components/checkbox.md
@@ -2,7 +2,8 @@
 template: component
 id: component-checkbox
 title: Checkbox
-description: Allows a user to make decisions and opt in to multiple attributes of a product.
+description: Typically shown in sets, Checkboxes appear as a square shaped UI accompanied by a caption.
+lead: Typically shown in sets, Checkboxes appear as a square shaped UI accompanied by a caption. Checkboxes can be found in tables, forms, or in and around text inputs.
 tabs:
   - label: 'Overview'
     id: 'overview'
@@ -21,63 +22,86 @@ links:
 
 ## Anatomy
 
-<Description class="is-fpo">
-
-Descriptive content around **checkbox anatomy** should go here.
-
-</Description>
-
 <Anatomy
   img="/images/anatomy-checkbox.svg"
 />
 
+## Behavior
+
 <Description>
 
-> <span class="is-fpo is-fpo-negative">`<input>` elements of type checkbox are rendered by default as square boxes that are checked (ticked) when activated, like you might see in an official government paper form. They allow you to select single values for submission in a form (or not). - <cite><a href='https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox'>MDN</a></cite> </span>
+Users can click a Checkbox to make a choice and click it again to deselect an option. They allow users to select one or more options of something.
 
 </Description>
 
 <Visual>
 
   <fieldset class="ods-fieldset">
-    <legend class="ods-input-legend">Donut toppings</legend>
-    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-2" value="example-2">
-    <label class="ods-checkbox--label" for="example-2">Sprinkles</label>
+    <legend class="ods-input-legend">Payload includes</legend>
+    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-2" value="example-2" checked>
+    <label class="ods-checkbox--label" for="example-2">Tungsten rods</label>
+    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-3" value="example-3" checked>
+    <label class="ods-checkbox--label" for="example-3">Oxygen filters</label>
     <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-3" value="example-3">
-    <label class="ods-checkbox--label" for="example-3">Peanuts</label>
+    <label class="ods-checkbox--label" for="example-3">Liquid fuel</label>
     <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-3" value="example-3">
-    <label class="ods-checkbox--label" for="example-3">Shredded coconut</label>
-    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-3" value="example-3">
-    <label class="ods-checkbox--label" for="example-3">Oreos</label>
+    <label class="ods-checkbox--label" for="example-3">Replacement crew</label>
   </fieldset>
 
 </Visual>
 
 ## States
 
-<Description class="is-fpo">
+<Description>
 
-Descriptive content around **states** should go here.
+There are six Checkbox states: Checked, unchecked, disabled, invalid, optional/required, and indeterminate.
 
 </Description>
 
-### Disabled
+### Checked
 
 <Description>
 
-> <span class="is-fpo is-fpo-negative">This Boolean attribute prevents the user from interacting with the input. In particular, the `click` event is not dispatched on disabled controls, and disabled controls aren't submitted with their form. - <cite><a href='https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-disabled'>MDN</a></cite></span>
-
-Disabling checkboxes happens on a per-option basis.
+Checked Checkboxes, sometimes referred to as "ticked", display a check to indicate the they are selected.
 
 </Description>
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <legend class="ods-input-legend">Disabled examples</legend>
+    <input checked class="ods-checkbox" type="checkbox" name="checkbox" id="example-1" value="example-1">
+    <label class="ods-checkbox--label" for="example-1">Enable auto-docking</label>
+  </fieldset>
+</Visual>
+
+### Unchecked
+
+<Description>
+
+Unchecked Checkboxes appear as stated above as a rounded rectangle with white fill. This indicates that the Checkbox is not selected.
+
+</Description>
+
+<Visual>
+  <fieldset class="ods-fieldset">
+    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-1" value="example-1">
+    <label class="ods-checkbox--label" for="example-1">Allow low-oxygen mix</label>
+  </fieldset>
+</Visual>
+
+### Disabled
+
+<Description>
+
+Disabled inputs are unavailable for interaction and cannot be focused. They can be used when input is disallowed, possibly due to a system state or access restrictions.
+
+Checkboxes are disabled individually. The values of disabled inputs will not be submitted.
+
+</Description>
+
+<Visual>
+  <fieldset class="ods-fieldset">
     <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-0" value="example-0" disabled>
-    <label class="ods-checkbox--label" for="example-0">Unchecked</label>
-    <input checked class="ods-checkbox" type="checkbox" name="checkbox" id="example-1" value="example-1" disabled>
-    <label class="ods-checkbox--label" for="example-1">Checked</label>
+    <label class="ods-checkbox--label" for="example-0">Open pod bay doors</label>
   </fieldset>
 </Visual>
 
@@ -85,43 +109,41 @@ Disabling checkboxes happens on a per-option basis.
 
 <Description>
 
-> <span class="is-fpo is-fpo-negative">The :invalid CSS pseudo-class represents any `<input>` or other `<form>` element whose contents fail to validate. - <cite><a href='https://developer.mozilla.org/en-US/docs/Web/CSS/:invalid'>MDN</a></cite></span>
+Checkboxes present as invalid when a required input is left unchecked or some other criteria isn’t met.
 
-Because of the current inability to ensure consistent validation behavior across browsers, we're using the `[data-invalid]` attribute to indicate this state.
+Unlike Radio Buttons, Checkboxes validate individually, not as a group.
 
-Note, when indicating a validation error, please use an `.ods-field--error` to indicate the nature of the error. Color alone is not an accessible way to signify that something has gone wrong.
-
-Unlike radio buttons, checkboxes validate individually, not as a group.
+Visually, they appear in an error red color.
 
 </Description>
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <legend class="ods-input-legend">Invalid examples</legend>
-    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-0" value="example-0" data-invalid>
-    <label class="ods-checkbox--label" for="example-0">Unchecked</label>
-    <input checked class="ods-checkbox" type="checkbox" name="checkbox" id="example-1" value="example-1" data-invalid>
-    <label class="ods-checkbox--label" for="example-1">Checked</label>
-    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-1" value="example-1" data-invalid data-example-indeterminate>
-    <label class="ods-checkbox--label" for="example-1">Indeterminate</label>
-    <aside class="ods-field--error" id="checkbox-invalid-error">Validation error message.</aside>
+    <legend class="ods-input-legend">Undocking Procedure</legend>
+    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-0" value="example-0" checked>
+    <label class="ods-checkbox--label" for="example-0">Cycle airlock</label>
+    <input checked class="ods-checkbox" type="checkbox" name="checkbox" id="example-1" value="example-1">
+    <label class="ods-checkbox--label" for="example-1">Disengage maglock</label>
+    <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-1" value="example-1" data-invalid checked>
+    <label class="ods-checkbox--label" for="example-1">Release docking clamps</label>
+    <aside class="ods-field--error" id="checkbox-invalid-error">Clamp C is still engaged.</aside>
   </fieldset>
 </Visual>
 
-### Optional/Required
+### Required
 
 <Description>
 
-Unlike radio buttons, checkbox groups do not validate as a group. By default, checkbox groups should be treated as `:optional`.
+Unlike other inputs, Odyssey assumes Checkboxes are optional by default.
 
-Individually, checkboxes can be set to `required` - most commonly seen when a user confirms they have read terms of service.
+Individual checkboxes can be set to required. This is useful when a user confirms they have read the terms of service.
 
 </Description>
 
 <Visual>
   <fieldset class="ods-fieldset">
     <input class="ods-checkbox" type="checkbox" name="checkbox-required" id="checkbox-required" value="terms-accepted" checked required>
-    <label class="ods-checkbox--label" for="checkbox-required">I agree to share the donut assortment.</label>
+    <label class="ods-checkbox--label" for="checkbox-required">I understand the risks of space travel.</label>
   </fieldset>
 </Visual>
 
@@ -129,19 +151,19 @@ Individually, checkboxes can be set to `required` - most commonly seen when a us
 
 <Description>
 
-In the case of nested checkboxes, an `:indeterminate` state may be required.
+In the case of nested checkboxes, an indeterminate state may be required.
 
-Please note that this state must be set via javascript and is not reflected in the DOM - only `checked` and `unchecked` states will be submitted by default.
+Note that this state is visual-only and will be submitted as either "checked" or "unchecked" depending on the design of your UI.
 
 </Description>
 
 <Visual>
   <figure class="ods-table--figure">
     <figcaption class="ods-table--figcaption">
-      Best donuts poll results
+      Hangar 18 inventory
     </figcaption>
     <table class="ods-table">
-      <caption>Results of the most popular donuts poll administered October 2020.</caption>
+      <caption>A checklist for auditing facility storage.</caption>
       <thead>
         <tr>
           <th scope="column" class="is-ods-table-checkbox">
@@ -150,32 +172,29 @@ Please note that this state must be set via javascript and is not reflected in t
               <span class="u-visually-hidden">Select this row</span>
             </label>
           </th>
-          <th scope="column" class="is-ods-table-num">Rank</th>
-          <th scope="column">Name</th>
-          <th scope="column">Votes</th>
+          <th scope="column">Item</th>
+          <th scope="column" class="is-ods-table-num">Count</th>
         </tr>
       </thead>
       <tbody>
         <tr>
           <td class="is-ods-table-checkbox">
-            <input class="ods-checkbox" type="checkbox" name="row[0]" id="checkbox-0" value="check-0">
+            <input class="ods-checkbox" type="checkbox" name="row[0]" id="checkbox-0" value="check-0" checked>
             <label class="ods-checkbox--label" for="checkbox-0">
               <span class="u-visually-hidden">Select this row</span>
             </label>
           </td>
-          <td class="is-ods-table-num">1</td>
-          <td>Glazed</td>
+          <td>Hermetic seals</td>
           <td class="is-ods-table-num">8,514,877</td>
         </tr>
         <tr>
           <td class="is-ods-table-checkbox">
-            <input class="ods-checkbox" type="checkbox" name="row[1]" id="checkbox-1" value="check-1">
+            <input class="ods-checkbox" type="checkbox" name="row[1]" id="checkbox-1" value="check-1" checked>
             <label class="ods-checkbox--label" for="checkbox-1">
               <span class="u-visually-hidden">Select this row</span>
             </label>
           </td>
-          <td class="is-ods-table-num">2</td>
-          <td>Chocolate Glazed</td>
+          <td>Tiny flags</td>
           <td class="is-ods-table-num">2,780,400</td>
         </tr>
         <tr>
@@ -185,8 +204,7 @@ Please note that this state must be set via javascript and is not reflected in t
               <span class="u-visually-hidden">Select this row</span>
             </label>
           </td>
-          <td class="is-ods-table-num">3</td>
-          <td>Boston Creme</td>
+          <td>Moon rocks</td>
           <td class="is-ods-table-num">2,344,858</td>
         </tr>
       </tbody>

--- a/packages/docs/components/checkbox.md
+++ b/packages/docs/components/checkbox.md
@@ -10,9 +10,6 @@ tabs:
     id: 'html-scss'
 links:
   - icon: github
-    label: Legacy docs
-    href: https://github.com/okta/odyssey/blob/master/packages/docs/components/checkbox.md
-  - icon: github
     label: View source
     href: https://github.com/okta/odyssey/blob/master/packages/odyssey/src/scss/components/_checkbox.scss
   - icon: figma
@@ -30,8 +27,8 @@ Descriptive content around **checkbox anatomy** should go here.
 
 </Description>
 
-<Anatomy 
-  img="/images/anatomy-checkbox.svg" 
+<Anatomy
+  img="/images/anatomy-checkbox.svg"
 />
 
 <Description>
@@ -41,7 +38,7 @@ Descriptive content around **checkbox anatomy** should go here.
 </Description>
 
 <Visual>
-  
+
   <fieldset class="ods-fieldset">
     <legend class="ods-input-legend">Donut toppings</legend>
     <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-2" value="example-2">
@@ -53,7 +50,7 @@ Descriptive content around **checkbox anatomy** should go here.
     <input class="ods-checkbox" type="checkbox" name="checkbox" id="example-3" value="example-3">
     <label class="ods-checkbox--label" for="example-3">Oreos</label>
   </fieldset>
-  
+
 </Visual>
 
 ## States
@@ -199,7 +196,7 @@ Please note that this state must be set via javascript and is not reflected in t
 
 <script>
 export default {
-  mounted () { 
+  mounted () {
     let checkbox = this.$el.querySelectorAll("[data-example-indeterminate]");
 
     checkbox.forEach((input) => {

--- a/packages/docs/components/field-labels.md
+++ b/packages/docs/components/field-labels.md
@@ -1,0 +1,22 @@
+---
+template: component
+title: Field Labels
+description:
+lead:
+tabs:
+  - label: 'Overview'
+    id: 'overview'
+  - label: 'HTML & SCSS'
+    id: 'html-scss'
+links:
+  - icon: github
+    label: View source
+    href: https://github.com/okta/odyssey/blob/master/packages/odyssey/src/scss/components/_label.scss
+  - icon: figma
+    label: View designs
+    href: https://www.figma.com/file/tVkWsXwnWICeguWhzX6Vwl/Inputs?node-id=476%3A3848
+---
+
+::: slot overview
+
+:::

--- a/packages/docs/components/link.md
+++ b/packages/docs/components/link.md
@@ -11,7 +11,7 @@ tabs:
     id: 'html-scss'
 links:
   - icon: github
-    label: View code
+    label: View Source
     href: https://github.com/okta/odyssey/blob/master/packages/odyssey/src/scss/base/_typography-link.scss
   - icon: figma
     label: View designs

--- a/packages/docs/components/radio-button.md
+++ b/packages/docs/components/radio-button.md
@@ -37,12 +37,12 @@ Radio Buttons allow users to select one option from a set. Users can click a Rad
 <Visual>
   <fieldset class="ods-fieldset">
     <legend class="ods-input-legend">Select speed</legend>
-    <input class="ods-radio" type="radio" name="question-0" id="radio-0-glazed" value="0" required>
-    <label class="ods-radio--label" for="radio-0-glazed">Lightspeed</label>
-    <input class="ods-radio" type="radio" name="question-0" id="radio-0-boston-cream" value="3" required checked>
-    <label class="ods-radio--label" for="radio-0-boston-cream">Warp Speed</label>
-    <input class="ods-radio" type="radio" name="question-0" id="radio-0-homer" value="3" required>
-    <label class="ods-radio--label" for="radio-0-homer">Ludicrous Speed</label>
+    <input class="ods-radio" type="radio" name="overview-behavior" id="overview-behavior-1" value="1" required>
+    <label class="ods-radio--label" for="overview-behavior-1">Lightspeed</label>
+    <input class="ods-radio" type="radio" name="overview-behavior" id="roverview-behavior-2" value="2" required checked>
+    <label class="ods-radio--label" for="overview-behavior-2">Warp Speed</label>
+    <input class="ods-radio" type="radio" name="overview-behavior" id="overview-behavior-3" value="3" required>
+    <label class="ods-radio--label" for="overview-behavior-3">Ludicrous Speed</label>
   </fieldset>
 </Visual>
 
@@ -64,8 +64,8 @@ Radio Buttons in their "unchecked" state are considered enabled. They are ready 
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <input class="ods-radio" type="radio" name="question-0" id="radio-0-glazed" value="0" required>
-    <label class="ods-radio--label" for="radio-0-glazed">Warp speed</label>
+    <input class="ods-radio" type="radio" name="overview-enabled" id="overview-enabled" value="0" required>
+    <label class="ods-radio--label" for="overview-enabled">Warp speed</label>
   </fieldset>
 </Visual>
 
@@ -79,8 +79,8 @@ Hover states are activated when the user pauses their pointer over the input.
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <input class="ods-radio" type="radio" name="question-0" id="radio-0-glazed" value="0" required>
-    <label class="ods-radio--label is-ods-radio-hover" for="radio-0-glazed">Warp speed</label>
+    <input class="ods-radio" type="radio" name="overview-hover" id="overview-hover" value="0" required>
+    <label class="ods-radio--label is-ods-radio-hover" for="overview-hover">Warp speed</label>
   </fieldset>
 </Visual>
 
@@ -94,8 +94,8 @@ The focus state is a visual affordance that the user has highlighted the input w
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <input class="ods-radio is-ods-radio-focus" type="radio" name="question-0" id="radio-0-glazed" value="0" required>
-    <label class="ods-radio--label" for="radio-0-glazed">Warp speed</label>
+    <input class="ods-radio is-ods-radio-focus" type="radio" name="overview-focus" id="overview-focus" value="0" required>
+    <label class="ods-radio--label" for="overview-focus">Warp speed</label>
   </fieldset>
 </Visual>
 
@@ -109,8 +109,8 @@ Checked Radios display a blue fill to indicate the they are selected.
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <input class="ods-radio" type="radio" name="question-0" id="radio-0-glazed" value="0" required checked>
-    <label class="ods-radio--label" for="radio-0-glazed">Warp speed</label>
+    <input class="ods-radio" type="radio" name="overview-checked" id="overview-checked" value="0" required checked>
+    <label class="ods-radio--label" for="overview-checked">Warp speed</label>
   </fieldset>
 </Visual>
 
@@ -126,8 +126,8 @@ Radios are disabled by option.
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <input class="ods-radio" type="radio" name="question-0" id="radio-0-glazed" value="0" required disabled>
-    <label class="ods-radio--label" for="radio-0-glazed">Warp speed</label>
+    <input class="ods-radio" type="radio" name="overview-disabled" id="overview-disabled" value="0" required disabled>
+    <label class="ods-radio--label" for="overview-disabled">Warp speed</label>
   </fieldset>
 </Visual>
 
@@ -142,12 +142,12 @@ Odyssey assumes inputs are required by default. Optional inputs should be used t
 <Visual>
   <fieldset class="ods-fieldset">
     <legend class="ods-input-legend">Select speed  <span class="ods-label--optional">Optional</span></legend>
-    <input class="ods-radio" type="radio" name="question-0" id="radio-0-glazed" value="0">
-    <label class="ods-radio--label" for="radio-0-glazed">Lightspeed</label>
-    <input class="ods-radio" type="radio" name="question-0" id="radio-0-boston-cream" value="3" checked>
-    <label class="ods-radio--label" for="radio-0-boston-cream">Warp Speed</label>
-    <input class="ods-radio" type="radio" name="question-0" id="radio-0-homer" value="3">
-    <label class="ods-radio--label" for="radio-0-homer">Ludicrous Speed</label>
+    <input class="ods-radio" type="radio" name="overview-optional[]" id="overview-optional-1" value="1">
+    <label class="ods-radio--label" for="overview-optional-1">Lightspeed</label>
+    <input class="ods-radio" type="radio" name="overview-optional[]" id="overview-optional-2" value="2" checked>
+    <label class="ods-radio--label" for="overview-optional-2">Warp Speed</label>
+    <input class="ods-radio" type="radio" name="overview-optional[]" id="overview-optional-3" value="3">
+    <label class="ods-radio--label" for="overview-optional-3">Ludicrous Speed</label>
   </fieldset>
 </Visual>
 
@@ -166,13 +166,13 @@ Unlike Checkboxes, Radios validate as a group, not individually.
 <Visual>
   <fieldset class="ods-fieldset">
     <legend class="ods-input-legend">Select speed</legend>
-    <input class="ods-radio" type="radio" name="question-0" id="radio-0-glazed" value="0" required data-invalid checked>
-    <label class="ods-radio--label" for="radio-0-glazed">Lightspeed</label>
-    <input class="ods-radio" type="radio" name="question-0" id="radio-0-boston-cream" value="3" required data-invalid>
-    <label class="ods-radio--label" for="radio-0-boston-cream">Warp Speed</label>
-    <input class="ods-radio" type="radio" name="question-0" id="radio-0-homer" value="3" required data-invalid>
-    <label class="ods-radio--label" for="radio-0-homer">Ludicrous Speed</label>
-    <aside class="ods-field--error" id="checkbox-invalid-error">The general theory of relativity forbids it.</aside>
+    <input class="ods-radio" type="radio" name="overview-invalid[]" id="overview-invalid-1" value="1" required data-invalid checked>
+    <label class="ods-radio--label" for="overview-invalid-1">Lightspeed</label>
+    <input class="ods-radio" type="radio" name="overview-invalid[]" id="overview-invalid-2" value="2" required data-invalid>
+    <label class="ods-radio--label" for="overview-invalid-2">Warp Speed</label>
+    <input class="ods-radio" type="radio" name="overview-invalid[]" id="overview-invalid-3" value="3" aria-describedby="overview-invalid-error" required data-invalid>
+    <label class="ods-radio--label" for="overview-invalid-3">Ludicrous Speed</label>
+    <aside class="ods-field--error" id="overview-invalid-error">General relativity forbids it.</aside>
   </fieldset>
 </Visual>
 

--- a/packages/docs/components/radio-button.md
+++ b/packages/docs/components/radio-button.md
@@ -2,7 +2,8 @@
 template: component
 id: component-radio-button
 title: Radio Button
-description: Allows a user to make decisions and opt in to single attributes of a product.
+description: Radios appear as a ring shaped UI accompanied by a caption that allows the user to choose only one option at a time.
+lead:
 tabs:
   - label: 'Overview'
     id: 'overview'
@@ -21,78 +22,112 @@ links:
 
 ## Anatomy
 
-<Description class="is-fpo">
-
-Descriptive content around **radio button anatomy** should go here.
-
-</Description>
-
 <Anatomy
   img="/images/anatomy-radio-button.svg"
 />
 
+## Behavior
+
 <Description>
 
-> <span class="is-fpo is-fpo-negative">`<input>` elements of type radio are generally used in radio groups—collections of radio buttons describing a set of related options. Only one radio button in a given group can be selected at the same time. Radio buttons are typically rendered as small circles, which are filled or highlighted when selected. - <cite><a href='https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio'>MDN</a></cite></span>
+Radio Buttons allow users to select one option from a set. Users can click a Radio to make a choice; selecting another will deselect the last.
 
 </Description>
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <legend class="ods-input-legend">Which donut has pink frosting?</legend>
-    <input class="ods-radio" type="radio" name="question-0" id="radio-0-glazed" value="0" required checked>
-    <label class="ods-radio--label" for="radio-0-glazed">Glazed</label>
-    <input class="ods-radio" type="radio" name="question-0" id="radio-0-boston-cream" value="3" required>
-    <label class="ods-radio--label" for="radio-0-boston-cream">Boston Cream</label>
-    <input class="ods-radio" type="radio" name="question-0" id="radio-0-homer" value="3" required checked>
-    <label class="ods-radio--label" for="radio-0-homer">"The Homer"</label>
-    <input class="ods-radio" type="radio" name="question-0" id="radio-0-old-fashioned" value="3" required>
-    <label class="ods-radio--label" for="radio-0-old-fashioned">Old Fashioned</label>
+    <legend class="ods-input-legend">Select speed</legend>
+    <input class="ods-radio" type="radio" name="question-0" id="radio-0-glazed" value="0" required>
+    <label class="ods-radio--label" for="radio-0-glazed">Lightspeed</label>
+    <input class="ods-radio" type="radio" name="question-0" id="radio-0-boston-cream" value="3" required checked>
+    <label class="ods-radio--label" for="radio-0-boston-cream">Warp Speed</label>
+    <input class="ods-radio" type="radio" name="question-0" id="radio-0-homer" value="3" required>
+    <label class="ods-radio--label" for="radio-0-homer">Ludicrous Speed</label>
   </fieldset>
 </Visual>
 
 ## States
 
+<Description>
+
+There are fives Checkbox states: enabled, hover, focus, disabled, invalid, and optional.
+
+</Description>
+
+### Enabled
+
+<Description>
+
+Radio Buttons in their "unchecked" state are considered enabled. They are ready for user interaction.
+
+</Description>
+
+<Visual>
+  <fieldset class="ods-fieldset">
+    <input class="ods-radio" type="radio" name="question-0" id="radio-0-glazed" value="0" required>
+    <label class="ods-radio--label" for="radio-0-glazed">Warp speed</label>
+  </fieldset>
+</Visual>
+
+### Hover
+
+<Description>
+
+Hover states are activated when the user pauses their pointer over the input.
+
+</Description>
+
+<Visual>
+  <fieldset class="ods-fieldset">
+    <input class="ods-radio" type="radio" name="question-0" id="radio-0-glazed" value="0" required>
+    <label class="ods-radio--label is-ods-radio-hover" for="radio-0-glazed">Warp speed</label>
+  </fieldset>
+</Visual>
+
+### Focus
+
+<Description>
+
+The focus state is a visual affordance that the user has highlighted the input with a pointer, keyboard, or voice.
+
+</Description>
+
+<Visual>
+  <fieldset class="ods-fieldset">
+    <input class="ods-radio is-ods-radio-focus" type="radio" name="question-0" id="radio-0-glazed" value="0" required>
+    <label class="ods-radio--label" for="radio-0-glazed">Warp speed</label>
+  </fieldset>
+</Visual>
+
+### Checked
+
+<Description>
+
+Checked Radios display a blue fill to indicate the they are selected.
+
+</Description>
+
+<Visual>
+  <fieldset class="ods-fieldset">
+    <input class="ods-radio" type="radio" name="question-0" id="radio-0-glazed" value="0" required checked>
+    <label class="ods-radio--label" for="radio-0-glazed">Warp speed</label>
+  </fieldset>
+</Visual>
+
 ### Disabled
 
 <Description>
 
-> <span class="is-fpo is-fpo-negative">This Boolean attribute prevents the user from interacting with the input. In particular, the `click` event is not dispatched on disabled controls, and disabled controls aren't submitted with their form. - <cite><a href='https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-disabled'>MDN</a></cite></span>
+Disabled inputs are unavailable for interaction and cannot be focused. They can be used when input is disallowed, possibly due to a system state or access restrictions.
 
-Disabling radio buttons happens on a per-option basis.
-
-</Description>
-
-<Visual>
-  <fieldset class="ods-fieldset">
-    <legend class="ods-input-legend">Disabled examples</legend>
-    <input class="ods-radio" type="radio" name="question-1" id="radio-1-unchecked" value="0" disabled >
-    <label class="ods-radio--label" for="radio-1-unchecked">Unchecked</label>
-    <input class="ods-radio" type="radio" name="question-1" id="radio-1-checked" value="1"  disabled checked>
-    <label class="ods-radio--label" for="radio-1-checked">Checked</label>
-  </fieldset>
-</Visual>
-
-### Invalid
-
-<Description>
-
-> <span class="is-fpo is-fpo-negative">The :invalid CSS pseudo-class represents any `<input>` or other `<form>` element whose contents fail to validate. - <cite><a href='https://developer.mozilla.org/en-US/docs/Web/CSS/:invalid'>MDN</a></cite></span>
-
-Because of the current inability to ensure consistent validation behavior across browsers, we're using the `[data-invalid]` attribute to indicate this state.
-
-Note, when indicating a validation error, please use an `.ods-field--error` to indicate the nature of the error. Color alone is not an accessible way to signify that something has gone wrong.
+Radios are disabled by option.
 
 </Description>
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <legend class="ods-input-legend">Invalid examples</legend>
-    <input class="ods-radio" type="radio" name="question-2" id="radio-2-unchecked" value="0" data-invalid>
-    <label class="ods-radio--label" for="radio-2-unchecked">Unchecked</label>
-    <input class="ods-radio" type="radio" name="question-2" id="radio-2-checked" value="1"  data-invalid checked>
-    <label class="ods-radio--label" for="radio-2-checked">Checked</label>
-    <aside class="ods-field--error" id="checkbox-invalid-error">Validation error message.</aside>
+    <input class="ods-radio" type="radio" name="question-0" id="radio-0-glazed" value="0" required disabled>
+    <label class="ods-radio--label" for="radio-0-glazed">Warp speed</label>
   </fieldset>
 </Visual>
 
@@ -100,9 +135,46 @@ Note, when indicating a validation error, please use an `.ods-field--error` to i
 
 <Description>
 
-> <span class="is-fpo is-fpo-negative">To avoid confusion as to whether a radio button group is required or not, authors are encouraged to specify the attribute on all the radio buttons in a group. - <cite><a href="https://www.w3.org/TR/html5/forms.html#the-required-attribute">W3</a></cite></span>
+Odyssey assumes inputs are required by default. Optional inputs should be used to indicate when data is not required for the user to complete a task.
 
 </Description>
+
+<Visual>
+  <fieldset class="ods-fieldset">
+    <legend class="ods-input-legend">Select speed  <span class="ods-label--optional">Optional</span></legend>
+    <input class="ods-radio" type="radio" name="question-0" id="radio-0-glazed" value="0">
+    <label class="ods-radio--label" for="radio-0-glazed">Lightspeed</label>
+    <input class="ods-radio" type="radio" name="question-0" id="radio-0-boston-cream" value="3" checked>
+    <label class="ods-radio--label" for="radio-0-boston-cream">Warp Speed</label>
+    <input class="ods-radio" type="radio" name="question-0" id="radio-0-homer" value="3">
+    <label class="ods-radio--label" for="radio-0-homer">Ludicrous Speed</label>
+  </fieldset>
+</Visual>
+
+### Invalid
+
+<Description>
+
+Radios present as invalid when a required input is left unchecked or an incompatible choice has been made.
+
+When indicating a validation error, please use a Field Error label to indicate the nature of the error. Color alone is not an accessible way to signify that something has gone wrong.
+
+Unlike Checkboxes, Radios validate as a group, not individually.
+
+</Description>
+
+<Visual>
+  <fieldset class="ods-fieldset">
+    <legend class="ods-input-legend">Select speed</legend>
+    <input class="ods-radio" type="radio" name="question-0" id="radio-0-glazed" value="0" required data-invalid checked>
+    <label class="ods-radio--label" for="radio-0-glazed">Lightspeed</label>
+    <input class="ods-radio" type="radio" name="question-0" id="radio-0-boston-cream" value="3" required data-invalid>
+    <label class="ods-radio--label" for="radio-0-boston-cream">Warp Speed</label>
+    <input class="ods-radio" type="radio" name="question-0" id="radio-0-homer" value="3" required data-invalid>
+    <label class="ods-radio--label" for="radio-0-homer">Ludicrous Speed</label>
+    <aside class="ods-field--error" id="checkbox-invalid-error">The general theory of relativity forbids it.</aside>
+  </fieldset>
+</Visual>
 
 :::
 

--- a/packages/docs/components/radio-button.md
+++ b/packages/docs/components/radio-button.md
@@ -3,7 +3,7 @@ template: component
 id: component-radio-button
 title: Radio Button
 description: Radios appear as a ring shaped UI accompanied by a caption that allows the user to choose only one option at a time.
-lead:
+lead: Radios appear as a ring shaped UI accompanied by a caption that allows the user to choose only one option at a time.
 tabs:
   - label: 'Overview'
     id: 'overview'

--- a/packages/docs/components/radio-button.md
+++ b/packages/docs/components/radio-button.md
@@ -10,9 +10,6 @@ tabs:
     id: 'html-scss'
 links:
   - icon: github
-    label: Legacy docs
-    href: https://github.com/okta/odyssey/blob/master/packages/docs/components/modal.md
-  - icon: github
     label: View source
     href: https://github.com/okta/odyssey/blob/master/packages/odyssey/src/scss/components/_radio-button.scss
   - icon: figma
@@ -30,8 +27,8 @@ Descriptive content around **radio button anatomy** should go here.
 
 </Description>
 
-<Anatomy 
-  img="/images/anatomy-radio-button.svg" 
+<Anatomy
+  img="/images/anatomy-radio-button.svg"
 />
 
 <Description>
@@ -205,7 +202,7 @@ Note, when indicating a validation error, please use an `.ods-field--error` to i
     <label class="ods-radio--label" for="radio-moon">The moon</label>
     <input class="ods-radio" type="radio" name="radio" id="radio-tennis-ball" value="tennis-ball" required>
     <label class="ods-radio--label" for="radio-tennis-ball">A tennis ball</label>
-    
+
     <aside class="ods-field--error" id="radio-invalid-error">This field is required.</aside>
   </fieldset>
   ```

--- a/packages/docs/components/select.md
+++ b/packages/docs/components/select.md
@@ -11,9 +11,6 @@ tabs:
     id: 'html-scss'
 links:
   - icon: github
-    label: Legacy docs
-    href: https://github.com/okta/odyssey/blob/master/packages/docs/components/select.md
-  - icon: github
     label: View source
     href: https://github.com/okta/odyssey/blob/master/packages/odyssey/src/scss/components/_select.scss
   - icon: figma
@@ -31,8 +28,8 @@ links:
 
 </Description>
 
-<Anatomy 
-  img="/images/anatomy-select.svg" 
+<Anatomy
+  img="/images/anatomy-select.svg"
 />
 
 :::

--- a/packages/docs/components/text-input.md
+++ b/packages/docs/components/text-input.md
@@ -286,7 +286,7 @@ Unlike email fields, tel inputs are not automatically validated because global f
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <input class="ods-text-input" type="phone" name="tel" id="tel" autocomplete="tel" spellcheck="false" value="555-555-1212" required>
-      <label class="ods-label" for="tel">Tel</label>
+      <label class="ods-label" for="tel">Telephone number</label>
     </div>
   </fieldset>
 </Visual>
@@ -303,7 +303,7 @@ Passwords inputs ensure that sensitive content is safely obscured.
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <input class="ods-text-input" type="password" name="password" id="password" autocomplete="password" spellcheck="false" value="Big Gas Giants" required>
-      <label class="ods-label" for="password">Password</label>
+      <label class="ods-label" for="password">Authorization code</label>
     </div>
   </fieldset>
 </Visual>

--- a/packages/docs/components/text-input.md
+++ b/packages/docs/components/text-input.md
@@ -58,7 +58,7 @@ In this case, we recommend using the placeholder attribute to state the scope of
 </Description>
 
 <Visual>
-  <fieldset class="ods-fieldset docskit-visual--wide">
+  <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <input class="ods-text-input" type="search" name="search" id="search" autocomplete="search" spellcheck="false" placeholder="Search planets" required>
       <label class="ods-label" for="search">Search planets</label>
@@ -76,7 +76,7 @@ We also provide an attached button for in-page searching or avoiding placeholder
 
 <Visual>
   <form>
-    <fieldset class="ods-fieldset docskit-visual--wide">
+    <fieldset class="ods-fieldset">
       <div class="ods-fieldset--attached">
         <input class="ods-text-input" type="search" name="search" id="button-search" autocomplete="search" spellcheck="false" aria-labelledby="search-button" required>
         <button class="ods-button" id="search-button">Search planets</button>
@@ -181,7 +181,7 @@ The values of disabled inputs will not be submitted.
 </Description>
 
 <Visual>
-  <fieldset class="ods-fieldset docskit-visual--wide">
+  <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <input disabled class="ods-text-input" type="text" required disabled>
       <label class="ods-label" for="email">Destination</label>
@@ -202,7 +202,7 @@ The values of read-only inputs will be submitted.
 </Description>
 
 <Visual>
-  <fieldset class="ods-fieldset docskit-visual--wide">
+  <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <input class="ods-text-input" type="text" name="name-readonly" id="name-readonly" value="Jupiter" autocomplete="name" spellcheck="false" required readonly>
       <label class="ods-label" for="email">Destination</label>
@@ -238,7 +238,7 @@ When indicating a validation error, please use a Field Error label to indicate t
 </Description>
 
 <Visual>
-  <fieldset class="ods-fieldset docskit-visual--wide">
+  <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <input data-invalid class="ods-text-input" type="text" value="4.76 miles/s" required>
       <label class="ods-label" for="email">Destination</label>
@@ -359,8 +359,7 @@ Finally, Users with low digital literacy may not understand the purpose or behav
 
 ### Invalid
 
-The :invalid CSS pseudo-class represents any <input> or other <form> element whose contents fail to validate. - MDN
-Because of the current inability to ensure consistent validation behavior across browsers, we're using the [data-invalid] attribute to indicate this state.
-
+The `:invalid` CSS pseudo-class represents any `<input>` or other `<form>` element whose contents fail to validate. - MDN
+Because of the current inability to ensure consistent validation behavior across browsers, we're using the `[data-invalid]` attribute to indicate this state.
 
 :::

--- a/packages/docs/components/text-input.md
+++ b/packages/docs/components/text-input.md
@@ -2,17 +2,14 @@
 template: component
 id: component-text-input
 title: Text Input
-description: TODO
-lead: TODO
+description: Text inputs allow users to edit and input data.
+lead: Text inputs allow users to edit and input data. They can range from simple search boxes to long-form text areas.
 tabs:
   - label: 'Overview'
     id: 'overview'
   - label: 'HTML & SCSS'
     id: 'html-scss'
 links:
-  - icon: github
-    label: Legacy docs
-    href: https://github.com/okta/odyssey/blob/master/packages/docs/components/text-input.md
   - icon: github
     label: View source
     href: https://github.com/okta/odyssey/blob/master/packages/odyssey/src/scss/components/_text-input.scss
@@ -25,164 +22,46 @@ links:
 
 ## Anatomy
 
-<Description>
-
-Text input UI is simple. It consists of a label and a field for users to interact with.
-
-</Description>
-
-<Anatomy 
+<Anatomy
   title="title"
   meta="metadata"
-  img="/images/anatomy-text-input.svg" 
+  img="/images/anatomy-text-input.svg"
 />
 
-## Default
+## Variants
 
-<Description class="is-fpo">
-
-The foundation of all our inputs. By default, they have a 1px “Grey 500” stroke, with a 4px corner radius. They require to be paired with a label, shown in the Labels section below.
-
-Required for any input. Keep it as concise as possible in 2-3 words max.
-
-</Description>
-
-<Visual>
-  <fieldset class="ods-fieldset docskit-visual--wide">
-    <div class="ods-fieldset-flex">
-      <input class="ods-text-input" type="text" required>
-      <label class="ods-label" for="email">What is your favorite donut?</label>
-    </div>
-  </fieldset>
-</Visual>
-
-
-## States
-
-<Description class="is-fpo">
-
-Some high level text about the states
-
-</Description>
-
-### Disabled
-
-<Description class="is-fpo">
-
-<span class="is-fpo">Some text about the **disabled** state</span>
-
-</Description>
-
-<Visual>
-  <fieldset class="ods-fieldset docskit-visual--wide">
-    <div class="ods-fieldset-flex">
-      <input disabled class="ods-text-input" type="text" required>
-      <label class="ods-label" for="email">Label</label>
-    </div>
-  </fieldset>
-</Visual>
-
-### Invalid
-
-<Description class="is-fpo">
-
-Some text about the **invalid** state
-
-</Description>
-
-<Visual>
-  <fieldset class="ods-fieldset docskit-visual--wide">
-    <div class="ods-fieldset-flex">
-      <input data-invalid class="ods-text-input" type="text" required>
-      <label class="ods-label" for="email">Label</label>
-    </div>
-  </fieldset>
-</Visual>
-
-### Read only
-
-<Description class="is-fpo">
-
-Some text about the **read only** state
-
-</Description>
-
-<Visual>
-  <fieldset class="ods-fieldset docskit-visual--wide">
-    <div class="ods-fieldset-flex">
-      <input class="ods-text-input" type="text" name="name-readonly" id="name-readonly" value="Read only value" autocomplete="name" spellcheck="false" required readonly>
-      <label class="ods-label" for="email">Label</label>
-    </div>
-  </fieldset>
-</Visual>
-
-## Types
-
-<Description class="is-fpo">
-
-Odyssey provides inputs for types `email`, `tel` and `password` out of the box.
-
-### Email
-
-Some high level text about the email type
-
-### Tel
-
-Some high level text about the tel type
-
-### Password
-
-Some high level text about the password type
-
-</Description>
-
-<Visual>
-  <form class="docskit-visual--wide">
-    <fieldset class="ods-fieldset">
-      <div class="ods-fieldset-flex">
-        <input class="ods-text-input" type="email" name="email" id="email" autocomplete="email" spellcheck="false" value="donut@okta.com" required>
-        <label class="ods-label" for="email">Email</label>
-      </div>
-    </fieldset>
-    <fieldset class="ods-fieldset">
-      <div class="ods-fieldset-flex">
-        <input class="ods-text-input" type="phone" name="tel" id="tel" autocomplete="tel" spellcheck="false" required>
-        <label class="ods-label" for="tel">Tel</label>
-      </div>
-    </fieldset>
-    <fieldset class="ods-fieldset">
-      <div class="ods-fieldset-flex">
-        <input class="ods-text-input" type="password" name="password" id="password" autocomplete="password" spellcheck="false" required>
-        <label class="ods-label" for="password">Password</label>
-      </div>
-    </fieldset>
-  </form>
-</Visual>
-
-
-## Additional types
+### Default
 
 <Description>
 
-<span class="is-fpo">A description around what additional types are, and how they vary from the aformentioned types.</span>
+This default serves as the basis for our Text Inputs. A shown here, they required paired with a paired Label.
 
 </Description>
+
+<Visual>
+  <fieldset class="ods-fieldset">
+    <div class="ods-fieldset-flex">
+      <input class="ods-text-input" type="text" id="designation" required>
+      <label class="ods-label" for="designation">Destination</label>
+    </div>
+  </fieldset>
+</Visual>
 
 ### Search
 
 <Description>
 
-Odyssey's standalone search is styled to provide minimal UI while maintaining accessibility when searching outside of normal form contexts. Inputs with type="search" will render with the "Search" UI indicator as well as a visually hidden label.
+Standalone Search provides minimal UI for searching outside of normal form contexts. Search inputs will render with the "Search" UI indicator as well as a visually hidden label.
 
-Unlike other inputs, we recommend using the placeholder attribute to indicate the scope of your search input. This text should match the hidden label.
+In this case, we recommend using the placeholder attribute to state the scope of your search. This text should match the hidden label.
 
 </Description>
 
 <Visual>
   <fieldset class="ods-fieldset docskit-visual--wide">
     <div class="ods-fieldset-flex">
-      <input class="ods-text-input" type="search" name="search" id="search" autocomplete="search" spellcheck="false" placeholder="Search donuts" required>
-      <label class="ods-label" for="search">Search donuts</label>
+      <input class="ods-text-input" type="search" name="search" id="search" autocomplete="search" spellcheck="false" placeholder="Search planets" required>
+      <label class="ods-label" for="search">Search planets</label>
     </div>
   </fieldset>
 </Visual>
@@ -191,95 +70,297 @@ Unlike other inputs, we recommend using the placeholder attribute to indicate th
 
 <Description>
 
-We also provide a variant with an attached button for in-page searching or when placeholder text is undesirable. Please follow our [Button guidelines](/components/button) when using these variants.
+We also provide an attached button for in-page searching or avoiding placeholder text. Please follow our [Button guidelines](/components/button) when using these variants.
 
 </Description>
-
 
 <Visual>
   <form>
     <fieldset class="ods-fieldset docskit-visual--wide">
       <div class="ods-fieldset--attached">
         <input class="ods-text-input" type="search" name="search" id="button-search" autocomplete="search" spellcheck="false" aria-labelledby="search-button" required>
-        <button class="ods-button" id="search-button">Search donuts</button>
+        <button class="ods-button" id="search-button">Search planets</button>
       </div>
     </fieldset>
     <fieldset class="ods-fieldset">
       <div class="ods-fieldset--attached">
         <input class="ods-text-input" type="search" name="search" id="button-search-sec" autocomplete="search" spellcheck="false" aria-labelledby="search-button" required>
-        <button class="ods-button is-ods-button-secondary" id="search-button">Find donut</button>
+        <button class="ods-button is-ods-button-secondary" id="search-button">Find cosmonaut</button>
       </div>
     </fieldset>
   </form>
 </Visual>
 
+### Textarea
 
+<Description>
 
-## Labels
-
-<Description class="is-fpo">
-
-There are five label types; Default, Default with hint, Disabled, Error, and Supporting text. Each component has the margin built in and can be paired with any input field above. Just stack them on top or below and input and you’ll have a match.
-
-</Description>
-
-### Default
-
-<Description class="is-fpo">
-
-Some text about **default label states**
+Textareas should be used for multi-line text inputs. As the user types the field will grow vertically to accommodate the new lines.
 
 </Description>
 
 <Visual>
-  <fieldset class="ods-fieldset docskit-visual--wide">
+  <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input type="text" required="required" class="ods-text-input">
-      <label for="email" class="ods-label">Label</label>
+      <textarea class="ods-text-input ods-text-area" name="description" id="description" rows='4' cols='50' spellcheck="true" required></textarea>
+      <aside class="ods-field--hint">
+        Please describe your perfect planet in as many words as you need.
+      </aside>
+      <label class="ods-label" for="description">The perfect planet</label>
     </div>
   </fieldset>
 </Visual>
 
-### Default with hint
+## States
 
-<Description class="is-fpo">
+<Description>
 
-Some text about **default label states, with hints**
+Text inputs support the following states: Enabled, Focus, Hover, Disabled, Read-only, Optional, and Invalid.
+
+</Description>
+
+### Enabled
+
+<Description>
+
+Text inputs in their "normal" state are considered enabled. They are ready for user interaction.
 
 </Description>
 
 <Visual>
-  <fieldset class="ods-fieldset docskit-visual--wide">
+  <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input type="text" required="required" class="ods-text-input">
-      <aside class="ods-field--hint" id="name-hinted-hint">Hint: additional context can be provided here.</aside>
-      <label for="email" class="ods-label">Label</label>
+      <input class="ods-text-input" type="text" id="enabled" required>
+      <label class="ods-label" for="enabled">Destination</label>
     </div>
   </fieldset>
 </Visual>
 
-### Error
+### Focus
 
-<Description class="is-fpo">
+<Description>
 
-Some text about **label error states**
+The focus state is a visual affordance that the user has highlighted the input with a pointer, keyboard, or voice.
+
+</Description>
+
+<Visual>
+  <fieldset class="ods-fieldset">
+    <div class="ods-fieldset-flex">
+      <input class="ods-text-input is-ods-input-focus" type="text" id="focus" required>
+      <label class="ods-label" for="focus">Destination</label>
+    </div>
+  </fieldset>
+</Visual>
+
+### Hover
+
+<Description>
+
+Hover states are activated when the user pauses their pointer over the input.
+
+</Description>
+
+<Visual>
+  <fieldset class="ods-fieldset">
+    <div class="ods-fieldset-flex">
+      <input class="ods-text-input is-ods-input-hover" type="text" id="focus" required>
+      <label class="ods-label" for="focus">Destination</label>
+    </div>
+  </fieldset>
+</Visual>
+
+### Disabled
+
+<Description>
+
+Disabled inputs are unavailable for interaction and cannot be focused. They can be used when input is disallowed, possibly due to a system state or access restrictions.
+
+The values of disabled inputs will not be submitted.
 
 </Description>
 
 <Visual>
   <fieldset class="ods-fieldset docskit-visual--wide">
     <div class="ods-fieldset-flex">
-      <input data-invalid class="ods-text-input" type="text" required>
-      <label class="ods-label" for="email">Label</label>
-      <aside class="ods-field--error" id="name-invalid-hint">
-        Validation error message.
+      <input disabled class="ods-text-input" type="text" required disabled>
+      <label class="ods-label" for="email">Destination</label>
+    </div>
+  </fieldset>
+</Visual>
+
+### Read-only
+
+<Description>
+
+Similar to disabled inputs, users cannot modify the values of read-only inputs. However, users can otherwise interact with read-only inputs and select their values for copying.
+
+This state can be helpful when displaying computed or third-party values, or when a submitted form is being processed.
+
+The values of read-only inputs will be submitted.
+
+</Description>
+
+<Visual>
+  <fieldset class="ods-fieldset docskit-visual--wide">
+    <div class="ods-fieldset-flex">
+      <input class="ods-text-input" type="text" name="name-readonly" id="name-readonly" value="Jupiter" autocomplete="name" spellcheck="false" required readonly>
+      <label class="ods-label" for="email">Destination</label>
+    </div>
+  </fieldset>
+</Visual>
+
+### Optional
+
+<Description>
+
+Odyssey assumes inputs are required by default. Optional inputs should be used to indicate when data is not required for the user to complete a task.
+
+</Description>
+
+<Visual>
+  <fieldset class="ods-fieldset">
+    <div class="ods-fieldset-flex">
+      <input class="ods-text-input" type="text" name="name-optional" id="name-optional" autocomplete="name" spellcheck="false">
+      <label class="ods-label" for="name-optional">Destination <span class="ods-label--optional">Optional</span></label>
+    </div>
+  </fieldset>
+</Visual>
+
+### Invalid
+
+<Description>
+
+The invalid state is for inputs with incorrect values or values of the wrong format.
+
+When indicating a validation error, please use a Field Error label to indicate the nature of the error. Color alone is not an accessible way to signify that something has gone wrong.
+
+</Description>
+
+<Visual>
+  <fieldset class="ods-fieldset docskit-visual--wide">
+    <div class="ods-fieldset-flex">
+      <input data-invalid class="ods-text-input" type="text" value="4.76 miles/s" required>
+      <label class="ods-label" for="email">Destination</label>
+      <aside class="ods-field--error" id="email-invalid-error">
+        <span class="u-visually-hidden">Error:</span>This does not appear to be a valid planetoid.
       </aside>
     </div>
   </fieldset>
 </Visual>
 
+## Content Guidelines
+
+<Description>
+
+Text inputs support most free-form content, but we offer specific support for email, telephone numbers, and passwords.
+
+</Description>
+
+### Email
+
+<Description>
+
+There are no specific UI changes for email addresses, but inputs of this type will validate that the address is properly formatted.
+
+</Description>
+
+<Visual>
+  <fieldset class="ods-fieldset">
+    <div class="ods-fieldset-flex">
+      <input class="ods-text-input" type="email" name="email" id="email" autocomplete="email" spellcheck="false" value="homer@okta.com" required>
+      <label class="ods-label" for="email">Email</label>
+    </div>
+  </fieldset>
+</Visual>
+
+### Tel
+
+<Description>
+
+Unlike email fields, tel inputs are not automatically validated because global formats are so varied.
+
+</Description>
+
+<Visual>
+  <fieldset class="ods-fieldset">
+    <div class="ods-fieldset-flex">
+      <input class="ods-text-input" type="phone" name="tel" id="tel" autocomplete="tel" spellcheck="false" value="555-555-1212" required>
+      <label class="ods-label" for="tel">Tel</label>
+    </div>
+  </fieldset>
+</Visual>
+
+### Password
+
+<Description>
+
+Passwords inputs ensure that sensitive content is safely obscured.
+
+</Description>
+
+<Visual>
+  <fieldset class="ods-fieldset">
+    <div class="ods-fieldset-flex">
+      <input class="ods-text-input" type="password" name="password" id="password" autocomplete="password" spellcheck="false" value="Big Gas Giants" required>
+      <label class="ods-label" for="password">Password</label>
+    </div>
+  </fieldset>
+</Visual>
+
+## Accessibility
+
+### Placeholders
+
+<Description>
+
+Except for Search inputs, we advise against using placeholder text for inputs.
+
+</Description>
+
+#### Translation
+
+<Description>
+
+To prevent triggering a change in page layout, browsers don't translate certain attributes. Because of this, users will see untranslated placeholder text.
+
+</Description>
+
+#### Recall
+
+<Description>
+
+Placeholder text disappears when a field is interacted with. For this reason, it's not suitable for formatting guidelines or necessary context.
+
+</Description>
+
+#### Utility
+
+<Description>
+
+Placeholder content is limited to static text. Additionally, placeholder text is truncated beyond the width of its input.
+
+</Description>
+
+#### Field value confusion
+
+<Description>
+
+Low-contrast placeholders may be illegible for some users. Yet, placeholders with compliant contrast can be mistaken for field values. High Contrast Mode will make placeholders and values appear identical.
+
+Finally, Users with low digital literacy may not understand the purpose or behavior of placeholder text.
+
+</Description>
+
 :::
 
 ::: slot html-scss
 ## HTML & CSS
+
+### Invalid
+
+The :invalid CSS pseudo-class represents any <input> or other <form> element whose contents fail to validate. - MDN
+Because of the current inability to ensure consistent validation behavior across browsers, we're using the [data-invalid] attribute to indicate this state.
+
+
 :::

--- a/packages/docs/components/text-input.md
+++ b/packages/docs/components/text-input.md
@@ -115,7 +115,7 @@ Textareas should be used for multi-line text inputs. As the user types the field
 
 <Description>
 
-Text inputs support the following states: Enabled, Focus, Hover, Disabled, Read-only, Optional, and Invalid.
+Text inputs support the following states: enabled, hover, focus, disabled, read-only, optional, and invalid.
 
 </Description>
 
@@ -136,23 +136,6 @@ Text inputs in their "normal" state are considered enabled. They are ready for u
   </fieldset>
 </Visual>
 
-### Focus
-
-<Description>
-
-The focus state is a visual affordance that the user has highlighted the input with a pointer, keyboard, or voice.
-
-</Description>
-
-<Visual>
-  <fieldset class="ods-fieldset">
-    <div class="ods-fieldset-flex">
-      <input class="ods-text-input is-ods-input-focus" type="text" id="focus" required>
-      <label class="ods-label" for="focus">Destination</label>
-    </div>
-  </fieldset>
-</Visual>
-
 ### Hover
 
 <Description>
@@ -165,6 +148,23 @@ Hover states are activated when the user pauses their pointer over the input.
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <input class="ods-text-input is-ods-input-hover" type="text" id="focus" required>
+      <label class="ods-label" for="focus">Destination</label>
+    </div>
+  </fieldset>
+</Visual>
+
+### Focus
+
+<Description>
+
+The focus state is a visual affordance that the user has highlighted the input with a pointer, keyboard, or voice.
+
+</Description>
+
+<Visual>
+  <fieldset class="ods-fieldset">
+    <div class="ods-fieldset-flex">
+      <input class="ods-text-input is-ods-input-focus" type="text" id="focus" required>
       <label class="ods-label" for="focus">Destination</label>
     </div>
   </fieldset>

--- a/packages/docs/components/text-input.md
+++ b/packages/docs/components/text-input.md
@@ -41,8 +41,8 @@ This default serves as the basis for our Text Inputs. A shown here, they require
 <Visual>
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input class="ods-text-input" type="text" id="designation" required>
-      <label class="ods-label" for="designation">Destination</label>
+      <input class="ods-text-input" type="text" id="overview-default" required>
+      <label class="ods-label" for="overview-default">Destination</label>
     </div>
   </fieldset>
 </Visual>
@@ -60,8 +60,8 @@ In this case, we recommend using the placeholder attribute to state the scope of
 <Visual>
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input class="ods-text-input" type="search" name="search" id="search" autocomplete="search" spellcheck="false" placeholder="Search planets" required>
-      <label class="ods-label" for="search">Search planets</label>
+      <input class="ods-text-input" type="search" name="overview-search" id="overview-search" autocomplete="search" spellcheck="false" placeholder="Search planets" required>
+      <label class="ods-label" for="overview-search">Search planets</label>
     </div>
   </fieldset>
 </Visual>
@@ -78,14 +78,14 @@ We also provide an attached button for in-page searching or avoiding placeholder
   <form>
     <fieldset class="ods-fieldset">
       <div class="ods-fieldset--attached">
-        <input class="ods-text-input" type="search" name="search" id="button-search" autocomplete="search" spellcheck="false" aria-labelledby="search-button" required>
-        <button class="ods-button" id="search-button">Search planets</button>
+        <input class="ods-text-input" type="search" name="overview-search-button" id="overview-search-button" autocomplete="search" spellcheck="false" aria-labelledby="overview-search-button" required>
+        <button class="ods-button" id="overview-search-button">Search planets</button>
       </div>
     </fieldset>
     <fieldset class="ods-fieldset">
       <div class="ods-fieldset--attached">
-        <input class="ods-text-input" type="search" name="search" id="button-search-sec" autocomplete="search" spellcheck="false" aria-labelledby="search-button" required>
-        <button class="ods-button is-ods-button-secondary" id="search-button">Find cosmonaut</button>
+        <input class="ods-text-input" type="search" name="overview-search-button-sec" id="overview-search-button-sec" autocomplete="search" spellcheck="false" aria-labelledby="overview-search-button-sec" required>
+        <button class="ods-button is-ods-button-secondary" id="overview-search-button-sec">Find cosmonaut</button>
       </div>
     </fieldset>
   </form>
@@ -102,11 +102,11 @@ Textareas should be used for multi-line text inputs. As the user types the field
 <Visual>
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <textarea class="ods-text-input ods-text-area" name="description" id="description" rows='4' cols='50' spellcheck="true" required></textarea>
+      <textarea class="ods-text-input ods-text-area" name="overview-textarea" id="overview-textarea" rows='4' cols='50' spellcheck="true" required></textarea>
       <aside class="ods-field--hint">
         Please describe your perfect planet in as many words as you need.
       </aside>
-      <label class="ods-label" for="description">The perfect planet</label>
+      <label class="ods-label" for="overview-textarea">The perfect planet</label>
     </div>
   </fieldset>
 </Visual>
@@ -130,8 +130,8 @@ Text inputs in their "normal" state are considered enabled. They are ready for u
 <Visual>
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input class="ods-text-input" type="text" id="enabled" required>
-      <label class="ods-label" for="enabled">Destination</label>
+      <input class="ods-text-input" type="text" name="overview-enabled" id="overview-enabled" required>
+      <label class="ods-label" for="overview-enabled">Destination</label>
     </div>
   </fieldset>
 </Visual>
@@ -147,8 +147,8 @@ Hover states are activated when the user pauses their pointer over the input.
 <Visual>
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input class="ods-text-input is-ods-input-hover" type="text" id="focus" required>
-      <label class="ods-label" for="focus">Destination</label>
+      <input class="ods-text-input is-ods-input-hover" name="overview-hover" type="text" id="overview-hover" required>
+      <label class="ods-label" for="overview-hover">Destination</label>
     </div>
   </fieldset>
 </Visual>
@@ -164,8 +164,8 @@ The focus state is a visual affordance that the user has highlighted the input w
 <Visual>
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input class="ods-text-input is-ods-input-focus" type="text" id="focus" required>
-      <label class="ods-label" for="focus">Destination</label>
+      <input class="ods-text-input is-ods-input-focus" name="overview-focus" type="text" id="overview-focus" required>
+      <label class="ods-label" for="overview-focus">Destination</label>
     </div>
   </fieldset>
 </Visual>
@@ -183,8 +183,8 @@ The values of disabled inputs will not be submitted.
 <Visual>
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input disabled class="ods-text-input" type="text" required disabled>
-      <label class="ods-label" for="email">Destination</label>
+      <input disabled class="ods-text-input" type="text" name="overview-disabled" id="overview-disabled" required disabled>
+      <label class="ods-label" for="overview-disabled">Destination</label>
     </div>
   </fieldset>
 </Visual>
@@ -204,8 +204,8 @@ The values of read-only inputs will be submitted.
 <Visual>
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input class="ods-text-input" type="text" name="name-readonly" id="name-readonly" value="Jupiter" autocomplete="name" spellcheck="false" required readonly>
-      <label class="ods-label" for="email">Destination</label>
+      <input class="ods-text-input" type="text" name="overview-readonly" id="overview-readonly" value="Jupiter" required readonly spellcheck="false">
+      <label class="ods-label" for="overview-readonly">Destination</label>
     </div>
   </fieldset>
 </Visual>
@@ -221,8 +221,8 @@ Odyssey assumes inputs are required by default. Optional inputs should be used t
 <Visual>
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input class="ods-text-input" type="text" name="name-optional" id="name-optional" autocomplete="name" spellcheck="false">
-      <label class="ods-label" for="name-optional">Destination <span class="ods-label--optional">Optional</span></label>
+      <input class="ods-text-input" type="text" name="overview-optional" id="overview-optional" spellcheck="false">
+      <label class="ods-label" for="overview-optional">Destination <span class="ods-label--optional">Optional</span></label>
     </div>
   </fieldset>
 </Visual>
@@ -240,9 +240,9 @@ When indicating a validation error, please use a Field Error label to indicate t
 <Visual>
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input data-invalid class="ods-text-input" type="text" value="4.76 miles/s" required>
-      <label class="ods-label" for="email">Destination</label>
-      <aside class="ods-field--error" id="email-invalid-error">
+      <input data-invalid class="ods-text-input" type="text" name="overview-invalid" aria-describedby="overview-invalid-error" id="overview-invalid" spellcheck="false" value="4.76 miles/s" required>
+      <label class="ods-label" for="overview-invalid">Destination</label>
+      <aside class="ods-field--error" id="overview-invalid-error">
         <span class="u-visually-hidden">Error:</span>This does not appear to be a valid planetoid.
       </aside>
     </div>
@@ -268,8 +268,8 @@ There are no specific UI changes for email addresses, but inputs of this type wi
 <Visual>
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input class="ods-text-input" type="email" name="email" id="email" autocomplete="email" spellcheck="false" value="homer@okta.com" required>
-      <label class="ods-label" for="email">Email</label>
+      <input class="ods-text-input" type="email" name="overview-email" id="overview-email" autocomplete="email" spellcheck="false" value="homer@okta.com" required>
+      <label class="ods-label" for="overview-email">Email</label>
     </div>
   </fieldset>
 </Visual>
@@ -285,8 +285,8 @@ Unlike email fields, tel inputs are not automatically validated because global f
 <Visual>
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input class="ods-text-input" type="phone" name="tel" id="tel" autocomplete="tel" spellcheck="false" value="555-555-1212" required>
-      <label class="ods-label" for="tel">Telephone number</label>
+      <input class="ods-text-input" type="phone" name="overview-tel" id="overview-tel" autocomplete="tel" spellcheck="false" value="555-555-1212" required>
+      <label class="ods-label" for="overview-tel">Telephone number</label>
     </div>
   </fieldset>
 </Visual>
@@ -302,8 +302,8 @@ Passwords inputs ensure that sensitive content is safely obscured.
 <Visual>
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input class="ods-text-input" type="password" name="password" id="password" autocomplete="password" spellcheck="false" value="Big Gas Giants" required>
-      <label class="ods-label" for="password">Authorization code</label>
+      <input class="ods-text-input" type="password" name="overview-password" id="overview-password" autocomplete="password" spellcheck="false" value="Big Gas Giants" required>
+      <label class="ods-label" for="overview-password">Authorization code</label>
     </div>
   </fieldset>
 </Visual>

--- a/packages/odyssey/src/scss/abstracts/_mixins.scss
+++ b/packages/odyssey/src/scss/abstracts/_mixins.scss
@@ -48,11 +48,14 @@
   line-height: $base-line-height;
 
   &:hover,
-  &:focus {
+  &:focus,
+  &.is-ods-input-hover,
+  &.is-ods-input-focus {
     border-color: cv('blue');
   }
 
-  &:focus {
+  &:focus,
+  &.is-ods-input-focus {
     @include outline;
   }
 

--- a/packages/odyssey/src/scss/components/_checkbox.scss
+++ b/packages/odyssey/src/scss/components/_checkbox.scss
@@ -47,7 +47,8 @@ $size-checkbox: 1em / 0.875;
     }
   }
 
-  &:focus {
+  &:focus,
+  &.is-ods-checkbox-focus {
     + .ods-checkbox--label {
       &::before {
         @include outline($focus-ring-primary, 2px);
@@ -201,7 +202,8 @@ $size-checkbox: 1em / 0.875;
     background-position: center;
   }
 
-  &:hover {
+  &:hover,
+  &.is-ods-checkbox-hover {
     &::before {
       border-color: $color-primary-base;
     }

--- a/packages/odyssey/src/scss/components/_radio-button.scss
+++ b/packages/odyssey/src/scss/components/_radio-button.scss
@@ -31,7 +31,8 @@ $size-checkbox: 1em / 0.875;
     }
   }
 
-  &:focus {
+  &:focus,
+  &.is-ods-radio-focus {
     + .ods-radio--label {
       &::before {
         @include outline($focus-ring-primary, 2px);
@@ -163,7 +164,8 @@ $size-checkbox: 1em / 0.875;
     background-position: center;
   }
 
-  &:hover {
+  &:hover,
+  &.is-ods-radio-hover {
     &::before {
       border-color: $color-primary-base;
     }


### PR DESCRIPTION
This updates the content for Checkbox, Radios, and Text Inputs as a template for form elements. It also includes the initial setup for Field Labels.

Tackling Select and Field Label content separately so avoid a cumbersome review.

Re: feedback - There are still some remaining questions about naming, field label docs, and which states to document. If possible, I'd like to hold out on those until we have a preview available with all form materials for easy review.