### PR TITLE
Type Scale 4.0

### DIFF
--- a/packages/docs/components/tab.md
+++ b/packages/docs/components/tab.md
@@ -29,7 +29,7 @@ links:
 
 <Description>
 
-Users interact with Tab as they would a button, the main difference is the outcome. By default, the first tab from the left is active and the associated content displayed in the tab panel. Upon selecting a different tab, the tab indicator appears on the selected tab. The tab panel will then update to show the new content. 
+Users interact with Tab as they would a button, the main difference is the outcome. By default, the first tab from the left is active and the associated content displayed in the tab panel. Upon selecting a different tab, the tab indicator appears on the selected tab. The tab panel will then update to show the new content.
 
 Additionally, the tab element is keyboard-navigable (See [Accessibility: Keyboard Support](#keyboard-support))
 
@@ -37,10 +37,8 @@ Additionally, the tab element is keyboard-navigable (See [Accessibility: Keyboar
 
 <Visual layout="wide" content="full" fade>
   <template>
-    <header>
-      <h1>Terrestrial Planets</h1>
-      <p>Terrestrial planets are planets that are composed primarily of silicate rocks or metals.</p>
-    </header>
+    <h1>Terrestrial Planets</h1>
+    <p>Terrestrial planets are planets that are composed primarily of silicate rocks or metals.</p>
     <OdsTabs aria-label="Types of terrestrial planets" :active="tabsPlanets.active" :tablist="tabsPlanets.tablist" id="example-1">
       <template slot="tab-mercury">
         <blockquote class="is-sample-unimportant">
@@ -70,8 +68,8 @@ Additionally, the tab element is keyboard-navigable (See [Accessibility: Keyboar
 
 <Description>
 
-Tabs were created to shorten long pages. Before you use these, we’d recommend laying 
-out all of the content on your page out first. From there, figure out common themes and 
+Tabs were created to shorten long pages. Before you use these, we’d recommend laying
+out all of the content on your page out first. From there, figure out common themes and
 see what could be grouped together. Those themes should become your Tabs.
 
 </Description>
@@ -85,18 +83,14 @@ Tabs are not navigation. Meaning they don’t take you from place to place. Rath
 </Description>
 
 <Visual variant="positive" content="no-end" class="is-tab-small-sample">
-  <header>
-    <h2>Terrestrial Planets</h2>
-    <p>Terrestrial planets are planets that are composed primarily of silicate rocks or metals.</p>
-  </header>
+  <h2>Terrestrial Planets</h2>
+  <p>Terrestrial planets are planets that are composed primarily of silicate rocks or metals.</p>
   <OdsTabs aria-label="Types of terrestrial planets" :active="tabsPlanets.active" :tablist="tabsPlanets.tablist" id="example-2"></OdsTabs>
 </Visual>
 
 <Visual variant="negative" content="no-end" class="is-tab-small-sample">
-  <header>
-    <h2>Terrestrial Planets</h2>
-    <p>Terrestrial planets are planets that are composed primarily of silicate rocks or metals.</p>
-  </header>
+  <h2>Terrestrial Planets</h2>
+  <p>Terrestrial planets are planets that are composed primarily of silicate rocks or metals.</p>
   <OdsTabs aria-label="Famous constellations" :active="tabsConstellations.active" :tablist="tabsConstellations.tablist" id="example-3"></OdsTabs>
 </Visual>
 
@@ -110,32 +104,24 @@ Tabs are best used at the top of the page or situated above the content it’s r
 
 
 <Visual variant="positive" content="no-end" class="is-tab-small-sample">
-  <header>
-    <h2>Missions</h2>
-    <p>There have been 49 missions involving various types of spacecraft.</p>
-  </header>
+  <h2>Missions</h2>
+  <p>There have been 49 missions involving various types of spacecraft.</p>
   <OdsTabs aria-label="Missions by type" :active="tabs.active" :tablist="tabs.tablist" id="example-4"></OdsTabs>
 </Visual>
 
 <Visual variant="negative"  content="no-end" class="is-tab-small-sample">
   <OdsTabs aria-label="Missions by type" :active="tabs.active" :tablist="tabs.tablist" id="example-5">
   <template slot="tab-orbiter">
-    <header>
-      <h2>Missions</h2>
-      <p>There have been 8 missions involving orbiters.</p>
-    </header>
+    <h2>Missions</h2>
+    <p>There have been 8 missions involving orbiters.</p>
   </template>
   <template slot="tab-atmospheric">
-    <header>
-      <h2>Missions</h2>
-      <p>There have been 12 missions involving atmospheric vehicles.</p>
-    </header>
+    <h2>Missions</h2>
+    <p>There have been 12 missions involving atmospheric vehicles.</p>
   </template>
   <template slot="tab-lander">
-    <header>
-      <h2>Missions</h2>
-      <p>There have been 4 missions involving lander vehicles.</p>
-    </header>
+    <h2>Missions</h2>
+    <p>There have been 4 missions involving lander vehicles.</p>
   </template>
   </OdsTabs>
 </Visual>

--- a/packages/odyssey/src/scss/abstracts/_tokens.scss
+++ b/packages/odyssey/src/scss/abstracts/_tokens.scss
@@ -15,7 +15,7 @@ $body-font-family: 'Whyte', '-apple-system',  'BlinkMacSystemFont', 'Segoe UI', 
 $mono-font-family: 'Inconsolata', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
 $base-font-size: 16px;
-$scale-ratio: 1.2011;
+$scale-ratio: 1.1627;
 $base-line-height: 1.5;
 $title-line-height: 1.3;
 $max-line-length: 32em;

--- a/packages/odyssey/src/scss/abstracts/_tokens.scss
+++ b/packages/odyssey/src/scss/abstracts/_tokens.scss
@@ -19,7 +19,7 @@ $scale-ratio: 1.1627;
 $base-line-height: 1.5;
 $title-line-height: 1.3;
 $max-line-length: 32em;
-$type-margin: 1.5em;
+$type-margin: 2em;
 
 // Establish Type Scale
 $size-title-1: ms(5);

--- a/packages/odyssey/src/scss/abstracts/_tokens.scss
+++ b/packages/odyssey/src/scss/abstracts/_tokens.scss
@@ -11,15 +11,15 @@
  */
 
 // Typography
-$body-font-family: 'Noto Sans', 'Public Sans', 'Whyte', '-apple-system',  'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
+$body-font-family: 'Public Sans', 'Noto Sans', 'Whyte', '-apple-system',  'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
 $mono-font-family: 'Inconsolata', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
 $base-font-size: 16px;
-$scale-ratio: 1.1627;
+$scale-ratio: 1.1487;
 $base-line-height: 1.5;
 $title-line-height: 1.3;
 $max-line-length: 32em;
-$type-margin: 2em;
+$type-margin: 1.5em;
 
 // Establish Type Scale
 $size-title-1: ms(5);

--- a/packages/odyssey/src/scss/abstracts/_tokens.scss
+++ b/packages/odyssey/src/scss/abstracts/_tokens.scss
@@ -15,7 +15,7 @@ $body-font-family: 'Whyte', '-apple-system',  'BlinkMacSystemFont', 'Segoe UI', 
 $mono-font-family: 'Inconsolata', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
 $base-font-size: 16px;
-$scale-ratio: 1.1761;
+$scale-ratio: 1.2011;
 $base-line-height: 1.5;
 $title-line-height: 1.3;
 $max-line-length: 32em;

--- a/packages/odyssey/src/scss/abstracts/_tokens.scss
+++ b/packages/odyssey/src/scss/abstracts/_tokens.scss
@@ -15,7 +15,7 @@ $body-font-family: 'Whyte', '-apple-system',  'BlinkMacSystemFont', 'Segoe UI', 
 $mono-font-family: 'Inconsolata', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
 $base-font-size: 16px;
-$scale-ratio: 1.1487;
+$scale-ratio: 1.1761;
 $base-line-height: 1.5;
 $title-line-height: 1.3;
 $max-line-length: 32em;

--- a/packages/odyssey/src/scss/abstracts/_tokens.scss
+++ b/packages/odyssey/src/scss/abstracts/_tokens.scss
@@ -14,12 +14,11 @@
 $body-font-family: 'Whyte', '-apple-system',  'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
 $mono-font-family: 'Inconsolata', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
-$base-font-size: 14px; // Must be px value for now
-$scale-ratio: 1.1942;
-$base-line-height: 1.7142857;
+$base-font-size: 16px;
+$scale-ratio: 1.1487;
+$base-line-height: 1.5;
 $title-line-height: 1.3;
 $max-line-length: 32em;
-
 $type-margin: 1.5em;
 
 // Establish Type Scale

--- a/packages/odyssey/src/scss/abstracts/_tokens.scss
+++ b/packages/odyssey/src/scss/abstracts/_tokens.scss
@@ -11,7 +11,7 @@
  */
 
 // Typography
-$body-font-family: 'Whyte', '-apple-system',  'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
+$body-font-family: 'Noto Sans', 'Public Sans', 'Whyte', '-apple-system',  'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
 $mono-font-family: 'Inconsolata', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
 $base-font-size: 16px;

--- a/packages/odyssey/src/scss/base/_typography-global.scss
+++ b/packages/odyssey/src/scss/base/_typography-global.scss
@@ -11,7 +11,7 @@
  */
 
 html {
-  font-size: ($base-font-size / 16px) * 100%; // converts px value to % of default
+  font-size: ($base-font-size / 16px) * 100%; // converts px value to % of browser default
 }
 
 body {

--- a/packages/odyssey/src/scss/base/_typography-header.scss
+++ b/packages/odyssey/src/scss/base/_typography-header.scss
@@ -16,7 +16,7 @@ h3,
 h4,
 h5,
 h6 {
-  margin: 0 0 $spacing-xs-em;
+  margin: 0 0 $spacing-m-em;
   color: $text-heading;
   font-weight: 600;
 }

--- a/packages/odyssey/src/scss/base/_typography-header.scss
+++ b/packages/odyssey/src/scss/base/_typography-header.scss
@@ -16,7 +16,7 @@ h3,
 h4,
 h5,
 h6 {
-  margin: 0 0 $spacing-m-em;
+  margin: 0 0 $spacing-xs-em;
   color: $text-heading;
   font-weight: 600;
 }

--- a/packages/odyssey/src/scss/components/_infobox.scss
+++ b/packages/odyssey/src/scss/components/_infobox.scss
@@ -18,8 +18,8 @@
     '. actions';
   grid-template-columns: max-content 1fr;
   width: 100%;
-  max-width: calc(#{$max-line-length} + #{$spacing-s} + #{$spacing-s});
-  padding: $spacing-s;
+  max-width: calc(#{$max-line-length} + #{$spacing-m} + #{$spacing-m});
+  padding: $spacing-m;
   column-gap: $spacing-s;
   border-radius: $base-border-radius;
 
@@ -43,7 +43,6 @@
 
 .ods-infobox--title {
   grid-area: title;
-  margin-bottom: 0;
   font-size: $size-title-6;
 }
 

--- a/packages/odyssey/src/scss/components/_tab.scss
+++ b/packages/odyssey/src/scss/components/_tab.scss
@@ -24,7 +24,7 @@
   background: none;
   color: $text-body;
   font-family: inherit;
-  font-size: $size-title-5;
+  font-size: $size-title-6;
   font-weight: 600;
 
   &[aria-selected='true'] {

--- a/packages/vuepress-theme-odyssey/styles/components/_DocsPageHeader.scss
+++ b/packages/vuepress-theme-odyssey/styles/components/_DocsPageHeader.scss
@@ -25,6 +25,7 @@
 
   .docs-page-header--lead {
     grid-column: 1 / 2;
+    margin: 0;
     font-size: $size-title-4;
 
     @include mq(l) {


### PR DESCRIPTION
This updates our Typography in a few major ways:

- Our base font size is now `16px`, up from `14px`
- Our font stack now prefers Public Sans and Noto to Whyte
- Our body line-height is now `1.5`, down from `.7142857`
  - This previous number was to allow for 16px-based spacing units with a 14px font-size
- Our scale ratio is now `1.1487`, giving us a heading selection of 16px, 18px, 21px, 24px, 28px, 32px

This PR also includes related fixes for a handful of components that previously relied on our odd 14/16 interplay.

Preview here: https://d24ea1d.ods.dev/base/typography/