### PR TITLE
update focus state for dismiss button

### DIFF
--- a/packages/odyssey/src/scss/components/_button.scss
+++ b/packages/odyssey/src/scss/components/_button.scss
@@ -137,7 +137,7 @@
 
   &:focus,
   &.is-ods-button-focus {
-    outline: 0;
+    box-shadow: 0 0 0 2px;
     background-color: transparentize($white, 0.6);
   }
 

--- a/packages/odyssey/src/scss/components/_button.scss
+++ b/packages/odyssey/src/scss/components/_button.scss
@@ -137,8 +137,8 @@
 
   &:focus,
   &.is-ods-button-focus {
-    box-shadow: 0 0 0 2px;
     background-color: transparentize($white, 0.6);
+    box-shadow: 0 0 0 2px;
   }
 
   &:disabled {


### PR DESCRIPTION
This updates our Dismiss button to have an a11y compliant focus state. Examples below.

For the focus state, we leave off any color declarations, which allows the `box-shadow` to pick up the `color` in use.

```box-shadow: 0 0 0 2px;```

This allows for the Dismiss button to be used in multiple light/dark color contexts without the need for an additional variant.

NB: this change only changes our `:focus` state; `:hover` will behave as before without a focus ring.

Preview here: https://75d17a3.ods.dev/components/button/

<img width="530" alt="Screen Shot 2021-05-03 at 3 41 55 PM" src="https://user-images.githubusercontent.com/36284167/116942548-a6141200-ac26-11eb-8645-4f9ae0b449a8.png">
<img width="866" alt="Screen Shot 2021-05-03 at 3 41 46 PM" src="https://user-images.githubusercontent.com/36284167/116942550-a6aca880-ac26-11eb-9c73-441833a7ef39.png">
<img width="351" alt="Screen Shot 2021-05-03 at 3 41 20 PM" src="https://user-images.githubusercontent.com/36284167/116942553-a7453f00-ac26-11eb-8933-05781d5eb1fc.png">
<img width="362" alt="Screen Shot 2021-05-03 at 3 41 12 PM" src="https://user-images.githubusercontent.com/36284167/116942554-a7453f00-ac26-11eb-954f-6b0e63b99249.png">
<img width="446" alt="Screen Shot 2021-05-03 at 3 10 38 PM" src="https://user-images.githubusercontent.com/36284167/116942555-a7ddd580-ac26-11eb-8329-503f14964b55.png">
<img width="427" alt="Screen Shot 2021-05-03 at 3 10 34 PM" src="https://user-images.githubusercontent.com/36284167/116942557-a7ddd580-ac26-11eb-86c5-f0a5023a6b76.png">
<img width="199" alt="Screen Shot 2021-05-03 at 3 10 14 PM" src="https://user-images.githubusercontent.com/36284167/116942558-a7ddd580-ac26-11eb-83e4-cbb3558aa595.png">