### PR TITLE
Tab docs

### DIFF
--- a/packages/docs/components/select.md
+++ b/packages/docs/components/select.md
@@ -38,7 +38,7 @@ To support expected functionality and behaviors, Select relies on the Choices.js
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <select class="ods-select" data-js-choices id="overview-behavior" name="overview-behavior" required>
@@ -72,7 +72,7 @@ The default Select allows users to choose a single value from a list of options.
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <select class="ods-select" data-js-choices id="overview-single" name="overview-single" required>
@@ -98,7 +98,7 @@ The Multi-Select variant allows users to choose more than one value from the lis
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <select class="ods-select" data-js-choices id="overview-multi" name="overview-multi" multiple required>
@@ -132,7 +132,7 @@ Select inputs in their "normal" state are considered enabled. They are ready for
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <select class="ods-select" data-js-choices id="overview-enabled" name="overview-enabled" required>
@@ -158,7 +158,7 @@ Hover states are activated when the user pauses their pointer over the input.
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex is-ods-select-hover">
       <select class="ods-select is-ods-input-hover" data-js-choices id="overview-hover" name="overview-hover" required>
@@ -184,7 +184,7 @@ The focus state is a visual affordance that the user has highlighted the input w
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex is-ods-select-focus">
       <select class="ods-select" data-js-choices id="overview-focus" name="overview-focus" required>
@@ -212,7 +212,7 @@ The values of disabled inputs will not be submitted.
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <select class="ods-select" data-js-choices id="overview-disabled" name="overview-disabled" required disabled>
@@ -238,7 +238,7 @@ Odyssey assumes inputs are required by default. Optional inputs should be used t
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <select class="ods-select" data-js-choices id="overview-optional" name="overview-optional">
@@ -266,7 +266,7 @@ When indicating a validation error, please use a Field Error label to indicate t
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset" data-invalid>
     <div class="ods-fieldset-flex">
       <select class="ods-select" data-js-choices id="overview-invalid" name="overview-invalid" required data-invalid aria-describedby="overview-invalid-error">
@@ -299,7 +299,7 @@ Select inputs should not have a default selected unless a majority of users will
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <select class="ods-select" data-js-choices id="overview-groups" name="overview-groups" required>

--- a/packages/docs/components/tab.md
+++ b/packages/docs/components/tab.md
@@ -144,7 +144,7 @@ Tabs are best used at the top of the page or situated above the content it’s r
 
 <Description>
 
-Use tabs sparingly. Limit Tabs to one per page, and refrain from including a second set of Tabs within a tabpanel.
+Use Tab sparingly. Limit the Tab component to one per page, and refrain from including a second set of Tabs within a tabpanel.
 
 </Description>
 

