### PR TITLE
Docs: Minor cleanup items from the Typography audit

### DIFF
--- a/packages/docs/base/color.md
+++ b/packages/docs/base/color.md
@@ -3,7 +3,7 @@ template: plain
 id: base-color
 title: Color
 headline: Color
-lead: Odyssey colors consist of a variety of neutral, semantic, and brand values used in all UIs for utmost clarity and readability.
+lede: Odyssey colors consist of a variety of neutral, semantic, and brand values used in all UIs for utmost clarity and readability.
 description: Odyssey colors consist of a variety of neutral, semantic, and brand values used in all UIs for utmost clarity and readability.
 ---
 

--- a/packages/docs/base/elements.md
+++ b/packages/docs/base/elements.md
@@ -4,7 +4,7 @@ id: base-elements
 title: Elements
 headline: Elements
 description: A glossary of standard HTML elements provided by Odyssey.
-lead: A glossary of standard HTML elements provided by Odyssey.
+lede: A glossary of standard HTML elements provided by Odyssey.
 ---
 
 ## abbr <a name="abbr"></a>

--- a/packages/docs/base/index.md
+++ b/packages/docs/base/index.md
@@ -2,5 +2,5 @@
 template: index
 id: base
 title: Base
-lead: Base is the foundation of Odyssey, consisting of Color, Design Tokens, HTML Elements, Iconography and Typography
+lede: Base is the foundation of Odyssey, consisting of Color, Design Tokens, HTML Elements, Iconography and Typography
 ---

--- a/packages/docs/base/tokens.md
+++ b/packages/docs/base/tokens.md
@@ -3,7 +3,7 @@ template: plain
 id: base-tokens
 title: Design Tokens
 headline: Design Tokens
-lead: Design Tokens abstract Base elements into names that are commonly understood. They are then used together to build components.
+lede: Design Tokens abstract Base elements into names that are commonly understood. They are then used together to build components.
 description: Design Tokens abstract Base elements into names that are commonly understood. They are then used together to build components.
 
 ---

--- a/packages/docs/base/typography.md
+++ b/packages/docs/base/typography.md
@@ -6,6 +6,20 @@ headline: Typography
 lead: A set of pre-defined text styles for headers, body copy, & links designed for clarity in readability and hierarchy.
 description: A set of pre-defined text styles for headers, body copy, & links designed for clarity in readability and hierarchy.
 ---
+## Font family
+
+<p> Odyssey offers separate font stacks for UI, copy, and code:
+
+```scss
+$body-font-family: 'Public Sans', 'Noto Sans', 'Whyte', '-apple-system',  'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
+
+$mono-font-family: 'Inconsolata', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+```
+
+</p>
+
+UI and copy both utilize our `$body-font-family`. This stack prioritizes Public Sans. This is followed by Noto Sans to support internationalization, then Whyte for Okta-branded pages. Finally, we utilize a system font-stack to enable device-standard typography when our preferred families aren't available.
+
 ## Hierarchy
 
 <Description>
@@ -14,7 +28,7 @@ Typographical hierarchy indicates importance of content. Through size and weight
 
 </Description>
 
-## Type Styles
+## Type styles
 
 <Description>
 

--- a/packages/docs/base/typography.md
+++ b/packages/docs/base/typography.md
@@ -6,9 +6,10 @@ headline: Typography
 lead: A set of pre-defined text styles for headers, body copy, & links designed for clarity in readability and hierarchy.
 description: A set of pre-defined text styles for headers, body copy, & links designed for clarity in readability and hierarchy.
 ---
+
 ## Font family
 
