### PR TITLE
[a11y] respect prefers-reduced-motion in Toasts

### DIFF
--- a/packages/odyssey/src/scss/components/_toast.scss
+++ b/packages/odyssey/src/scss/components/_toast.scss
@@ -136,3 +136,17 @@
     opacity: 0;
   }
 }
+
+@media (prefers-reduced-motion) {
+  .ods-toast {
+    animation-name: ods-toast-in;
+    animation-duration: 300ms;
+    animation-delay: 0s;
+
+    &.is-toast-dismissed {
+      animation-name: ods-toast-out;
+      animation-duration: 300ms;
+      animation-delay: 0s;
+    }
+  }
+}


### PR DESCRIPTION
This adds a media query to check if `prefers-reduced-motion` is enabled. If so, we remove the automatic outbound animation. Since our component checks for that animation to finish before leaving the DOM, the user is able to view the Toast until they dismiss it manually.

Jira: https://oktainc.atlassian.net/browse/OKTA-361265

For some context, this is a system preference as seen here:

<img width="780" alt="Screen Shot 2021-04-23 at 9 49 50 AM" src="https://user-images.githubusercontent.com/36284167/115904578-cd463480-a419-11eb-8492-fdcf9c7cdbb3.png">