### PR TITLE
Design review fixes

### DIFF
--- a/packages/docs/components/link.md
+++ b/packages/docs/components/link.md
@@ -11,7 +11,7 @@ tabs:
     id: 'html-scss'
 links:
   - icon: github
-    label: View Source
+    label: View source
     href: https://github.com/okta/odyssey/blob/master/packages/odyssey/src/scss/base/_typography-link.scss
   - icon: figma
     label: View designs

--- a/packages/docs/components/modal.md
+++ b/packages/docs/components/modal.md
@@ -145,8 +145,8 @@ For users happy with their new context, we ensure their attention isn't misdirec
           </p>
         </main>
         <footer class="ods-modal--footer">
-          <button class="ods-button is-ods-button-clear" data-micromodal-close aria-label="Close this dialog window">Cancel</button>
-          <button class="ods-button">Confirm</button>
+          <button class="ods-button is-ods-button-clear" aria-label="Close this dialog window" data-micromodal-close>Cancel</button>
+          <button class="ods-button" data-micromodal-close>Confirm</button>
         </footer>
       </div>
     </div>

--- a/packages/docs/components/tab.md
+++ b/packages/docs/components/tab.md
@@ -167,6 +167,8 @@ Use Tab sparingly. Limit the Tab component to one per page, and refrain from inc
 
 ### Keyboard Support
 
+<Description>
+
 <figure class="ods-table--figure">
   <table class="ods-table">
     <caption>When implementing this component you should consider the following keyboard behaviors.</caption>
@@ -213,6 +215,8 @@ Use Tab sparingly. Limit the Tab component to one per page, and refrain from inc
     </tbody>
   </table>
 </figure>
+
+</Description>
 
 ## References
 

--- a/packages/docs/components/tooltip.md
+++ b/packages/docs/components/tooltip.md
@@ -11,9 +11,6 @@ tabs:
     id: 'html-scss'
 links:
   - icon: github
-    label: Legacy docs
-    href: https://github.com/okta/odyssey/blob/master/packages/docs/components/tooltip.md
-  - icon: github
     label: View source
     href: https://github.com/okta/odyssey/blob/master/packages/odyssey/src/scss/components/_tooltip.scss
   - icon: figma


### PR DESCRIPTION
- Fix sentence casing in Link doc header links
- Add `micromodal-data-close` to modal example buttons
- Wrap keyboard accessibility table with `Description` in Tab docs
- Remove legacy docs link in tooltip docs