### PR TITLE
chore: add stale workflow, rename preview workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,5 +1,4 @@
-name: 'Preview Deployment'
-
+name: Preview Deployment
 on:
   pull_request:
     branches:
@@ -7,7 +6,7 @@ on:
       - develop
       - "release/**"
 jobs:
-  deployment:
+  docs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -15,7 +14,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: cofigure aws
+      - name: Cofigure AWS
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -28,28 +27,28 @@ jobs:
       - name: set $PREVIEW_URL
         run: echo "PREVIEW_URL="https://${SHA7}.ods.dev"" >> $GITHUB_ENV
 
-      - name: get COMMIT_MSG
+      - name: get $COMMIT_MSG
         run: echo "COMMIT_MSG=$(git log --format=%B -n 1 ${{ github.event.after }})" >> $GITHUB_ENV
 
-      - name: cache dependencies
+      - name: Cache dependencies
         uses: actions/cache@v2
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
-      - name: install dependencies
+      - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: lint
+      - name: Run lint
         run: yarn lint
 
-      - name: test
+      - name: Run test
         run: yarn test
 
-      - name: build docs
+      - name: Build docs
         run: yarn workspace @okta/design-docs build
 
-      - name: 'deploy: create'
+      - name: Create GitHub deployment
         uses: bobheadxi/deployments@v0.4.2
         id: deployment
         with:
@@ -58,11 +57,11 @@ jobs:
           env: preview
           ref: ${{ github.head_ref }}
 
-      - name: 'deploy: 🚀 start'
+      - name: Deploy to S3
         run: |
           aws s3 sync ./packages/docs/dist/ s3://ods.dev/$SHA7 --delete
 
-      - name: 'deploy: update status'
+      - name: Update GitHub deployment status
         uses: bobheadxi/deployments@v0.4.2
         if: always()
         with:
@@ -72,7 +71,7 @@ jobs:
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           env_url: ${{ env.PREVIEW_URL }}
 
-      - name: 'notify: slack'
+      - name: 'Send workflow status to Slack (#odyssey-deployments)'
         run: sh ./scripts/notify-slack.sh
         env:
           INCOMING_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/preview-deployment.yml
+++ b/.github/workflows/preview-deployment.yml
@@ -1,4 +1,4 @@
-name: preview
+name: 'Preview Deployment'
 
 on:
   pull_request:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,11 +10,11 @@ jobs:
       - uses: actions/stale@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-issue-message: ':robot: This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           days-before-issue-stale: 30
-          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          stale-pr-message: ':robot: This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           days-before-pr-stale: 45
-          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          close-issue-message: ':robot: This issue was closed because it has been stalled for 5 days with no activity.'
           days-before-issue-close: 5
-          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+          close-pr-message: ':robot: This PR was closed because it has been stalled for 10 days with no activity.'
           days-before-pr-close: 10

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          days-before-issue-stale: 30
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          days-before-pr-stale: 45
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          days-before-issue-close: 5
+          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+          days-before-pr-close: 10


### PR DESCRIPTION
Adds a stale workflow that uses [actions/stale](https://github.com/actions/stale) to mark and close stale issues and PRs after a predetermined amount of time.

The current time before stale and closed are totally arbitrary and copied from the demo at the link above. They seemed sensible to me, but if anyone has specific thoughts on what these values should be, drop them in the comments.