--- a/packages/docs/components/tab.md
+++ b/packages/docs/components/tab.md
@@ -36,121 +36,32 @@ Additionally, the tab element is keyboard-navigable (See [Accessibility: Keyboar
 
 </Description>
 
-<Visual layout="wide" variant="content-full" fade>
+<Visual layout="wide" content="full" fade>
   <template>
-    <h1 class="is-sample-unimportant">NASA's Mars Missions</h1>
-    <p class="is-sample-unimportant">To date, NASA has had 49 missions involving rovers, orbiters and other spacecraft.</p>
-    <OdsTabs label="User profile options" :active="tabs.active" :tablist="tabs.tablist" :id="tabs.id">
-      <template slot="tab-orbiter">
-        <figure class="ods-table--figure is-sample-unimportant">
-          <figcaption class="ods-table--figcaption">
-            Orbiter Missions
-          </figcaption>
-          <table class="ods-table">
-            <caption>When implementing this component you should consider the following keyboard behaviors.</caption>
-            <thead>
-              <tr>
-                <th scope="column">Spacecraft</th>
-                <th scope="column">Launch vehicle</th>
-                <th scope="column">Launch date</th>
-                <th scope="column">Orbit insertion</th>
-                <th scope="column">Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row">2001 Mars Odyssey</th>
-                <td>Delta II</td>
-                <td class="is-ods-table-date">4/7/01</td>
-                <td class="is-ods-table-date">10/24/01</td>
-                <td>
-                  <dl class="ods-status is-ods-status-success is-ods-status-label-hidden">
-                    <dt class="ods-status--label">
-                      Result
-                    </dt>
-                    <dd class="ods-status--value">
-                      Still operating
-                    </dd>
-                  </dl>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </figure>
+    <header class="is-sample-unimportant">
+      <h1>Terrestrial Planets</h1>
+      <p>Terrestrial planets are planets that are composed primarily of silicate rocks or metals.</p>
+    </header>
+    <OdsTabs aria-label="Types of terrestrial planets" :active="tabsPlanets.active" :tablist="tabsPlanets.tablist" id="example-1">
+      <template slot="tab-mercury">
+        <blockquote class="is-sample-unimportant">
+          <p>Mercury is the smallest and innermost planet in the Solar System. Its orbit around the Sun takes 87.97 Earth days, the shortest of all the planets in the Solar System.</p>
+        </blockquote>
       </template>
-      <template slot="tab-atmospheric">
-        <figure class="ods-table--figure is-sample-unimportant">
-          <figcaption class="ods-table--figcaption">
-            Atmospheric Missions
-          </figcaption>
-          <table class="ods-table">
-            <caption>When implementing this component you should consider the following keyboard behaviors.</caption>
-            <thead>
-              <tr>
-                <th scope="column">Mission type</th>
-                <th scope="column">Launched</th>
-                <th scope="column">Landing</th>
-                <th scope="column">Mission duration</th>
-                <th scope="column">Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row">2001 Mars Odyssey</th>
-                <td>Delta II</td>
-                <td class="is-ods-table-date">4/7/01</td>
-                <td class="is-ods-table-date">10/24/01</td>
-                <td>
-                  <dl class="ods-status is-ods-status-success is-ods-status-label-hidden">
-                    <dt class="ods-status--label">
-                      Result
-                    </dt>
-                    <dd class="ods-status--value">
-                      Still operating
-                    </dd>
-                  </dl>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </figure>
+      <template slot="tab-venus">
+        <blockquote class="is-sample-unimportant">
+          <p>Venus is the second planet from the Sun. It is named after the Roman goddess of love and beauty. As the second-brightest natural object in the night sky after the Moon, Venus can cast shadows and can be, on rare occasion, visible to the naked eye in broad daylight.</p>
+        </blockquote>
       </template>
-      <template slot="tab-lander">
-        <figure class="ods-table--figure is-sample-unimportant">
-          <figcaption class="ods-table--figcaption">
-            Lander Missions
-          </figcaption>
-          <table class="ods-table">
-            <caption>When implementing this component you should consider the following keyboard behaviors.</caption>
-            <thead>
-              <tr>
-                <th scope="column">Mission type</th>
-                <th scope="column">Launched</th>
-                <th scope="column">Landing</th>
-                <th scope="column">Mission duration</th>
-                <th scope="column">Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row">2001 Mars Odyssey</th>
-                <td>Delta II</td>
-                <td class="is-ods-table-date">4/7/01</td>
-                <td class="is-ods-table-date">10/24/01</td>
-                <td>
-                  <dl class="ods-status is-ods-status-success is-ods-status-label-hidden">
-                    <dt class="ods-status--label">
-                      Result
-                    </dt>
-                    <dd class="ods-status--value">
-                      Still operating
-                    </dd>
-                  </dl>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </figure>
+      <template slot="tab-earth">
+        <blockquote class="is-sample-unimportant">
+          <p>Earth is the third planet from the Sun and the only astronomical object known to harbor life. About 29% of Earth's surface is land consisting of continents and islands.</p>
+        </blockquote>
+      </template>
+      <template slot="tab-mars">
+        <blockquote class="is-sample-unimportant">
+          <p>Mars is the fourth planet from the Sun and the second-smallest planet in the Solar System, being larger than only Mercury. In English, Mars carries the name of the Roman god of war and is often referred to as the "Red Planet".</p>
+        </blockquote>
       </template>
     </OdsTabs>
   </template>
@@ -174,8 +85,21 @@ Tabs are NOT navigation. Meaning they don’t take you from place to place. Rath
 
 </Description>
 
-<Visual variant="positive">Positive</Visual>
-<Visual variant="negative">Negative</Visual>
+<Visual variant="positive" content="no-end" class="is-tab-small-sample">
+  <header>
+    <h2>Terrestrial Planets</h2>
+    <p>Terrestrial planets are planets that are composed primarily of silicate rocks or metals.</p>
+  </header>
+  <OdsTabs aria-label="Types of terrestrial planets" :active="tabsPlanets.active" :tablist="tabsPlanets.tablist" id="example-2"></OdsTabs>
+</Visual>
+
+<Visual variant="negative" content="no-end" class="is-tab-small-sample">
+  <header>
+    <h2>Terrestrial Planets</h2>
+    <p>Terrestrial planets are planets that are composed primarily of silicate rocks or metals.</p>
+  </header>
+  <OdsTabs aria-label="Famous constellations" :active="tabsConstellations.active" :tablist="tabsConstellations.tablist" id="example-3"></OdsTabs>
+</Visual>
 
 ### Position above major content
 
@@ -185,8 +109,37 @@ Tabs are best used at the top of the page or situated above the content it’s r
 
 </Description>
 
-<Visual variant="positive">Positive</Visual>
-<Visual variant="negative">Negative</Visual>
+
+<Visual variant="positive" content="no-end" class="is-tab-small-sample">
+  <header>
+    <h2>Missions</h2>
+    <p>There have been 49 missions involving various types of spacecraft.</p>
+  </header>
+  <OdsTabs aria-label="Missions by type" :active="tabs.active" :tablist="tabs.tablist" id="example-4"></OdsTabs>
+</Visual>
+
+<Visual variant="negative"  content="no-end" class="is-tab-small-sample">
+  <OdsTabs aria-label="Missions by type" :active="tabs.active" :tablist="tabs.tablist" id="example-5">
+  <template slot="tab-orbiter">
+    <header>
+      <h2>Missions</h2>
+      <p>There have been 8 missions involving orbiters.</p>
+    </header>
+  </template>
+  <template slot="tab-atmospheric">
+    <header>
+      <h2>Missions</h2>
+      <p>There have been 12 missions involving atmospheric vehicles.</p>
+    </header>
+  </template>
+  <template slot="tab-lander">
+    <header>
+      <h2>Missions</h2>
+      <p>There have been 4 missions involving lander vehicles.</p>
+    </header>
+  </template>
+  </OdsTabs>
+</Visual>
 
 ### Don't stack tabs
 
@@ -194,11 +147,14 @@ Tabs are best used at the top of the page or situated above the content it’s r
 
 In fact, it’s really impossible to do because we include the tab panel with the tabs themselves. We’re calling this out to designers because the component doesn’t include the tab panel and shouldn’t be presented to an engineer.
 
-keuyUltimately this is bad practice because is will result in overloading users with information and reduce comprehension.
+Ultimately this is bad practice because is will result in overloading users with information and reduce comprehension.
 
 </Description>
 
-<Visual variant="negative">Negative</Visual>
+<Visual variant="negative" class="is-tab-stacked-example" content="no-end">
+  <OdsTabs aria-label="Missions by type" :active="tabs.active" :tablist="tabs.tablist" :id="tabs.id"></OdsTabs>
+  <OdsTabs aria-label="Missions by year" :active="tabsYears.active" :tablist="tabsYears.tablist" id="example-6"></OdsTabs>
+</Visual>
 
 ## Content Guidelines
 
@@ -261,24 +217,6 @@ keuyUltimately this is bad practice because is will result in overloading users 
   </table>
 </figure>
 
-<script>
-export default {
-  data () {
-    return {
-      tabs: {
-        id: 'example-0',
-        active: "tab-orbiter",
-        tablist: [
-          { id: "tab-orbiter", label: 'Orbiter' },
-          { id: "tab-atmospheric", label: 'Atmospheric' },
-          { id: "tab-lander", label: 'Lander' }
-        ]
-      }
-    }
-  }
-}
-</script>
-
 ## References
 
 ### Further Reading
@@ -288,6 +226,47 @@ export default {
 :::
 
 ::: slot html-scss
+
+
+## Basic example
+
+<figure class="docs-example">
+  <div class="docs-example--rendered">
+    <OdsTabs aria-label="Describes the purpose of this set of tabs" :active="tabsPlain.active" :tablist="tabsPlain.tablist" id="example">
+      <template slot="tab-1">
+        <p>Tabpanel 1 content&hellip;</p>
+      </template>
+      <template slot="tab-2">
+        <p>Tabpanel 2 content&hellip;</p>
+      </template>
+      <template slot="tab-3">
+        <p>Tabpanel 3 content&hellip;</p>
+      </template>
+    </OdsTabs>
+  </div>
+
+  ```html
+  <div id="example" class="ods-tabs" aria-label="Describes the purpose of this set of tabs">
+    <div role="tablist" aria-label="label" class="ods-tabs--tablist">
+      <button id="tab-1" role="tab" tabindex="0" aria-controls="tab-1-tabpanel" class="ods-tabs--tab" aria-selected="true">Tab 1</button>
+      <button id="tab-2" role="tab" tabindex="-1" aria-controls="tab-2-tabpanel" class="ods-tabs--tab">Tab 2</button>
+      <button id="tab-3" role="tab" tabindex="-1" aria-controls="tab-3-tabpanel" class="ods-tabs--tab">Tab 3</button>
+    </div>
+    <div class="ods-tabs--tabpanel">
+        <div id="tab-1-tabpanel" role="tabpanel" aria-labelledby="tab-1" tabindex="0">
+          <p>Tabpanel 1 content…</p>
+        </div>
+        <div id="tab-2-tabpanel" role="tabpanel" aria-labelledby="tab-2" tabindex="0" hidden="hidden">
+          <p>Tabpanel 2 content…</p>
+        </div>
+        <div id="tab-3-tabpanel" role="tabpanel" aria-labelledby="tab-3" tabindex="0" hidden="hidden">
+          <p>Tabpanel 3 content…</p>
+        </div>
+    </div>
+  </div>
+  ```
+
+</figure>
 
 ## Switching tabs
 
@@ -301,3 +280,54 @@ The JS included in the `@okta/odyssey` package is for demo purposes only. For th
 </Description>
 
 :::
+
+
+<script>
+export default {
+  data () {
+    return {
+      tabs: {
+        active: "tab-orbiter",
+        tablist: [
+          { id: "tab-orbiter", label: 'Orbiter' },
+          { id: "tab-atmospheric", label: 'Atmospheric' },
+          { id: "tab-lander", label: 'Lander' }
+        ]
+      },
+      tabsYears: {
+        active: "tab-1990s",
+        tablist: [
+          { id: "tab-1990s", label: '1990s' },
+          { id: "tab-2000s", label: '2000s' },
+          { id: "tab-2010s", label: '2010s' }
+        ]
+      },
+      tabsPlanets: {
+        active: "tab-mercury",
+        tablist: [
+          { id: "tab-mercury", label: 'Mercury' },
+          { id: "tab-venus", label: 'Venus' },
+          { id: "tab-earth", label: 'Earth' },
+          { id: "tab-mars", label: 'Mars' }
+        ]
+      },
+      tabsConstellations: {
+        active: "tab-aquarius",
+        tablist: [
+          { id: "tab-aquarius", label: 'Aquarius' },
+          { id: "tab-leo", label: 'Leo' },
+          { id: "tab-pisces", label: 'Pisces' }
+        ]
+      },
+      tabsPlain: {
+        active: "tab-1",
+        tablist: [
+          { id: "tab-1", label: 'Tab 1' },
+          { id: "tab-2", label: 'Tab 2' },
+          { id: "tab-3", label: 'Tab 3' }
+        ]
+      }
+    }
+  }
+}
+</script>

--- a/packages/docs/components/tab.md
+++ b/packages/docs/components/tab.md
@@ -29,8 +29,7 @@ links:
 
 <Description>
 
-Users interact with Tab as they would a button, the main difference is the outcome. By default, the first tab from the left is active and the associated content 
-displayed in the tab panel. Upon selecting a different tab, the tab indicator appears on the selected tab. The tab panel will then update to show the new content. 
+Users interact with Tab as they would a button, the main difference is the outcome. By default, the first tab from the left is active and the associated content displayed in the tab panel. Upon selecting a different tab, the tab indicator appears on the selected tab. The tab panel will then update to show the new content. 
 
 Additionally, the tab element is keyboard-navigable (See [Accessibility: Keyboard Support](#keyboard-support))
 
@@ -81,7 +80,7 @@ see what could be grouped together. Those themes should become your Tabs.
 
 <Description>
 
-Tabs are NOT navigation. Meaning they don’t take you from place to place. Rather, they are meant for context switching related to the page.
+**Tabs are not navigation**. Meaning they don’t take you from place to place. Rather, they are meant for context switching related to the page.
 
 </Description>
 
@@ -145,9 +144,7 @@ Tabs are best used at the top of the page or situated above the content it’s r
 
 <Description>
 
-In fact, it’s really impossible to do because we include the tab panel with the tabs themselves. We’re calling this out to designers because the component doesn’t include the tab panel and shouldn’t be presented to an engineer.
-
-Ultimately this is bad practice because is will result in overloading users with information and reduce comprehension.
+Use tabs sparingly. Limit Tabs to one per page, and refrain from including a second set of Tabs within a tabpanel.
 
 </Description>
 
@@ -160,9 +157,9 @@ Ultimately this is bad practice because is will result in overloading users with
 
 <Description>
 
-- Don't from using tabs without tabpanels.
+- Refrain from using tabs without tabpanels.
 - Don't have more than 8 tabs in a tablist.
-- Don't Add an icon to a tab. Icons should be reserved for very specific things. It can be hard to maintain consistency with use of icons as it pertains to their semantic meanings and meaning to Okta.
+- Don't add an icon to a tab. Icons should be reserved for very specific things. It can be hard to maintain consistency with use of icons as it pertains to their semantic meanings and meaning to Okta.
 
 </Description>
 

--- a/packages/docs/components/tab.md
+++ b/packages/docs/components/tab.md
@@ -38,7 +38,7 @@ Additionally, the tab element is keyboard-navigable (See [Accessibility: Keyboar
 
 <Visual layout="wide" content="full" fade>
   <template>
-    <header class="is-sample-unimportant">
+    <header>
       <h1>Terrestrial Planets</h1>
       <p>Terrestrial planets are planets that are composed primarily of silicate rocks or metals.</p>
     </header>

--- a/packages/docs/components/tab.md
+++ b/packages/docs/components/tab.md
@@ -2,17 +2,14 @@
 template: component
 id: component-tab
 title: Tab
-description: TODO
-lead: TODO
+description: Tabs are a navigational component used to organize content by grouping similar information on the same page.
+lead: Navigation component used to organize content by grouping similar information on the same page. They allow content to be viewed without having to navigate away from that page or route.
 tabs:
   - label: 'Overview'
     id: 'overview'
   - label: 'HTML & SCSS'
     id: 'html-scss'
 links:
-  - icon: github
-    label: Legacy docs
-    href: https://github.com/okta/odyssey/blob/master/packages/docs/components/tab.md
   - icon: github
     label: View source
     href: https://github.com/okta/odyssey/blob/master/packages/odyssey/src/scss/components/_tab.scss
@@ -25,16 +22,282 @@ links:
 
 ## Anatomy
 
+
+<Anatomy img="/images/anatomy-tab.svg" />
+
+## Behavior
+
 <Description>
 
-<span class="is-fpo">Descriptive content around **tab anatomy** should go here.</span>
+Users interact with Tab as they would a button, the main difference is the outcome. By default, the first tab from the left is active and the associated content 
+displayed in the tab panel. Upon selecting a different tab, the tab indicator appears on the selected tab. The tab panel will then update to show the new content. 
+
+Additionally, the tab element is keyboard-navigable (See [Accessibility: Keyboard Support](#keyboard-support))
 
 </Description>
 
-<Anatomy img="/images/anatomy-tab.svg" />
+<Visual layout="wide" variant="content-full" fade>
+  <template>
+    <h1 class="is-sample-unimportant">NASA's Mars Missions</h1>
+    <p class="is-sample-unimportant">To date, NASA has had 49 missions involving rovers, orbiters and other spacecraft.</p>
+    <OdsTabs label="User profile options" :active="tabs.active" :tablist="tabs.tablist" :id="tabs.id">
+      <template slot="tab-orbiter">
+        <figure class="ods-table--figure is-sample-unimportant">
+          <figcaption class="ods-table--figcaption">
+            Orbiter Missions
+          </figcaption>
+          <table class="ods-table">
+            <caption>When implementing this component you should consider the following keyboard behaviors.</caption>
+            <thead>
+              <tr>
+                <th scope="column">Spacecraft</th>
+                <th scope="column">Launch vehicle</th>
+                <th scope="column">Launch date</th>
+                <th scope="column">Orbit insertion</th>
+                <th scope="column">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">2001 Mars Odyssey</th>
+                <td>Delta II</td>
+                <td class="is-ods-table-date">4/7/01</td>
+                <td class="is-ods-table-date">10/24/01</td>
+                <td>
+                  <dl class="ods-status is-ods-status-success is-ods-status-label-hidden">
+                    <dt class="ods-status--label">
+                      Result
+                    </dt>
+                    <dd class="ods-status--value">
+                      Still operating
+                    </dd>
+                  </dl>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </figure>
+      </template>
+      <template slot="tab-atmospheric">
+        <figure class="ods-table--figure is-sample-unimportant">
+          <figcaption class="ods-table--figcaption">
+            Atmospheric Missions
+          </figcaption>
+          <table class="ods-table">
+            <caption>When implementing this component you should consider the following keyboard behaviors.</caption>
+            <thead>
+              <tr>
+                <th scope="column">Mission type</th>
+                <th scope="column">Launched</th>
+                <th scope="column">Landing</th>
+                <th scope="column">Mission duration</th>
+                <th scope="column">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">2001 Mars Odyssey</th>
+                <td>Delta II</td>
+                <td class="is-ods-table-date">4/7/01</td>
+                <td class="is-ods-table-date">10/24/01</td>
+                <td>
+                  <dl class="ods-status is-ods-status-success is-ods-status-label-hidden">
+                    <dt class="ods-status--label">
+                      Result
+                    </dt>
+                    <dd class="ods-status--value">
+                      Still operating
+                    </dd>
+                  </dl>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </figure>
+      </template>
+      <template slot="tab-lander">
+        <figure class="ods-table--figure is-sample-unimportant">
+          <figcaption class="ods-table--figcaption">
+            Lander Missions
+          </figcaption>
+          <table class="ods-table">
+            <caption>When implementing this component you should consider the following keyboard behaviors.</caption>
+            <thead>
+              <tr>
+                <th scope="column">Mission type</th>
+                <th scope="column">Launched</th>
+                <th scope="column">Landing</th>
+                <th scope="column">Mission duration</th>
+                <th scope="column">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">2001 Mars Odyssey</th>
+                <td>Delta II</td>
+                <td class="is-ods-table-date">4/7/01</td>
+                <td class="is-ods-table-date">10/24/01</td>
+                <td>
+                  <dl class="ods-status is-ods-status-success is-ods-status-label-hidden">
+                    <dt class="ods-status--label">
+                      Result
+                    </dt>
+                    <dd class="ods-status--value">
+                      Still operating
+                    </dd>
+                  </dl>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </figure>
+      </template>
+    </OdsTabs>
+  </template>
+</Visual>
+
+## Usage
+
+<Description>
+
+Tabs were created to shorten long pages. Before you use these, we’d recommend laying 
+out all of the content on your page out first. From there figure out common themes and 
+see what could be grouped together. Those themes should become your Tabs.
+
+</Description>
+
+### Relate to the page title
+
+<Description>
+
+Tabs are NOT navigation. Meaning they don’t take you from place to place. Rather, they are meant for context switching related to the page.
+
+</Description>
+
+<Visual variant="positive">Positive</Visual>
+<Visual variant="negative">Negative</Visual>
+
+### Position above major content
+
+<Description>
+
+Tabs are best used at the top of the page or situated above the content it’s related to. This will help establish hierarchy.
+
+</Description>
+
+<Visual variant="positive">Positive</Visual>
+<Visual variant="negative">Negative</Visual>
+
+### Don't stack tabs
+
+<Description>
+
+In fact, it’s really impossible to do because we include the tab panel with the tabs themselves. We’re calling this out to designers because the component doesn’t include the tab panel and shouldn’t be presented to an engineer.
+
+keuyUltimately this is bad practice because is will result in overloading users with information and reduce comprehension.
+
+</Description>
+
+<Visual variant="negative">Negative</Visual>
+
+## Content Guidelines
+
+<Description>
+
+- Don't from using tabs without tabpanels.
+- Don't have more than 8 tabs in a tablist.
+- Don't Add an icon to a tab. Icons should be reserved for very specific things. It can be hard to maintain consistency with use of icons as it pertains to their semantic meanings and meaning to Okta.
+
+</Description>
+
+## Accessibility
+
+### Keyboard Support
+
+<figure class="ods-table--figure">
+  <table class="ods-table">
+    <caption>When implementing this component you should consider the following keyboard behaviors.</caption>
+    <thead>
+      <tr>
+        <th scope="column">Key</th>
+        <th scope="column">Behavior</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row" rowspan="2"><kbd>Tab</kbd></th>
+        <td>When focus moves in to <code>tablist</code> the focus is placed on the first <code>tab</code> element.</td>
+      </tr>
+      <tr>
+        <td>Unlike the right arrow key, if you tab past the last element, the tab focus continues down the page as normal. In this case, it should set focus in to the active <code>tabpanel</code></td>
+      </tr>
+      <tr>
+        <td><kbd>Enter</kbd> <kbd>Space</kbd></td>
+        <td>When focus is placed on a tab, the corresponding <code>tabpanel</code> is activated/displayed.</td>
+      </tr>
+      <tr>
+        <th scope="row" rowspan="2"><kbd>Right Arrow</kbd></th>
+        <td>When focus is within the <code>tablist</code> the next tab is selected.</td>
+      </tr>
+      <tr>
+        <td>If the last tab is focused the focus is moved to the first tab.</td>
+      </tr>
+      <tr>
+        <th scope="row" rowspan="2"><kbd>Left Arrow</kbd></th>
+        <td>When focus is within the <code>tablist</code> the previous tab is selected.</td>
+      </tr>
+      <tr>
+        <td>If the first tab is focused the focus is moved to the last tab.</td>
+      </tr>
+      <tr>
+        <td><kbd>Home</kbd></td>
+        <td>If a tab has focus, the focus is moved to the first tab.</td>
+      </tr>
+      <tr>
+        <td><kbd>End</kbd></td>
+        <td>If a tab has focus, the focus is moved to the last tab.</td>
+      </tr>
+    </tbody>
+  </table>
+</figure>
+
+<script>
+export default {
+  data () {
+    return {
+      tabs: {
+        id: 'example-0',
+        active: "tab-orbiter",
+        tablist: [
+          { id: "tab-orbiter", label: 'Orbiter' },
+          { id: "tab-atmospheric", label: 'Atmospheric' },
+          { id: "tab-lander", label: 'Lander' }
+        ]
+      }
+    }
+  }
+}
+</script>
+
+## References
+
+### Further Reading
+
+- [Tabs Design Pattern in WAI-ARIA Authoring Practices 1.1](https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel)
 
 :::
 
 ::: slot html-scss
-## HTML & CSS
+
+## Switching tabs
+
+<Description>
+
+The JS included in the `@okta/odyssey` package is for demo purposes only. For those implementing the Tab component from scratch, be sure to implement the behavior as follows:
+
+1. Set the select tab button's aria-selected attribute to true. If a different tab was previously selected, that tab button's aria-selected attribute must be set to false.
+2. The tabpanel corresponding to the tab button is shown. This is done by removing the hidden attribute on the tabpanel. If a different tabpanel was previously visible, the hidden attribute is applied to it.
+
+</Description>
+
 :::

--- a/packages/docs/components/tab.md
+++ b/packages/docs/components/tab.md
@@ -71,7 +71,7 @@ Additionally, the tab element is keyboard-navigable (See [Accessibility: Keyboar
 <Description>
 
 Tabs were created to shorten long pages. Before you use these, we’d recommend laying 
-out all of the content on your page out first. From there figure out common themes and 
+out all of the content on your page out first. From there, figure out common themes and 
 see what could be grouped together. Those themes should become your Tabs.
 
 </Description>

--- a/packages/docs/components/text-input.md
+++ b/packages/docs/components/text-input.md
@@ -38,7 +38,7 @@ This default serves as the basis for our Text Inputs. A shown here, they require
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <input class="ods-text-input" type="text" id="overview-default" required>
@@ -57,7 +57,7 @@ In this case, we recommend using the placeholder attribute to state the scope of
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <input class="ods-text-input" type="search" name="overview-search" id="overview-search" autocomplete="search" spellcheck="false" placeholder="Search planets" required>
@@ -74,7 +74,7 @@ We also provide an attached button for in-page searching or avoiding placeholder
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <form>
     <fieldset class="ods-fieldset">
       <div class="ods-fieldset--attached">
@@ -99,7 +99,7 @@ Textareas should be used for multi-line text inputs. As the user types the field
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <textarea class="ods-text-input ods-text-area" name="overview-textarea" id="overview-textarea" rows='4' cols='50' spellcheck="true" required></textarea>
@@ -127,7 +127,7 @@ Text inputs in their "normal" state are considered enabled. They are ready for u
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <input class="ods-text-input" type="text" name="overview-enabled" id="overview-enabled" required>
@@ -144,7 +144,7 @@ Hover states are activated when the user pauses their pointer over the input.
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <input class="ods-text-input is-ods-input-hover" name="overview-hover" type="text" id="overview-hover" required>
@@ -161,7 +161,7 @@ The focus state is a visual affordance that the user has highlighted the input w
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <input class="ods-text-input is-ods-input-focus" name="overview-focus" type="text" id="overview-focus" required>
@@ -180,7 +180,7 @@ The values of disabled inputs will not be submitted.
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <input disabled class="ods-text-input" type="text" name="overview-disabled" id="overview-disabled" required disabled>
@@ -201,7 +201,7 @@ The values of read-only inputs will be submitted.
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <input class="ods-text-input" type="text" name="overview-readonly" id="overview-readonly" value="Jupiter" required readonly spellcheck="false">
@@ -218,7 +218,7 @@ Odyssey assumes inputs are required by default. Optional inputs should be used t
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <input class="ods-text-input" type="text" name="overview-optional" id="overview-optional" spellcheck="false">
@@ -237,7 +237,7 @@ When indicating a validation error, please use a Field Error label to indicate t
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <input data-invalid class="ods-text-input" type="text" name="overview-invalid" aria-describedby="overview-invalid-error" id="overview-invalid" spellcheck="false" value="4.76 miles/s" required>
@@ -265,7 +265,7 @@ There are no specific UI changes for email addresses, but inputs of this type wi
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <input class="ods-text-input" type="email" name="overview-email" id="overview-email" autocomplete="email" spellcheck="false" value="homer@okta.com" required>
@@ -282,7 +282,7 @@ Unlike email fields, tel inputs are not automatically validated because global f
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <input class="ods-text-input" type="phone" name="overview-tel" id="overview-tel" autocomplete="tel" spellcheck="false" value="555-555-1212" required>
@@ -299,7 +299,7 @@ Passwords inputs ensure that sensitive content is safely obscured.
 
 </Description>
 
-<Visual variant="content-full">
+<Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
       <input class="ods-text-input" type="password" name="overview-password" id="overview-password" autocomplete="password" spellcheck="false" value="Big Gas Giants" required>

--- a/packages/odyssey/src/scss/components/_tab.scss
+++ b/packages/odyssey/src/scss/components/_tab.scss
@@ -33,6 +33,7 @@
     &::before {
       content: '';
       position: absolute;
+      z-index: 1;
       bottom: -1px;
       left: 0;
       width: 100%;

--- a/packages/odyssey/src/scss/components/_tab.scss
+++ b/packages/odyssey/src/scss/components/_tab.scss
@@ -33,7 +33,6 @@
     &::before {
       content: '';
       position: absolute;
-      z-index: 1;
       bottom: -1px;
       left: 0;
       width: 100%;

--- a/packages/vuepress-theme-odyssey/global-components/Visual.vue
+++ b/packages/vuepress-theme-odyssey/global-components/Visual.vue
@@ -5,7 +5,8 @@
       'with-fade': fade,
       [`layout-${layout}`]: layout,
       [`theme-${theme}`]: theme,
-      [`is-docskit-visual-${variant}`]: variant
+      [`is-docskit-visual-${variant}`]: variant,
+      [`is-docskit-visual-content-${content}`]: content
     }"
   >
     <h6
@@ -33,6 +34,10 @@ export default {
       required: false
     },
     theme: {
+      type: String,
+      required: false
+    },
+    content: {
       type: String,
       required: false
     },

--- a/packages/vuepress-theme-odyssey/global-components/Visual.vue
+++ b/packages/vuepress-theme-odyssey/global-components/Visual.vue
@@ -2,7 +2,9 @@
   <div
     :class="{
       'docskit-visual': true,
-      'docskit-visual--wide': wide,
+      'with-fade': fade,
+      [`layout-${layout}`]: layout,
+      [`theme-${theme}`]: theme,
       [`is-docskit-visual-${variant}`]: variant
     }"
   >
@@ -24,13 +26,19 @@ export default {
   props: {
     variant: {
       type: String,
-      required: false,
-      default: null
+      required: false
     },
-    wide: {
+    layout: {
+      type: String,
+      required: false
+    },
+    theme: {
+      type: String,
+      required: false
+    },
+    fade: {
       type: Boolean,
-      required: false,
-      default: false
+      required: false
     }
   }
 };

--- a/packages/vuepress-theme-odyssey/styles/_Visual.scss
+++ b/packages/vuepress-theme-odyssey/styles/_Visual.scss
@@ -46,9 +46,9 @@
       right: 1px;
       bottom: 1px;
       left: 1px;
-      height: 33%;
+      height: 50%;
       border-radius: 0 0 $base-border-radius $base-border-radius;
-      background: linear-gradient(to top, rgba(255, 255, 255, 1) 33.33%, rgba(255, 255, 255, 0) 100%);
+      background: linear-gradient(to top, rgba(255, 255, 255, 1) 33.33%, rgba(255, 255, 255, 0) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
     }
   }
 

--- a/packages/vuepress-theme-odyssey/styles/docskit/_Visual.scss
+++ b/packages/vuepress-theme-odyssey/styles/docskit/_Visual.scss
@@ -1,6 +1,6 @@
 .docskit-visual {
   grid-column: 2 / 3;
-  min-width: 420px;
+  min-width: $max-line-length;
   margin-bottom: $spacing-m;
 
   .docskit-visual--title {

--- a/packages/vuepress-theme-odyssey/styles/docskit/_Visual.scss
+++ b/packages/vuepress-theme-odyssey/styles/docskit/_Visual.scss
@@ -2,21 +2,7 @@
   grid-column: 2 / 3;
   margin-bottom: $spacing-m;
 
-  &,
-  p {
-    font-size: ms(0);
-  }
-
-  &.docskit-visual--wide {
-    grid-column: 1 / 3;
-    width: 100%;
-  }
-
   .docskit-visual--title {
-    display: flex;
-    align-items: center;
-    font-weight: normal;
-
     &::before {
       margin-right: $spacing-xs;
       font-size: $size-title-5;
@@ -27,11 +13,41 @@
     display: grid;
     position: relative;
     grid-auto-columns: max-content;
-    align-items: center;
     justify-content: center;
     padding: $spacing-l $spacing-l;
     border: 1px solid var(--border-color-display, #{$border-color-display});
     border-radius: $base-border-radius;
+  }
+
+  &.layout-wide {
+    grid-column: 1 / 3;
+  }
+
+  &.theme-transparent {
+    .docskit-visual--figure {
+      padding: 0;
+      border: 0;
+    }
+  }
+
+  &.with-fade {
+    display: block;
+    position: relative;
+    .docskit-visual--figure {
+      padding-bottom: 0;
+    }
+
+    &::after {
+      content: '';
+      display: block;
+      position: absolute;
+      right: 1px;
+      bottom: 1px;
+      left: 1px;
+      height: 50%;
+      border-radius: 0 0 $base-border-radius $base-border-radius;
+      background: linear-gradient(to top, rgba(255,255,255,1) 33.33%,rgba(255,255,255,0) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+    }
   }
 
   &.is-docskit-visual-content-full {

--- a/packages/vuepress-theme-odyssey/styles/index.scss
+++ b/packages/vuepress-theme-odyssey/styles/index.scss
@@ -119,6 +119,10 @@ h6 {
 
 // Component Samples
 
+.is-sample-unimportant {
+  opacity: 0.33;
+}
+
 .sample-color {
   display: inline-block;
   width: 1em;

--- a/packages/vuepress-theme-odyssey/styles/index.scss
+++ b/packages/vuepress-theme-odyssey/styles/index.scss
@@ -123,6 +123,22 @@ h6 {
   opacity: 0.33;
 }
 
+.is-tab-small-sample {
+  .ods-tabs--tabpanel [role='tabpanel'] {
+    padding-bottom: $spacing-s;
+  }
+}
+
+.is-tab-stacked-example {
+  .ods-tabs [role='tabpanel'] {
+    padding: $spacing-l;
+  }
+
+  .ods-tabs:first-child [role='tabpanel'] {
+    padding: $spacing-xs;
+  }
+}
+
 .sample-color {
   display: inline-block;
   width: 1em;

--- a/packages/vuepress-theme-odyssey/styles/templates/_DocsTemplateComponent.scss
+++ b/packages/vuepress-theme-odyssey/styles/templates/_DocsTemplateComponent.scss
@@ -91,7 +91,7 @@
   /* stylelint-enable */
 }
 
-.ods-tabs--tablist {
+.docs-main--content-tabs > .ods-tabs--tablist {
   position: sticky;
   z-index: z-index(base);
   top: 0;

--- a/packages/vuepress-theme-odyssey/templates/DocsTemplateComponent.vue
+++ b/packages/vuepress-theme-odyssey/templates/DocsTemplateComponent.vue
@@ -24,6 +24,7 @@
 
     <OdsTabs
       id="tabs-doc-sections"
+      class="docs-main--content-tabs"
       :label="$page.frontmatter.name + ' documentation sections'"
       :active="$page.frontmatter.tabs[0].id"
       :tablist="$page.frontmatter.tabs"


### PR DESCRIPTION
- remove unnecessary z-index from odyssey tab.scss
- introduce layout: wide, theme: transparent, fade prop/values to Visual component
- add is-sample-unimportant class to docs which turns down opacity for a given element
- adds class to OdsTabs within DocsTemplateComponent
- adds tab component content
- adds content prop to Visuals component, moves content-full variant to this new prop