### PR TITLE
Updates section

### DIFF
--- a/packages/docs/updates/index.md
+++ b/packages/docs/updates/index.md
@@ -2,8 +2,8 @@
 template: plain
 title: Odyssey Updates
 headline: Updates
-lead: Here’s a list of all our most recent updates. Updates can vary from component changes to team updates and contribution.
-description: Odyssey colors consist of a variety of neutral, semantic, and brand values used in all UIs for utmost clarity and readability.
+lead: Here’s a list of all our most recent updates. Updates can vary from component changes to team updates and contributions.
+description: Here’s a list of all our most recent updates. Updates can vary from component changes to team updates and contributions.
 links:
   - icon: github
     label: Changelog

--- a/packages/docs/updates/index.md
+++ b/packages/docs/updates/index.md
@@ -2,23 +2,35 @@
 template: plain
 title: Odyssey Updates
 headline: Updates
+lead: Here’s a list of all our most recent updates. Updates can vary from component changes to team updates and contribution.
+description: Odyssey colors consist of a variety of neutral, semantic, and brand values used in all UIs for utmost clarity and readability.
+links:
+  - icon: github
+    label: Changelog
+    href: https://github.com/okta/odyssey/blob/master/packages/odyssey/src/scss/components/_text-input.scss
 ---
 
- 
-- [October 2, 2020](./2020-10-02.md)
+ ## 2020
 
+<Description>
 
-The following are TODO:
+- [October 2, 2020 - v0.6.0](https://github.com/okta/odyssey/releases/tag/%40okta%2Fodyssey_0.6.0)
+- [September 18, 2020 - v0.5.1](https://github.com/okta/odyssey/releases/tag/%40okta%2Fodyssey_0.5.1)
+- [September 3, 2020 - v0.5.0](https://github.com/okta/odyssey/releases/tag/%40okta%2Fodyssey_0.5.0)
+- [August 5, 2020 - v0.4.0](https://github.com/okta/odyssey/releases/tag/%40okta%2Fodyssey_0.4.0)
+- [June 25, 2020 - v0.3.0](https://github.com/okta/odyssey/releases/tag/%40okta%2Fodyssey_0.3.0)
+- [April 30, 2020 - v0.2.0](https://github.com/okta/odyssey/releases/tag/%40okta%2Fodyssey_0.2.0)
+- [April 20, 2020 - v0.1.3](https://github.com/okta/odyssey/releases/tag/%40okta%2Fodyssey_0.1.3)
+- [April 6, 2020 - v0.1.2](https://github.com/okta/odyssey/releases/tag/%40okta%2Fodyssey_0.1.2)
+- [April 3, 2020 - v0.1.1](https://github.com/okta/odyssey/releases/tag/%40okta%2Fodyssey_0.1.1)
 
-- [September 18, 2020 (0.5.1)](./2020-09-18.md)
-- [September 3, 2020 (0.5.0)](./2020-09-03.md)
-- [August 6, 2020 (0.4.0)](./2020-08-06.md)
-- [July 16, 2020 (0.3.0)](./2020-07-16.md)
-- [June 25, 2020 (0.3.0)](./2020-06-25.md)
-- [April 30, 2020 (0.2.0)](./2020-04-30.md)
-- [April 20, 2020 (0.1.3)](./2020-04-20.md)
-- [April 6, 2020 (0.1.2)](./2020-04-06.md)
-- [April 3, 2020 (0.1.1)](./2020-04-03.md)
-- [April 2, 2020 (0.1.0)](./2020-04-02.md)
-- [October 10, 2019 (0.0.1)](./2019-10-02.md)
-- [April 25, 2019 (0.0.0)](./2019-04-25.md)
+</Description>
+
+## 2019
+
+<Description>
+
+- [October 10, 2019 - v0.0.1](https://github.com/okta/odyssey/releases/tag/odyssey-0.0.1)
+- [April 25, 2019 - v0.0.0](https://github.com/okta/odyssey/releases/tag/0.0.0)
+
+</Description>

--- a/packages/odyssey/CHANGELOG.md
+++ b/packages/odyssey/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.0] - 2020-10-01
+## [0.6.0] - 2020-10-02
 
 ### Added
 - Toast: a transient messaging component
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Docs] `title` displays correctly once more ("Odyssey Design System")
 - [Docs] VuePress no longer modifies outbound links automatically
 
-## [0.5.0] - 2020-09-02
+## [0.5.0] - 2020-09-03
 
 ### Added
 - [Docs] Iconography documentation, available at /base/iconography
@@ -90,7 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Buttons labels no longer wrap (`white-spacing: nowrap`)
 
-## [0.3.0] - 2020-06-24
+## [0.3.0] - 2020-06-25
 
 ### Added
 - Design Tokens
@@ -123,7 +123,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Docs] Fix misspelling in Form documentation
 - [Docs] Rename "Foundation" to "Base" in nav
 
-## [0.1.3] - 2020-04-10
+## [0.1.3] - 2020-04-20
 
 ### Added
 


### PR DESCRIPTION
- update "Updates" section to link to GH Release notes
- updates CHANGELOG to reflect the date the release went out, rather than when the changelog entry was authored.