-<p> Odyssey offers separate font stacks for UI, copy, and code:
+<p>Odyssey offers separate font stacks for UI, copy, and code:
 
 ```scss
 $body-font-family: 'Public Sans', 'Noto Sans', 'Whyte', '-apple-system',  'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
@@ -110,7 +111,7 @@ Titles are used to describe the main idea of a page, a section, or content that 
 
 <Description>
 
-Odyssey ships with a base font of `14px`. However there are times when different sizes are required.
+Odyssey ships with a base font-size of `16px`. However there are times when different sizes are required.
 
 </Description>
 

--- a/packages/docs/base/typography.md
+++ b/packages/docs/base/typography.md
@@ -3,7 +3,7 @@ template: plain
 id: base-type
 title: Typography
 headline: Typography
-lead: A set of pre-defined text styles for headers, body copy, & links designed for clarity in readability and hierarchy.
+lede: A set of pre-defined text styles for headers, body copy, & links designed for clarity in readability and hierarchy.
 description: A set of pre-defined text styles for headers, body copy, & links designed for clarity in readability and hierarchy.
 ---
 
@@ -135,6 +135,12 @@ Odyssey ships with a base font-size of `16px`. However there are times when diff
         </tr>
       </thead>
       <tbody>
+        <tr class="type-sample-body">
+          <td class="type-sample-body--token"><code>$size-body-lede</code></td>
+          <td class="type-sample-body--rem"></td>
+          <td class="type-sample-body--px"></td>
+          <td class="type-sample-body--example">Waltz, bad nymph, for quick jigs vex!</td>
+        </tr>
         <tr class="type-sample-body">
           <td class="type-sample-body--token"><code>$size-body-base</code></td>
           <td class="type-sample-body--rem"></td>

--- a/packages/docs/beta.md
+++ b/packages/docs/beta.md
@@ -2,8 +2,8 @@
 template: plain
 title: Beta
 headline: Beta
-lead: Odyssey is currently in Beta. This can mean different things for different teams, so we’d like to offer some clarity of what it means for the Odyssey Design System.
-description: Odyssey is currently in Beta. This can mean different things for different teams, so we’d like to offer some clarity of what it means for the Odyssey Design System. 
+lede: Odyssey is currently in Beta. This can mean different things for different teams, so we’d like to offer some clarity of what it means for the Odyssey Design System.
+description: Odyssey is currently in Beta. This can mean different things for different teams, so we’d like to offer some clarity of what it means for the Odyssey Design System.
 ---
 
 ## What does this mean?
@@ -12,7 +12,7 @@ description: Odyssey is currently in Beta. This can mean different things for di
 
 Designers - the UI Kit and guidelines you are presented with today have been vetted by our team. You should feel safe using them to design features as long as you are comfortable with change. Radical changes may occur, but they will not be implemented without consideration and communication.
 
-Engineers - the @okta/odyssey package will see major changes between now and 1.0. These resources we deliver are ready for early adopters, but breaking changes should be expected. An estimated 1.0 release date is still TBD. 
+Engineers - the @okta/odyssey package will see major changes between now and 1.0. These resources we deliver are ready for early adopters, but breaking changes should be expected. An estimated 1.0 release date is still TBD.
 
 </Description>
 
@@ -21,7 +21,7 @@ Engineers - the @okta/odyssey package will see major changes between now and 1.0
 <Description>
 
 There are two main reasons we regard Odyssey as a product in Beta.
-1. Odyssey has not been tested, end-to-end, on enough platforms. We like to believe our UI is strong enough to support the needs of Okta and our customers, but that belief has not been validated. Indeed, there are known gaps! In this way, the Beta flag is an acknowledgement that we know your needs may not be met yet but we are working hard to get there. 
+1. Odyssey has not been tested, end-to-end, on enough platforms. We like to believe our UI is strong enough to support the needs of Okta and our customers, but that belief has not been validated. Indeed, there are known gaps! In this way, the Beta flag is an acknowledgement that we know your needs may not be met yet but we are working hard to get there.
 2. Our foundations are still emerging. Whether it’s visual foundations or technical architecture, the most basic structures of the system are being actively tested and rewritten. You should always expect improvement from Odyssey. Beta is a period where most improvements may introduce breaking changes.
 
 </Description>

--- a/packages/docs/components/banner.md
+++ b/packages/docs/components/banner.md
@@ -3,7 +3,7 @@ template: component
 id: component-banner
 title: Banner
 description: Banners let users know important messages related to their overall experience on the website.
-lead: Banners let users know important messages related to their overall experience on the website. They can be purely informational messages or critical errors to act upon.
+lede: Banners let users know important messages related to their overall experience on the website. They can be purely informational messages or critical errors to act upon.
 tabs:
   - label: 'Overview'
     id: 'overview'

--- a/packages/docs/components/button.md
+++ b/packages/docs/components/button.md
@@ -256,13 +256,17 @@ Don't use buttons to navigate users around the site or product; use links instea
 
 ## Content Guidelines
 
-### Punctuation and copy
+<Description>
 
-#### Context
+Consider the following when writing content for buttons. By doing so, it will ensure users can easily navigate the page and complete the task at hand efficiently.
+
+</Description>
+
+### Context
 
 <Description>
 
-Be as direct as possible with the goal you are trying to get the user to do. Avoid patterns that need the user to discover what a button does.
+Provide enough context to ensure the user is aware what the interaction will achieve. Avoid patterns that require the user to discover what a button does.
 
 </Description>
 
@@ -288,7 +292,7 @@ Be strategic in your button placement so a user has the best context. For exampl
   </template>
 </Visual>
 
-#### Word count
+### Word count
 
 <Description>
 
@@ -312,7 +316,7 @@ Don't use more than three words inside of a button. If a user needs more context
   </template>
 </Visual>
 
-#### Capitalization
+### Capitalization
 
 <Description>
 

--- a/packages/docs/components/button.md
+++ b/packages/docs/components/button.md
@@ -3,7 +3,7 @@ template: component
 id: component-button
 title: Button
 description: Buttons are used for in-page interactions like form submissions.
-lead: A clickable button used for form submissions and most in-page interactions.
+lede: A clickable button used for form submissions and most in-page interactions.
 tabs:
   - label: 'Overview'
     id: 'overview'

--- a/packages/docs/components/checkbox.md
+++ b/packages/docs/components/checkbox.md
@@ -3,7 +3,7 @@ template: component
 id: component-checkbox
 title: Checkbox
 description: Checkboxes appear as a square shaped UI accompanied by a caption.
-lead: Checkboxes appear as a square shaped UI accompanied by a caption. Checkboxes can be found in tables, forms, or in and around text inputs.
+lede: Checkboxes appear as a square shaped UI accompanied by a caption. Checkboxes can be found in tables, forms, or in and around text inputs.
 tabs:
   - label: 'Overview'
     id: 'overview'

--- a/packages/docs/components/field-labels.md
+++ b/packages/docs/components/field-labels.md
@@ -3,7 +3,7 @@ template: component
 id: component-field-labels
 title: Field Labels
 description: These captions help make forms more accessible.
-lead: These captions help make forms more accessible by providing context to the user. They can be used with all Odyssey inputs.
+lede: These captions help make forms more accessible by providing context to the user. They can be used with all Odyssey inputs.
 tabs:
   - label: 'Overview'
     id: 'overview'

--- a/packages/docs/components/index.md
+++ b/packages/docs/components/index.md
@@ -2,5 +2,5 @@
 template: index
 id: components
 title: Components
-lead: Components are commonly found, pre-assembled UI Objects built from Odyssey's Base and organized by form and function.
+lede: Components are commonly found, pre-assembled UI Objects built from Odyssey's Base and organized by form and function.
 ---

--- a/packages/docs/components/infobox.md
+++ b/packages/docs/components/infobox.md
@@ -3,7 +3,7 @@ template: component
 id: component-infobox
 title: Infobox
 description: An infobox is a type of alert that provides feedback in response to a user action or system activity.
-lead: An infobox is a type of alert that provides feedback in response to a user action or system activity.
+lede: An infobox is a type of alert that provides feedback in response to a user action or system activity.
 tabs:
   - label: 'Overview'
     id: 'overview'

--- a/packages/docs/components/link.md
+++ b/packages/docs/components/link.md
@@ -3,7 +3,7 @@ template: component
 id: component-link
 title: Link
 description: Links are navigation elements displayed as text.
-lead: Links are navigation elements displayed as text. Use a Link to bring a user to another page or start a download.
+lede: Links are navigation elements displayed as text. Use a Link to bring a user to another page or start a download.
 tabs:
   - label: 'Overview'
     id: 'overview'

--- a/packages/docs/components/modal.md
+++ b/packages/docs/components/modal.md
@@ -2,7 +2,7 @@
 template: component
 id: component-modal
 description: UI that appears on top of the main content and moves the system into a mode requiring user interaction.
-lead: UI that appears on top of the main content and moves the system into a mode requiring user interaction. This dialog disables the main content until the user interacts with the modal dialog.
+lede: UI that appears on top of the main content and moves the system into a mode requiring user interaction. This dialog disables the main content until the user interacts with the modal dialog.
 title: Modal
 tabs:
   - label: 'Overview'

--- a/packages/docs/components/radio-button.md
+++ b/packages/docs/components/radio-button.md
@@ -3,7 +3,7 @@ template: component
 id: component-radio-button
 title: Radio Button
 description: Radios appear as a ring shaped UI accompanied by a caption that allows the user to choose only one option at a time.
-lead: Radios appear as a ring shaped UI accompanied by a caption that allows the user to choose only one option at a time.
+lede: Radios appear as a ring shaped UI accompanied by a caption that allows the user to choose only one option at a time.
 tabs:
   - label: 'Overview'
     id: 'overview'

--- a/packages/docs/components/select.md
+++ b/packages/docs/components/select.md
@@ -3,7 +3,7 @@ template: component
 id: component-select
 title: Select
 description: Often referred to as a “dropdown menu” this input triggers a menu of options a user can select.
-lead: Often referred to as a “dropdown menu” this input triggers a menu of options a user can select. Country and state Selects are common examples.
+lede: Often referred to as a “dropdown menu” this input triggers a menu of options a user can select. Country and state Selects are common examples.
 tabs:
   - label: 'Overview'
     id: 'overview'

--- a/packages/docs/components/status.md
+++ b/packages/docs/components/status.md
@@ -3,7 +3,7 @@ template: component
 id: component-status
 title: Status
 description: Status is used to inform users by providing feedback on system states.
-lead: Status is used to inform users by providing feedback on system states. Status can display broad operational states as well as granular states like user status.
+lede: Status is used to inform users by providing feedback on system states. Status can display broad operational states as well as granular states like user status.
 tabs:
   - label: 'Overview'
     id: 'overview'

--- a/packages/docs/components/tab.md
+++ b/packages/docs/components/tab.md
@@ -3,7 +3,7 @@ template: component
 id: component-tab
 title: Tab
 description: Tabs are a navigational component used to organize content by grouping similar information on the same page.
-lead: Navigation component used to organize content by grouping similar information on the same page. They allow content to be viewed without having to navigate away from that page or route.
+lede: Navigation component used to organize content by grouping similar information on the same page. They allow content to be viewed without having to navigate away from that page or route.
 tabs:
   - label: 'Overview'
     id: 'overview'

--- a/packages/docs/components/table.md
+++ b/packages/docs/components/table.md
@@ -3,7 +3,7 @@ template: component
 id: component-table
 title: Table
 description: Tables provide structure for displaying sets of data across rows and columns.
-lead: Tables provide structure for displaying sets of data across rows and columns. They support multiple content types and some internal actions.
+lede: Tables provide structure for displaying sets of data across rows and columns. They support multiple content types and some internal actions.
 tabs:
   - label: 'Overview'
     id: 'overview'

--- a/packages/docs/components/tag.md
+++ b/packages/docs/components/tag.md
@@ -3,7 +3,7 @@ template: component
 id: component-tag
 title: Tag
 description: Tags are used to help describe and differentiate an entity or object.
-lead: Use Tags to help describe and differentiate an entity or object. Think of them as “adjectives” in your UI toolbox that make navigating  and parsing content easier.
+lede: Use Tags to help describe and differentiate an entity or object. Think of them as “adjectives” in your UI toolbox that make navigating  and parsing content easier.
 tabs:
   - label: 'Overview'
     id: 'overview'

--- a/packages/docs/components/text-input.md
+++ b/packages/docs/components/text-input.md
@@ -3,7 +3,7 @@ template: component
 id: component-text-input
 title: Text Input
 description: Text inputs allow users to edit and input data.
-lead: Text inputs allow users to edit and input data. They can range from simple search boxes to long-form text areas.
+lede: Text inputs allow users to edit and input data. They can range from simple search boxes to long-form text areas.
 tabs:
   - label: 'Overview'
     id: 'overview'

--- a/packages/docs/components/toast.md
+++ b/packages/docs/components/toast.md
@@ -2,7 +2,7 @@
 template: component
 id: component-toast
 title: Toast
-lead: Toasts are transient, non-disruptive messages that provide at-a-glance, asynchronous feedback or updates.
+lede: Toasts are transient, non-disruptive messages that provide at-a-glance, asynchronous feedback or updates.
 description: Toasts are transient bits of messaging that provide quick, at-a-glance feedback.
 tabs:
   - label: 'Overview'

--- a/packages/docs/components/tooltip.md
+++ b/packages/docs/components/tooltip.md
@@ -3,7 +3,7 @@ template: component
 id: component-tooltip
 title: Tooltip
 description: A contextual pop-up that provides a label for or description of an element.
-lead: A transient element that provides additional context for an element when it receives hover or focus.
+lede: A transient element that provides additional context for an element when it receives hover or focus.
 tabs:
   - label: 'Overview'
     id: 'overview'

--- a/packages/docs/help.md
+++ b/packages/docs/help.md
@@ -2,7 +2,7 @@
 template: plain
 title: Help
 headline: Need Help?
-lead: The Odyssey team is here to help as best we can. Don't hesitate to reach out!
+lede: The Odyssey team is here to help as best we can. Don't hesitate to reach out!
 description: The Odyssey team is here to help as best we can. Don't hesitate to reach out!
 ---
 

--- a/packages/docs/icons.md
+++ b/packages/docs/icons.md
@@ -4,7 +4,7 @@ template: plain
 pageHeaderVariant: icon
 title: Icons
 headline: Icons
-lead: A system of icons which establishes a visual language that can be easily understood regardless of age, language or culture.
+lede: A system of icons which establishes a visual language that can be easily understood regardless of age, language or culture.
 tabs:
   - label: 'Overview'
     id: 'overview'

--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -1,7 +1,7 @@
 ---
 template: home
 headline: Odyssey Design System
-lead: Build and design consistent, efficient, and accessible UIs for all Okta users.
+lede: Build and design consistent, efficient, and accessible UIs for all Okta users.
 contentPrimary:
   - coin: base
     title: Base

--- a/packages/docs/principles.md
+++ b/packages/docs/principles.md
@@ -1,8 +1,8 @@
 ---
 template: plain
-title: Principles 
-headline: Principles 
-lead: Okta's design principles are Odyssey's north star. They guide us in making critical decisions as a team.
+title: Principles
+headline: Principles
+lede: Okta's design principles are Odyssey's north star. They guide us in making critical decisions as a team.
 ---
 
 <Description>

--- a/packages/docs/type-test.md
+++ b/packages/docs/type-test.md
@@ -3,7 +3,7 @@ template: plain
 id: base-type
 title: Type Test
 headline: Projoesal w relative margins
-lead:
+lede:
 description:
 ---
 

--- a/packages/docs/updates/2020-10-02.md
+++ b/packages/docs/updates/2020-10-02.md
@@ -2,7 +2,7 @@
 template: plain
 title: October 2, 2020
 headline: October 2, 2020
-lead: New Components, Icons, Color and Previews! 
+lede: New Components, Icons, Color and Previews!
 ---
 
 ## :art: Base

--- a/packages/docs/updates/index.md
+++ b/packages/docs/updates/index.md
@@ -2,7 +2,7 @@
 template: plain
 title: Odyssey Updates
 headline: Updates
-lead: Here is a list of all our most recent updates. These can vary from component changes to team updates and contributions.
+lede: Here is a list of all our most recent updates. These can vary from component changes to team updates and contributions.
 description: Here is a list of all our most recent updates. These can vary from component changes to team updates and contributions.
 links:
   - icon: github

--- a/packages/odyssey/src/scss/abstracts/_tokens.scss
+++ b/packages/odyssey/src/scss/abstracts/_tokens.scss
@@ -29,6 +29,7 @@ $size-title-4: ms(2);
 $size-title-5: ms(1);
 $size-title-6: ms(0);
 
+$size-body-lede: ms(1);
 $size-body-base: ms(0);
 $size-body-caption: ms(-1);
 

--- a/packages/vuepress-theme-odyssey/components/DocsPageHeader.vue
+++ b/packages/vuepress-theme-odyssey/components/DocsPageHeader.vue
@@ -6,7 +6,7 @@
     }"
   >
     <h1 class="docs-page-header--title">{{ title }}</h1>
-    <p v-if="lead" class="docs-page-header--lead">{{ lead }}</p>
+    <p v-if="lede" class="docs-page-header--lede">{{ lede }}</p>
     <slot name="right"></slot>
   </header>
 </template>
@@ -19,7 +19,7 @@ export default {
       type: String,
       default: "default"
     },
-    lead: {
+    lede: {
       type: String,
       required: false,
       default: null

--- a/packages/vuepress-theme-odyssey/styles/components/_DocsPageHeader.scss
+++ b/packages/vuepress-theme-odyssey/styles/components/_DocsPageHeader.scss
@@ -23,13 +23,13 @@
     display: block;
   }
 
-  .docs-page-header--lead {
+  .docs-page-header--lede {
     grid-column: 1 / 2;
     margin: 0;
-    font-size: $size-title-4;
+    font-size: $size-body-lede;
 
     @include mq(l) {
-      font-size: $size-title-5;
+      font-size: $size-body-lede;
     }
   }
 

--- a/packages/vuepress-theme-odyssey/styles/docskit/_Description.scss
+++ b/packages/vuepress-theme-odyssey/styles/docskit/_Description.scss
@@ -23,18 +23,23 @@
 
   &.is-docskit-desc-counter {
     display: grid;
+    grid-auto-flow: column;
     grid-column: 1 / 3;
-    //grid-gap: $spacing-l $spacing-m;
-    grid-gap: 0 $spacing-m;
-    // Grid template math to achieve min size:
-    // max width ($max-line-length * 2)
-    // less grid-gap (2 x $spacing-m)
-    // divided by desired count (3)
-    grid-template-columns: repeat(auto-fill, minmax(calc(((#{$max-line-length} * 2) - (#{$spacing-m} * 2) ) / 3), 1fr));
+    grid-gap: $spacing-m;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(2, auto);
     list-style-position: inside;
     list-style-type: decimal;
 
+    @include mq(m) {
+      display: block;
+    }
+
     .desc-counter--item {
+      @include mq(m) {
+        margin-bottom: $spacing-m;
+      }
+
       &::marker {
         color: $text-heading;
         font-family: $body-font-family;

--- a/packages/vuepress-theme-odyssey/styles/index.scss
+++ b/packages/vuepress-theme-odyssey/styles/index.scss
@@ -323,9 +323,9 @@ $spacing-units: (
   }
 }
 
-@for $i from 3 through 1 {
+@for $i from 4 through 1 {
   $x: $i - 2;
-  $n: 3 - $i;
+  $n: 4 - $i;
 
   .type-sample-body:nth-of-type(#{$n}) {
     .type-sample-body--rem {

--- a/packages/vuepress-theme-odyssey/templates/DocsTemplateComponent.vue
+++ b/packages/vuepress-theme-odyssey/templates/DocsTemplateComponent.vue
@@ -2,7 +2,7 @@
   <article class="docs-main--content">
     <DocsPageHeader
       :title="$page.frontmatter.title"
-      :lead="$page.frontmatter.lead"
+      :lede="$page.frontmatter.lede"
     >
       <template v-slot:right>
         <ul v-if="$page.frontmatter.links" class="docs-page-header--links">

--- a/packages/vuepress-theme-odyssey/templates/DocsTemplateHome.vue
+++ b/packages/vuepress-theme-odyssey/templates/DocsTemplateHome.vue
@@ -4,7 +4,7 @@
     <header class="docs-hero">
       <div class="docs-hero--content">
         <h1 class="docs-hero--title">{{ $page.frontmatter.headline }}</h1>
-        <p class="docs-hero--desc">{{ $page.frontmatter.lead }}</p>
+        <p class="docs-hero--desc">{{ $page.frontmatter.lede }}</p>
       </div>
       <!-- eslint-disable vue/no-v-html -->
       <div

--- a/packages/vuepress-theme-odyssey/templates/DocsTemplateIndex.vue
+++ b/packages/vuepress-theme-odyssey/templates/DocsTemplateIndex.vue
@@ -2,7 +2,7 @@
   <article class="docs-index">
     <DocsPageHeader
       :title="$page.frontmatter.title"
-      :lead="$page.frontmatter.lead"
+      :lede="$page.frontmatter.lede"
       :variant="$page.frontmatter.id"
     />
     <DocsCardGroup

--- a/packages/vuepress-theme-odyssey/templates/DocsTemplatePlain.vue
+++ b/packages/vuepress-theme-odyssey/templates/DocsTemplatePlain.vue
@@ -3,7 +3,7 @@
     <DocsPageHeader
       :variant="$page.frontmatter.pageHeaderVariant || 'default'"
       :title="$page.frontmatter.headline"
-      :lead="$page.frontmatter.lead"
+      :lede="$page.frontmatter.lede"
     />
 
     <hr />


### PR DESCRIPTION
Adds missing docs around `font-family`:

<img width="1420" alt="Screen Shot 2021-05-17 at 12 26 24 PM" src="https://user-images.githubusercontent.com/36284167/118545311-45e39c80-b70b-11eb-904e-27366dd83e43.png">

Adjusts Button headings to meet our guidelines for use:

<img width="1172" alt="Screen Shot 2021-05-20 at 11 08 50 AM" src="https://user-images.githubusercontent.com/36284167/119027987-cc8eb880-b95b-11eb-89ae-4f7cd8ef8db3.png">

Standardizes lede styling:

<img width="713" alt="Screen Shot 2021-05-20 at 11 30 27 AM" src="https://user-images.githubusercontent.com/36284167/119031440-f518b180-b95f-11eb-84e7-ffd723c0a144.png">

<img width="599" alt="Screen Shot 2021-05-20 at 11 38 42 AM" src="https://user-images.githubusercontent.com/36284167/119031450-f6e27500-b95f-11eb-940b-083005e95926.png">

Docs Kit "counter" items should flow vertically:

<img width="1096" alt="Screen Shot 2021-05-20 at 12 14 44 PM" src="https://user-images.githubusercontent.com/36284167/119036027-234cc000-b965-11eb-8408-8b33ebec9482.png">

<img width="431" alt="Screen Shot 2021-05-20 at 12 14 31 PM" src="https://user-images.githubusercontent.com/36284167/119036046-2778dd80-b965-11eb-84be-c21ed4c425a9.png">
