### PR TITLE
Legal updates for OSS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,29 @@
+const { pattern, template, header } = require('./header');
+
 module.exports = {
   parserOptions: {
     ecmaVersion: 6,
-    sourceType: "module"
-  }
+    sourceType: 'module'
+  },
+  overrides: [
+    {
+      files: '*.js',
+      excludedFiles: [".eslintrc.js", "header.js"],
+      plugins: [
+        'header'
+      ],
+      rules: {
+        'header/header': [
+          'error',
+          'block',
+          [
+            '!',
+            { pattern, template },
+            ...header.split('\n')
+          ],
+          2,
+        ]
+      }
+    }
+  ]
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ const { pattern, template, header } = require('./header');
 
 module.exports = {
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2018,
     sourceType: 'module'
   },
   overrides: [

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -31,8 +31,11 @@ jobs:
       - name: install dependencies
         run: yarn
 
+      - name: lint
+        run: yarn lint
+
       - name: test
-        run: ./node_modules/lerna/cli.js run test
+        run: yarn test
 
       - name: build docs
         run: yarn workspace @okta/design-docs build

--- a/README.md
+++ b/README.md
@@ -93,3 +93,9 @@ Before publishing a new version, ensure the following steps are performed:
 3. Commit your changes and submit the `CHANGELOG` for approval. Once approved, merge into `master`.
 
 4. (*Internal use only*) Reach out in the `#odyssey` slack channel to promote the package to public NPM.
+
+## Support Disclaimer
+
+This library is community supported and is maintained by members of the Okta team for developers and IT professionals.
+This library is not an official Okta product and does not qualify for any Okta support. Anyone who chooses to use this
+library must ensure that their implementation meets any applicable legal obligations including any Okta terms and conditions.

--- a/header.js
+++ b/header.js
@@ -1,0 +1,16 @@
+const getYear = () => new Date().getUTCFullYear().toString().slice(-2);
+
+exports.pattern = `\\* Copyright \\(c\\) 20\\d{2}-present, Okta, Inc\\. and\\/or its affiliates\\. All rights reserved\\.`
+
+exports.template= ` * Copyright (c) 20${getYear()}-present, Okta, Inc. and/or its affiliates. All rights reserved.`
+
+exports.header = `\
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ `

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
     "lerna-version": "lerna version --no-git-tag-version --force-publish",
     "prelerna-publish": "lerna run build",
     "lerna-publish": "lerna publish from-package --no-push --force-publish --no-verify-access --no-verify-registry",
-    "lint": "eslint . --ext .js,.vue && stylelint ./*.scss", 
-    "test": "yarn lint" 
+    "lint": "yarn eslint && yarn stylelint",
+    "eslint": "eslint .",
+    "stylelint": "lerna run stylelint",
+    "test": "lerna run test"
   },
   "devDependencies": {
     "eslint": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "eslint": "^7.9.0",
+    "eslint-plugin-header": "^3.1.1",
     "lerna": "3.3.2"
   },
   "version": "0.5.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "name": "odyssey",
+  "author": "Okta, Inc.",
+  "license": "Apache-2.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -7,8 +7,7 @@
   ],
   "scripts": {
     "build": "vuepress build",
-    "start": "yarn build && vuepress dev --no-clear-screen",
-    "test": "echo \"Tests have not been implemented for ${npm_package_name}\" && exit 0"
+    "start": "yarn build && vuepress dev --no-clear-screen"
   },
   "browserslist": [
     "last 2 versions"

--- a/packages/odyssey/package.json
+++ b/packages/odyssey/package.json
@@ -13,8 +13,7 @@
   "scripts": {
     "prepare": "yarn build",
     "build": "node-sass src/scss/odyssey.scss dist/odyssey.css",
-    "lint": "stylelint src/",
-    "test": "yarn lint"
+    "stylelint": "stylelint src/"
   },
   "devDependencies": {
     "node-sass": "^4.9.4",

--- a/packages/prism-theme-odyssey/src/index.js
+++ b/packages/prism-theme-odyssey/src/index.js
@@ -1,3 +1,15 @@
+/*!
+ * Copyright (c) 2020-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
 import '@okta/odyssey';
 
 import "prismjs";

--- a/packages/prism-theme-odyssey/src/utils/CustomPropertyInspector.js
+++ b/packages/prism-theme-odyssey/src/utils/CustomPropertyInspector.js
@@ -1,3 +1,15 @@
+/*!
+ * Copyright (c) 2020-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
 const Storage = window.localStorage;
 const LOCALSTORAGE_ID = "ods-prism-theme";
 class CustomPropertyInspector {

--- a/packages/prism-theme-odyssey/webpack.config.js
+++ b/packages/prism-theme-odyssey/webpack.config.js
@@ -1,3 +1,15 @@
+/*!
+ * Copyright (c) 2020-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
 var path = require('path');
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 

--- a/packages/vuepress-theme-odyssey/.eslintrc.js
+++ b/packages/vuepress-theme-odyssey/.eslintrc.js
@@ -1,3 +1,8 @@
 module.exports = {
-  extends: ["vuepress"]
+  overrides: [
+    {
+      files: ["*.js", "*.vue"],
+      extends: ["vuepress"]
+    }
+  ]
 };

--- a/packages/vuepress-theme-odyssey/enhanceApp.js
+++ b/packages/vuepress-theme-odyssey/enhanceApp.js
@@ -1,1 +1,13 @@
+/*!
+ * Copyright (c) 2020-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
 export default ({ Vue, options, router, siteData }) => {};

--- a/packages/vuepress-theme-odyssey/index.js
+++ b/packages/vuepress-theme-odyssey/index.js
@@ -1,3 +1,15 @@
+/*!
+ * Copyright (c) 2020-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
 // Theme API.
 module.exports = (options, ctx) => {
   return {

--- a/packages/vuepress-theme-odyssey/utils/index.js
+++ b/packages/vuepress-theme-odyssey/utils/index.js
@@ -1,3 +1,15 @@
+/*!
+ * Copyright (c) 2020-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
 export const hashRE = /#.*$/;
 export const extRE = /\.(md|html)$/;
 export const endingSlashRE = /\/$/;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4929,6 +4929,11 @@ eslint-plugin-es@^2.0.0:
     eslint-utils "^1.4.2"
     regexpp "^3.0.0"
 
+eslint-plugin-header@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz#6ce512432d57675265fac47292b50d1eff11acd6"
+  integrity sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==
+
 eslint-plugin-import@^2.18.2:
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz#0896c7e6a0cf44109a2d97b95903c2bb689d7702"


### PR DESCRIPTION
This PR helps align a few details here in our monorepo with Okta's OSS guidance.

I've also reworked our lint script to support failing the CI build if a `.js` file is does not include our license header. A bit more effort will be required for `.vue` files or other source files we want to prefix in a similar fashion.