### PR TITLE
cache node_modules in CI

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,4 +1,5 @@
 name: preview
+
 on:
   pull_request:
     branches:
@@ -20,8 +21,10 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
+
       - name: set $SHA7
         run: echo "SHA7=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.sha }})" >> $GITHUB_ENV
+
       - name: set $PREVIEW_URL
         run: echo "PREVIEW_URL="https://${SHA7}.ods.dev"" >> $GITHUB_ENV
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -31,6 +31,12 @@ jobs:
       - name: get COMMIT_MSG
         run: echo "COMMIT_MSG=$(git log --format=%B -n 1 ${{ github.event.after }})" >> $GITHUB_ENV
 
+      - name: cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+
       - name: install dependencies
         run: yarn install --frozen-lockfile
 


### PR DESCRIPTION
This PR caches `node_modules` directories within our monorepo during CI builds. It uses a content hash of every `yarn.lock` file (currently we have just one at the root) as a key for cache invalidation meaning any time a new dependency is added anywhere within the monorepo the cache is invalidated.

This speeds up our CI builds considerably as the cache weighs in currently at 176 MB and I saw a build speed improvement of roughly 3 minutes 30 seconds when the cache is warm vs cold.