### PR TITLE
fix: invalid checkbox disabled state

### DIFF
--- a/packages/docs/components/checkbox.md
+++ b/packages/docs/components/checkbox.md
@@ -128,8 +128,14 @@ Checkboxes are disabled individually. The values of disabled inputs will not be 
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <input class="ods-checkbox" type="checkbox" name="checkbox" id="overview-disabled" value="overview-disabled" disabled>
+    <input class="ods-checkbox" type="checkbox" name="overview-disabled[]" id="overview-disabled-checked" value="overview-disabled" checked disabled>
+    <label class="ods-checkbox--label" for="overview-disabled-checked">Enable auto-docking</label>
+    <input class="ods-checkbox" type="checkbox" name="overview-disabled[]" id="overview-disabled" value="overview-disabled" disabled>
     <label class="ods-checkbox--label" for="overview-disabled">Enable auto-docking</label>
+    <input class="ods-checkbox" type="checkbox" name="overview-disabled[]" id="overview-disabled-invalid-checked" value="overview-disabled" checked disabled data-invalid>
+    <label class="ods-checkbox--label" for="overview-disabled-invalid-checked">Enable auto-docking</label>
+    <input class="ods-checkbox" type="checkbox" name="overview-disabled[]" id="overview-disabled-invalid" value="overview-disabled" disabled data-invalid>
+    <label class="ods-checkbox--label" for="overview-disabled-invalid">Enable auto-docking</label>
   </fieldset>
 </Visual>
 
@@ -315,8 +321,10 @@ export default {
       <label class="ods-checkbox--label" for="example-2-1">Label 1</label>
       <input class="ods-checkbox" type="checkbox" name="example-2" id="example-2-2" value="value-2" disabled>
       <label class="ods-checkbox--label" for="example-2-2">Label 2</label>
-      <input class="ods-checkbox" type="checkbox" name="example-2" id="example-2-3" value="value-3" disabled>
+      <input class="ods-checkbox" type="checkbox" name="example-2" id="example-2-3" value="value-3" checked disabled data-invalid>
       <label class="ods-checkbox--label" for="example-2-3">Label 3</label>
+      <input class="ods-checkbox" type="checkbox" name="example-2" id="example-2-4" value="value-4" disabled data-invalid>
+      <label class="ods-checkbox--label" for="example-2-4">Label 4</label>
     </fieldset>
   </div>
 

--- a/packages/odyssey/src/scss/components/_checkbox.scss
+++ b/packages/odyssey/src/scss/components/_checkbox.scss
@@ -36,6 +36,17 @@
     }
   }
 
+  &:not(:checked) {
+    + .ods-checkbox--label {
+      &:hover,
+      &.is-ods-checkbox-hover {
+        &::before {
+          border-color: $color-primary-base;
+        }
+      }
+    }
+  }
+
   &:indeterminate,
   &.is-ods-checkbox-indeterminate {
     + .ods-checkbox--label {
@@ -58,7 +69,8 @@
   }
 
   &:disabled {
-    + .ods-checkbox--label {
+    + .ods-checkbox--label,
+    + .ods-checkbox--label:hover {
       color: $text-body;
       cursor: not-allowed;
 
@@ -115,9 +127,14 @@
       }
     }
 
-    &:hover:not(:checked) {
-      + .ods-checkbox--label::before {
-        border-color: $color-danger-dark;
+    &:not(:checked) {
+      + .ods-checkbox--label {
+        &:hover,
+        &.is-ods-checkbox-hover {
+          &::before {
+            border-color: $color-danger-dark;
+          }
+        }
       }
     }
 
@@ -136,7 +153,7 @@
         color: $text-danger;
 
         &::before {
-          background-color: $color-danger-light;
+          border-color: $color-danger-light;
         }
 
         &::after {
@@ -144,7 +161,16 @@
         }
       }
 
+      &:checked {
+        + .ods-checkbox--label {
+          &::before {
+            background-color: $color-danger-light;
+          }
+        }
+      }
+
       &:checked,
+      &:not(:checked),
       &:indeterminate {
         + .ods-checkbox--label {
           &::before {
@@ -201,12 +227,5 @@
     background-image: get-icon('check', transparent);
     background-repeat: no-repeat;
     background-position: center;
-  }
-
-  &:hover,
-  &.is-ods-checkbox-hover {
-    &::before {
-      border-color: $color-primary-base;
-    }
   }
 }


### PR DESCRIPTION
Fixes incorrect display and `:hover` state of checked, disabled checkboxes. Adds example to HTML/CSS docs.

# Before

<img width="248" alt="Screen Shot 2021-04-26 at 12 50 31 PM" src="https://user-images.githubusercontent.com/36284167/116596167-f1ea5280-a8d8-11eb-94b0-99c5ffa484ff.png">

# After

<img width="941" alt="Screen Shot 2021-04-29 at 10 49 42 AM" src="https://user-images.githubusercontent.com/36284167/116596214-fdd61480-a8d8-11eb-85a6-7c46a31bfc25.png">

Preview: https://05774fe.ods.dev/components/checkbox/
