### PR TITLE
Refactor: remove data-attrs in favor of :invalid or class

### DIFF
--- a/packages/docs/components/checkbox.md
+++ b/packages/docs/components/checkbox.md
@@ -132,9 +132,9 @@ Checkboxes are disabled individually. The values of disabled inputs will not be 
     <label class="ods-checkbox--label" for="overview-disabled-checked">Enable auto-docking</label>
     <input class="ods-checkbox" type="checkbox" name="overview-disabled[]" id="overview-disabled" value="overview-disabled" disabled>
     <label class="ods-checkbox--label" for="overview-disabled">Enable auto-docking</label>
-    <input class="ods-checkbox" type="checkbox" name="overview-disabled[]" id="overview-disabled-invalid-checked" value="overview-disabled" checked disabled data-invalid>
+    <input class="ods-checkbox is-ods-checkbox-invalid" type="checkbox" name="overview-disabled[]" id="overview-disabled-invalid-checked" value="overview-disabled" checked disabled>
     <label class="ods-checkbox--label" for="overview-disabled-invalid-checked">Enable auto-docking</label>
-    <input class="ods-checkbox" type="checkbox" name="overview-disabled[]" id="overview-disabled-invalid" value="overview-disabled" disabled data-invalid>
+    <input class="ods-checkbox is-ods-checkbox-invalid" type="checkbox" name="overview-disabled[]" id="overview-disabled-invalid" value="overview-disabled" disabled>
     <label class="ods-checkbox--label" for="overview-disabled-invalid">Enable auto-docking</label>
   </fieldset>
 </Visual>
@@ -158,7 +158,7 @@ Unlike Radio Buttons, Checkboxes validate individually, not as a group.
     <label class="ods-checkbox--label" for="overview-invalid-1">Cycle airlock</label>
     <input checked class="ods-checkbox" type="checkbox" name="overview-invalid[]" id="overview-invalid-2" value="overview-invalid-2">
     <label class="ods-checkbox--label" for="overview-invalid-2">Disengage maglock</label>
-    <input class="ods-checkbox" type="checkbox" name="overview-invalid[]" id="overview-invalid-3" value="overview-invalid-3" aria-describedby="overview-invalid-3-error" data-invalid checked>
+    <input class="ods-checkbox is-ods-checkbox-invalid" type="checkbox" name="overview-invalid[]" id="overview-invalid-3" value="overview-invalid-3" aria-describedby="overview-invalid-3-error" checked>
     <label class="ods-checkbox--label" for="overview-invalid-3">Open the pod bay doors</label>
     <aside class="ods-field--error" id="overview-invalid-3-error">
       <span class="u-visually-hidden">Error:</span> I'm afraid I can't do that, Dave.
@@ -321,9 +321,9 @@ export default {
       <label class="ods-checkbox--label" for="example-2-1">Label 1</label>
       <input class="ods-checkbox" type="checkbox" name="example-2" id="example-2-2" value="value-2" disabled>
       <label class="ods-checkbox--label" for="example-2-2">Label 2</label>
-      <input class="ods-checkbox" type="checkbox" name="example-2" id="example-2-3" value="value-3" checked disabled data-invalid>
+      <input class="ods-checkbox is-ods-checkbox-invalid" type="checkbox" name="example-2" id="example-2-3" value="value-3" checked disabled>
       <label class="ods-checkbox--label" for="example-2-3">Label 3</label>
-      <input class="ods-checkbox" type="checkbox" name="example-2" id="example-2-4" value="value-4" disabled data-invalid>
+      <input class="ods-checkbox is-ods-checkbox-invalid" type="checkbox" name="example-2" id="example-2-4" value="value-4" disabled>
       <label class="ods-checkbox--label" for="example-2-4">Label 4</label>
     </fieldset>
   </div>
@@ -335,8 +335,10 @@ export default {
     <label class="ods-checkbox--label" for="example-2-1">Label 1</label>
     <input class="ods-checkbox" type="checkbox" name="example-2" id="example-2-2" value="value-2" disabled>
     <label class="ods-checkbox--label" for="example-2-2">Label 2</label>
-    <input class="ods-checkbox" type="checkbox" name="example-2" id="example-2-3" value="value-3" disabled>
+    <input class="ods-checkbox is-ods-checkbox-invalid" type="checkbox" name="example-2" id="example-2-3" value="value-3" checked disabled>
     <label class="ods-checkbox--label" for="example-2-3">Label 3</label>
+    <input class="ods-checkbox is-ods-checkbox-invalid" type="checkbox" name="example-2" id="example-2-4" value="value-4" disabled>
+    <label class="ods-checkbox--label" for="example-2-4">Label 4</label>
   </fieldset>
   ```
 </figure>
@@ -347,11 +349,11 @@ export default {
   <div class="docs-example--rendered">
     <fieldset class="ods-fieldset">
       <legend class="ods-input-legend">Field legend label</legend>
-      <input class="ods-checkbox" type="checkbox" name="example-3" id="example-3-1" value="value-1" checked data-invalid>
+      <input class="ods-checkbox is-ods-checkbox-valid" type="checkbox" name="example-3" id="example-3-1" value="value-1" checked>
       <label class="ods-checkbox--label" for="example-3-1">Label 1</label>
-      <input class="ods-checkbox" type="checkbox" name="example-3" id="example-3-2" value="value-2" data-invalid>
+      <input class="ods-checkbox is-ods-checkbox-invalid" type="checkbox" name="example-3" id="example-3-2" value="value-2">
       <label class="ods-checkbox--label" for="example-3-2">Label 2</label>
-      <input class="ods-checkbox" type="checkbox" name="example-3" id="example-3-3" value="value-3" data-invalid>
+      <input class="ods-checkbox is-ods-checkbox-invalid" type="checkbox" name="example-3" id="example-3-3" value="value-3">
       <label class="ods-checkbox--label" for="example-3-3">Label 3</label>
       <aside class="ods-field--error" id="checkbox-invalid-error">Invalid error description</aside>
     </fieldset>
@@ -360,11 +362,11 @@ export default {
   ```html
   <fieldset class="ods-fieldset">
     <legend class="ods-input-legend">Field legend label</legend>
-    <input class="ods-checkbox" type="checkbox" name="example-3" id="example-3-1" value="value-1" checked data-invalid>
+    <input class="ods-checkbox is-ods-checkbox-valid" type="checkbox" name="example-3" id="example-3-1" value="value-1" checked>
     <label class="ods-checkbox--label" for="example-3-1">Label 1</label>
-    <input class="ods-checkbox" type="checkbox" name="example-3" id="example-3-2" value="value-2" data-invalid>
+    <input class="ods-checkbox is-ods-checkbox-invalid" type="checkbox" name="example-3" id="example-3-2" value="value-2">
     <label class="ods-checkbox--label" for="example-3-2">Label 2</label>
-    <input class="ods-checkbox" type="checkbox" name="example-3" id="example-3-3" value="value-3" data-invalid>
+    <input class="ods-checkbox is-ods-checkbox-invalid" type="checkbox" name="example-3" id="example-3-3" value="value-3">
     <label class="ods-checkbox--label" for="example-3-3">Label 3</label>
     <aside class="ods-field--error" id="checkbox-invalid-error">Invalid error description</aside>
   </fieldset>

--- a/packages/docs/components/field-labels.md
+++ b/packages/docs/components/field-labels.md
@@ -45,7 +45,7 @@ Keep labels to a word or two so users can quickly scan the form. Always use sent
   <form>
     <fieldset class="ods-fieldset">
       <div class="ods-fieldset-flex">
-        <input class="ods-text-input" type="text" id="overview-label" required>
+        <input class="ods-text-input" type="text" id="overview-label">
         <label class="ods-label" for="overview-label">Destination</label>
       </div>
     </fieldset>
@@ -89,7 +89,7 @@ If possible, describe how the error may be resolved.
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <input class="ods-checkbox" type="checkbox" name="overview-error" id="overview-error" value="terms-accepted" aria-describedby="checkbox-invalid-error" required data-invalid>
+    <input class="ods-checkbox is-ods-checkbox-invalid" type="checkbox" name="overview-error" id="overview-error" value="terms-accepted" aria-describedby="checkbox-invalid-error" required>
     <label class="ods-checkbox--label" for="overview-error">I understand the risks of space travel.</label>
     <aside class="ods-field--error" id="checkbox-invalid-error">You must acknowledge the dangers before proceeding.</aside>
   </fieldset>
@@ -104,7 +104,7 @@ Odyssey assumes inputs are required by default. Optional labels should be used t
 </Description>
 
 <Visual content="full">
-  <fieldset class="ods-fieldset">
+  <fieldset class="ods-fieldset" data-optional>
     <div class="ods-fieldset-flex">
       <select class="ods-select" data-js-choices id="overview-optional" name="overview-optional">
         <option></option>
@@ -196,11 +196,11 @@ Please refer to individual components for complete documentation. These examples
   <div class="docs-example--rendered">
     <fieldset class="ods-fieldset">
       <legend class="ods-input-legend">Field legend label</legend>
-      <input class="ods-checkbox" type="checkbox" name="example-2" id="example-2-1" value="value-1" checked data-invalid>
+      <input class="ods-checkbox is-ods-checkbox-invalid" type="checkbox" name="example-2" id="example-2-1" value="value-1" checked>
       <label class="ods-checkbox--label" for="example-2-1">Label 1</label>
-      <input class="ods-checkbox" type="checkbox" name="example-2" id="example-2-2" value="value-2" data-invalid>
+      <input class="ods-checkbox is-ods-checkbox-invalid" type="checkbox" name="example-2" id="example-2-2" value="value-2">
       <label class="ods-checkbox--label" for="example-2-2">Label 2</label>
-      <input class="ods-checkbox" type="checkbox" name="example-2" id="example-2-3" value="value-3" data-invalid>
+      <input class="ods-checkbox is-ods-checkbox-invalid" type="checkbox" name="example-2" id="example-2-3" value="value-3">
       <label class="ods-checkbox--label" for="example-2-3">Label 3</label>
       <aside class="ods-field--error" id="checkbox-invalid-error"><span class="u-visually-hidden">Error:</span> Invalid error description</aside>
     </fieldset>
@@ -209,11 +209,11 @@ Please refer to individual components for complete documentation. These examples
   ```html
   <fieldset class="ods-fieldset">
     <legend class="ods-input-legend">Field legend label</legend>
-    <input class="ods-checkbox" type="checkbox" name="example-2" id="example-2-1" value="value-1" checked data-invalid>
+    <input class="ods-checkbox is-ods-checkbox-invalid" type="checkbox" name="example-2" id="example-2-1" value="value-1" checked>
     <label class="ods-checkbox--label" for="example-2-1">Label 1</label>
-    <input class="ods-checkbox" type="checkbox" name="example-2" id="example-2-2" value="value-2" data-invalid>
+    <input class="ods-checkbox is-ods-checkbox-invalid" type="checkbox" name="example-2" id="example-2-2" value="value-2">
     <label class="ods-checkbox--label" for="example-2-2">Label 2</label>
-    <input class="ods-checkbox" type="checkbox" name="example-2" id="example-2-3" value="value-3" data-invalid>
+    <input class="ods-checkbox is-ods-checkbox-invalid" type="checkbox" name="example-2" id="example-2-3" value="value-3">
     <label class="ods-checkbox--label" for="example-2-3">Label 3</label>
     <aside class="ods-field--error" id="checkbox-invalid-error"><span class="u-visually-hidden">Error:</span> Invalid error description</aside>
   </fieldset>
@@ -226,7 +226,7 @@ Please refer to individual components for complete documentation. These examples
   <div class="docs-example--rendered">
     <fieldset class="ods-fieldset" data-optional>
       <div class="ods-fieldset-flex">
-        <select class="ods-select" data-js-choices id="example-3" name="example-3" required>
+        <select class="ods-select" data-js-choices id="example-3" name="example-3">
           <option></option>
           <option value="value-1">Option 1</option>
           <option value="value-2">Option 2</option>
@@ -243,7 +243,7 @@ Please refer to individual components for complete documentation. These examples
   ```html
   <fieldset class="ods-fieldset" data-optional>
     <div class="ods-fieldset-flex">
-      <select class="ods-select" data-js-choices id="example-3" name="example-3" required>
+      <select class="ods-select" data-js-choices id="example-3" name="example-3">
         <option></option>
         <option value="value-1">Option 1</option>
         <option value="value-2">Option 2</option>

--- a/packages/docs/components/radio-button.md
+++ b/packages/docs/components/radio-button.md
@@ -64,7 +64,7 @@ Radio Buttons in their "unchecked" state are considered enabled. They are ready 
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <input class="ods-radio" type="radio" name="overview-enabled" id="overview-enabled" value="0" required>
+    <input class="ods-radio" type="radio" name="overview-enabled" id="overview-enabled" value="0">
     <label class="ods-radio--label" for="overview-enabled">Warp speed</label>
   </fieldset>
 </Visual>
@@ -79,7 +79,7 @@ Hover states are activated when the user pauses their pointer over the input.
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <input class="ods-radio" type="radio" name="overview-hover" id="overview-hover" value="0" required>
+    <input class="ods-radio" type="radio" name="overview-hover" id="overview-hover" value="0">
     <label class="ods-radio--label is-ods-radio-hover" for="overview-hover">Warp speed</label>
   </fieldset>
 </Visual>
@@ -94,7 +94,7 @@ The focus state is a visual affordance that the user has highlighted the input w
 
 <Visual>
   <fieldset class="ods-fieldset">
-    <input class="ods-radio is-ods-radio-focus" type="radio" name="overview-focus" id="overview-focus" value="0" required>
+    <input class="ods-radio is-ods-radio-focus" type="radio" name="overview-focus" id="overview-focus" value="0">
     <label class="ods-radio--label" for="overview-focus">Warp speed</label>
   </fieldset>
 </Visual>
@@ -130,9 +130,9 @@ Radios are disabled by option.
     <label class="ods-radio--label" for="overview-disabled">Warp speed</label>
     <input class="ods-radio" type="radio" name="overview-disabled-checked" id="overview-disabled-checked" value="0" required disabled checked>
     <label class="ods-radio--label" for="overview-disabled-checked">Warp speed</label>
-    <input class="ods-radio" type="radio" name="overview-disabled-invalid" id="overview-disabled-invalid" value="1" required disabled data-invalid>
+    <input class="ods-radio is-ods-radio-invalid" type="radio" name="overview-disabled-invalid" id="overview-disabled-invalid" value="1" required disabled>
     <label class="ods-radio--label" for="overview-disabled-invalid">Warp speed</label>
-    <input class="ods-radio" type="radio" name="overview-disabled-invalid-checked" id="overview-disabled-invalid-checked" value="1" required disabled data-invalid checked>
+    <input class="ods-radio is-ods-radio-invalid" type="radio" name="overview-disabled-invalid-checked" id="overview-disabled-invalid-checked" value="1" required disabled checked>
     <label class="ods-radio--label" for="overview-disabled-invalid-checked">Warp speed</label>
   </fieldset>
 </Visual>
@@ -172,11 +172,11 @@ Unlike Checkboxes, Radios validate as a group, not individually.
 <Visual>
   <fieldset class="ods-fieldset">
     <legend class="ods-input-legend">Select speed</legend>
-    <input class="ods-radio" type="radio" name="overview-invalid[]" id="overview-invalid-1" value="1" required data-invalid checked>
+    <input class="ods-radio is-ods-radio-invalid" type="radio" name="overview-invalid[]" id="overview-invalid-1" value="1" required checked>
     <label class="ods-radio--label" for="overview-invalid-1">Lightspeed</label>
-    <input class="ods-radio" type="radio" name="overview-invalid[]" id="overview-invalid-2" value="2" required data-invalid>
+    <input class="ods-radio is-ods-radio-invalid" type="radio" name="overview-invalid[]" id="overview-invalid-2" value="2" required>
     <label class="ods-radio--label" for="overview-invalid-2">Warp Speed</label>
-    <input class="ods-radio" type="radio" name="overview-invalid[]" id="overview-invalid-3" value="3" aria-describedby="overview-invalid-error" required data-invalid>
+    <input class="ods-radio is-ods-radio-invalid" type="radio" name="overview-invalid[]" id="overview-invalid-3" value="3" aria-describedby="overview-invalid-error" required>
     <label class="ods-radio--label" for="overview-invalid-3">Ludicrous Speed</label>
     <aside class="ods-field--error" id="overview-invalid-error"><span class="u-visually-hidden">Error:</span> General relativity forbids it.</aside>
   </fieldset>
@@ -249,11 +249,11 @@ Unlike Checkboxes, Radios validate as a group, not individually.
   <div class="docs-example--rendered">
     <fieldset class="ods-fieldset">
       <legend class="ods-input-legend">Field label</legend>
-      <input class="ods-radio" type="radio" name="example-2" id="example-2-0" value="value-0" aria-describedby="group-name-error" data-invalid required checked>
+      <input class="ods-radio is-ods-radio-invalid" type="radio" name="example-2" id="example-2-0" value="value-0" aria-describedby="group-name-error" required checked>
       <label class="ods-radio--label" for="example-2-0">Label 1</label>
-      <input class="ods-radio" type="radio" name="example-2" id="example-2-1" value="value-1" data-invalid required>
+      <input class="ods-radio is-ods-radio-invalid" type="radio" name="example-2" id="example-2-1" value="value-1" required>
       <label class="ods-radio--label" for="example-2-1">Label 2</label>
-      <input class="ods-radio" type="radio" name="example-2" id="example-2-2" value="value-2" data-invalid required>
+      <input class="ods-radio is-ods-radio-invalid" type="radio" name="example-2" id="example-2-2" value="value-2" required>
       <label class="ods-radio--label" for="example-2-2">Label 3</label>
       <aside class="ods-field--error" id="group-name-error"><span class="u-visually-hidden">Error:</span> This is an invalid selection.</aside>
     </fieldset>
@@ -262,12 +262,12 @@ Unlike Checkboxes, Radios validate as a group, not individually.
   ```html
   <fieldset class="ods-fieldset">
     <legend class="ods-input-legend">Field label</legend>
-    <input class="ods-radio" type="radio" name="group-name" id="input-0" value="value-0" aria-describedby="group-name-error" data-invalid required checked>
-    <label class="ods-radio--label" for="input-0">Label 1</label>
-    <input class="ods-radio" type="radio" name="group-name" id="input-1" value="value-1" data-invalid required>
-    <label class="ods-radio--label" for="input-1">Label 2</label>
-    <input class="ods-radio" type="radio" name="group-name" id="input-2" value="value-2" data-invalid required>
-    <label class="ods-radio--label" for="input-2">Label 3</label>
+    <input class="ods-radio is-ods-radio-invalid" type="radio" name="example-2" id="example-2-0" value="value-0" aria-describedby="group-name-error" required checked>
+    <label class="ods-radio--label" for="example-2-0">Label 1</label>
+    <input class="ods-radio is-ods-radio-invalid" type="radio" name="example-2" id="example-2-1" value="value-1" required>
+    <label class="ods-radio--label" for="example-2-1">Label 2</label>
+    <input class="ods-radio is-ods-radio-invalid" type="radio" name="example-2" id="example-2-2" value="value-2" required>
+    <label class="ods-radio--label" for="example-2-2">Label 3</label>
     <aside class="ods-field--error" id="group-name-error"><span class="u-visually-hidden">Error:</span> This is an invalid selection.</aside>
   </fieldset>
   ```

--- a/packages/docs/components/select.md
+++ b/packages/docs/components/select.md
@@ -267,9 +267,9 @@ When indicating a validation error, please use a Field Error label to indicate t
 </Description>
 
 <Visual content="full">
-  <fieldset class="ods-fieldset" data-invalid>
+  <fieldset class="ods-fieldset is-ods-select-invalid">
     <div class="ods-fieldset-flex">
-      <select class="ods-select" data-js-choices id="overview-invalid" name="overview-invalid" required data-invalid aria-describedby="overview-invalid-error">
+      <select class="ods-select is-ods-select-invalid" data-js-choices id="overview-invalid" name="overview-invalid" required aria-describedby="overview-invalid-error">
         <option></option>
         <option value="proxima">Proxima Centauri</option>
         <option value="barnards">Barnard's Star</option>
@@ -544,15 +544,15 @@ Options may be grouped within the Select list to help guide users. When doing th
 
 <Description>
 
-Because of the current inability to ensure consistent validation behavior across browsers, we're using the `[data-invalid]` attribute to indicate this state.
+Because of the current inability to ensure consistent validation behavior across browsers, we're using the `.is-ods-select-invalid` class to indicate this state.
 
 </Description>
 
 <figure class="docs-example">
   <div class="docs-example--rendered">
-    <fieldset class="ods-fieldset" data-invalid>
+    <fieldset class="ods-fieldset is-ods-select-invalid">
       <div class="ods-fieldset-flex">
-        <select class="ods-select" data-js-choices id="example-6" name="example-6" data-invalid required>
+        <select class="ods-select is-ods-select-invalid" data-js-choices id="example-6" name="example-6" required>
           <option></option>
           <option value="value-1">Option 1</option>
           <option value="value-2">Option 2</option>
@@ -570,9 +570,9 @@ Because of the current inability to ensure consistent validation behavior across
   </div>
 
   ```html
-  <fieldset class="ods-fieldset" data-invalid>
+  <fieldset class="ods-fieldset is-ods-select-invalid">
     <div class="ods-fieldset-flex">
-      <select class="ods-select" data-js-choices id="example-6" name="example-6" data-invalid required>
+      <select class="ods-select is-ods-select-invalid" data-js-choices id="example-6" name="example-6" required>
         <option></option>
         <option value="value-1">Option 1</option>
         <option value="value-2">Option 2</option>

--- a/packages/docs/components/text-input.md
+++ b/packages/docs/components/text-input.md
@@ -37,7 +37,7 @@ This default serves as the basis for our Text Inputs. A shown here, they require
 <Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input class="ods-text-input" type="text" id="overview-default" required>
+      <input class="ods-text-input" type="text" id="overview-default">
       <label class="ods-label" for="overview-default">Destination</label>
     </div>
   </fieldset>
@@ -56,7 +56,7 @@ In this case, we recommend using the placeholder attribute to state the scope of
 <Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input class="ods-text-input" type="search" name="overview-search" id="overview-search" autocomplete="search" spellcheck="false" placeholder="Search planets" required>
+      <input class="ods-text-input" type="search" name="overview-search" id="overview-search" autocomplete="search" spellcheck="false" placeholder="Search planets">
       <label class="ods-label" for="overview-search">Search planets</label>
     </div>
   </fieldset>
@@ -74,13 +74,13 @@ We also provide an attached button for in-page searching or avoiding placeholder
   <form>
     <fieldset class="ods-fieldset">
       <div class="ods-fieldset--attached">
-        <input class="ods-text-input" type="search" name="overview-search-button" id="overview-search-button" autocomplete="search" spellcheck="false" aria-labelledby="overview-search-button-label" required>
+        <input class="ods-text-input" type="search" name="overview-search-button" id="overview-search-button" autocomplete="search" spellcheck="false" aria-labelledby="overview-search-button-label">
         <button class="ods-button" id="overview-search-button-label">Search planets</button>
       </div>
     </fieldset>
     <fieldset class="ods-fieldset">
       <div class="ods-fieldset--attached">
-        <input class="ods-text-input" type="search" name="overview-search-button-sec" id="overview-search-button-sec" autocomplete="search" spellcheck="false" aria-labelledby="overview-search-button-sec-label" required>
+        <input class="ods-text-input" type="search" name="overview-search-button-sec" id="overview-search-button-sec" autocomplete="search" spellcheck="false" aria-labelledby="overview-search-button-sec-label">
         <button class="ods-button is-ods-button-secondary" id="overview-search-button-sec-label">Find cosmonaut</button>
       </div>
     </fieldset>
@@ -98,7 +98,7 @@ Textareas should be used for multi-line text inputs. As the user types the field
 <Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <textarea class="ods-text-input ods-text-area" name="overview-textarea" id="overview-textarea" rows='4' cols='50' spellcheck="true" required></textarea>
+      <textarea class="ods-text-input ods-text-area" name="overview-textarea" id="overview-textarea" rows='4' cols='50' spellcheck="true"></textarea>
       <aside class="ods-field--hint">
         Describe your perfect planet in as many words as you need.
       </aside>
@@ -126,7 +126,7 @@ Text inputs in their "normal" state are considered enabled. They are ready for u
 <Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input class="ods-text-input" type="text" name="overview-enabled" id="overview-enabled" required>
+      <input class="ods-text-input" type="text" name="overview-enabled" id="overview-enabled">
       <label class="ods-label" for="overview-enabled">Destination</label>
     </div>
   </fieldset>
@@ -143,7 +143,7 @@ Hover states are activated when the user pauses their pointer over the input.
 <Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input class="ods-text-input is-ods-input-hover" name="overview-hover" type="text" id="overview-hover" required>
+      <input class="ods-text-input is-ods-input-hover" name="overview-hover" type="text" id="overview-hover">
       <label class="ods-label" for="overview-hover">Destination</label>
     </div>
   </fieldset>
@@ -160,7 +160,7 @@ The focus state is a visual affordance that the user has highlighted the input w
 <Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input class="ods-text-input is-ods-input-focus" name="overview-focus" type="text" id="overview-focus" required>
+      <input class="ods-text-input is-ods-input-focus" name="overview-focus" type="text" id="overview-focus">
       <label class="ods-label" for="overview-focus">Destination</label>
     </div>
   </fieldset>
@@ -179,7 +179,7 @@ The values of disabled inputs will not be submitted.
 <Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input disabled class="ods-text-input" type="text" name="overview-disabled" id="overview-disabled" required disabled>
+      <input disabled class="ods-text-input" type="text" name="overview-disabled" id="overview-disabled" disabled>
       <label class="ods-label" for="overview-disabled">Destination</label>
     </div>
   </fieldset>
@@ -200,7 +200,7 @@ The values of read-only inputs will be submitted.
 <Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input class="ods-text-input" type="text" name="overview-readonly" id="overview-readonly" value="Jupiter" required readonly spellcheck="false">
+      <input class="ods-text-input" type="text" name="overview-readonly" id="overview-readonly" value="Jupiter" readonly spellcheck="false">
       <label class="ods-label" for="overview-readonly">Destination</label>
     </div>
   </fieldset>
@@ -236,7 +236,7 @@ When indicating a validation error, please use a Field Error label to indicate t
 <Visual content="full">
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input data-invalid class="ods-text-input" type="text" name="overview-invalid" aria-describedby="overview-invalid-error" id="overview-invalid" spellcheck="false" value="4.76 miles/s" required>
+      <input class="ods-text-input is-ods-input-invalid" type="text" name="overview-invalid" aria-describedby="overview-invalid-error" id="overview-invalid" spellcheck="false" value="4.76 miles/s" required>
       <label class="ods-label" for="overview-invalid">Destination</label>
       <aside class="ods-field--error" id="overview-invalid-error">
         <span class="u-visually-hidden">Error:</span>This does not appear to be a valid planetoid.
@@ -462,14 +462,14 @@ Out of the box, Odyssey supports input types for `text`, `email`, `search`, `tel
 <figure class="docs-example">
   <div class="docs-example--rendered">
     <fieldset class="ods-fieldset">
-      <input type="search" name="example-5" id="example-5" autocomplete="search" placeholder="Placeholder value" spellcheck="false" required="required" class="ods-text-input">
+      <input type="search" name="example-5" id="example-5" autocomplete="search" placeholder="Placeholder value" spellcheck="false" class="ods-text-input">
       <label class="ods-label" for="example-5">Search</label>
     </fieldset>
   </div>
 
   ```html
   <fieldset class="ods-fieldset">
-    <input type="search" name="example-5" id="example-5" autocomplete="search" placeholder="Placeholder value" spellcheck="false" required="required" class="ods-text-input">
+    <input type="search" name="example-5" id="example-5" autocomplete="search" placeholder="Placeholder value" spellcheck="false" class="ods-text-input">
     <label class="ods-label" for="example-5">Search</label>
   </fieldset>
   ```
@@ -481,19 +481,19 @@ Out of the box, Odyssey supports input types for `text`, `email`, `search`, `tel
   <div class="docs-example--rendered">
     <fieldset class="ods-fieldset">
       <div class="ods-fieldset--attached">
-        <input type="search" name="example-6" id="example-6" autocomplete="search" spellcheck="false" aria-labelledby="example-6-button" required="required" class="ods-text-input">
+        <input type="search" name="example-6" id="example-6" autocomplete="search" spellcheck="false" aria-labelledby="example-6-button" class="ods-text-input">
         <button id="example-6-button" class="ods-button">Button label</button>
       </div>
     </fieldset>
   </div>
 
   ```html
-    <fieldset class="ods-fieldset">
-      <div class="ods-fieldset--attached">
-        <input type="search" name="example-6" id="example-6" autocomplete="search" spellcheck="false" aria-labelledby="example-6-button" required="required" class="ods-text-input">
-        <button id="example-6-button" class="ods-button">Button label</button>
-      </div>
-    </fieldset>
+  <fieldset class="ods-fieldset">
+    <div class="ods-fieldset--attached">
+      <input type="search" name="example-6" id="example-6" autocomplete="search" spellcheck="false" aria-labelledby="example-6-button" class="ods-text-input">
+      <button id="example-6-button" class="ods-button">Button label</button>
+    </div>
+  </fieldset>
   ```
 </figure>
 
@@ -503,19 +503,19 @@ Out of the box, Odyssey supports input types for `text`, `email`, `search`, `tel
   <div class="docs-example--rendered">
     <fieldset class="ods-fieldset">
       <div class="ods-fieldset--attached">
-        <input type="search" name="example-7" id="example-7" autocomplete="search" spellcheck="false" aria-labelledby="example-7-button" required="required" class="ods-text-input">
+        <input type="search" name="example-7" id="example-7" autocomplete="search" spellcheck="false" aria-labelledby="example-7-button" class="ods-text-input">
         <button id="example-7-button" class="ods-button is-ods-button-secondary">Button label</button>
       </div>
     </fieldset>
   </div>
 
   ```html
-    <fieldset class="ods-fieldset">
-      <div class="ods-fieldset--attached">
-        <input type="search" name="example-7" id="example-7" autocomplete="search" spellcheck="false" aria-labelledby="example-7-button" required="required" class="ods-text-input">
-        <button id="example-7-button" class="ods-button is-ods-button-secondary">Button label</button>
-      </div>
-    </fieldset>
+  <fieldset class="ods-fieldset">
+    <div class="ods-fieldset--attached">
+      <input type="search" name="example-7" id="example-7" autocomplete="search" spellcheck="false" aria-labelledby="example-7-button" class="ods-text-input">
+      <button id="example-7-button" class="ods-button is-ods-button-secondary">Button label</button>
+    </div>
+  </fieldset>
   ```
 </figure>
 
@@ -525,7 +525,7 @@ Out of the box, Odyssey supports input types for `text`, `email`, `search`, `tel
   <div class="docs-example--rendered">
     <fieldset class="ods-fieldset">
       <div class="ods-fieldset-flex">
-        <textarea class="ods-text-input ods-text-area" name="example-8" id="example-8" rows='4' cols='50' spellcheck="true" required></textarea>
+        <textarea class="ods-text-input ods-text-area" name="example-8" id="example-8" rows='4' cols='50' spellcheck="true"></textarea>
         <aside class="ods-field--hint">
           Descriptive field hint
         </aside>
@@ -537,7 +537,7 @@ Out of the box, Odyssey supports input types for `text`, `email`, `search`, `tel
   ```html
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <textarea class="ods-text-input ods-text-area" name="example-8" id="example-8" rows='4' cols='50' spellcheck="true" required></textarea>
+      <textarea class="ods-text-input ods-text-area" name="example-8" id="example-8" rows='4' cols='50' spellcheck="true"></textarea>
       <aside class="ods-field--hint">
         Descriptive field hint
       </aside>
@@ -597,15 +597,15 @@ Out of the box, Odyssey supports input types for `text`, `email`, `search`, `tel
 
 <Description>
 
-  Because of the current inability to ensure consistent validation behavior across browsers, we're using the `[data-invalid]` attribute to indicate this state.
+  Because of the current inability to ensure consistent validation behavior across browsers, we're using the `.is-ods-input-invalid` class to indicate this state.
 
 </Description>
 
-<figure class="docs-example" data-invalid>
+<figure class="docs-example">
   <div class="docs-example--rendered">
     <fieldset class="ods-fieldset">
       <div class="ods-fieldset-flex">
-        <input class="ods-text-input" type="text" name="example-11" id="example-11" spellcheck="false" value="" data-invalid required>
+        <input class="ods-text-input is-ods-input-invalid" type="text" name="example-11" id="example-11" spellcheck="false" value="" required>
         <label class="ods-label" for="example-11">Field label</label>
         <aside class="ods-field--error" id="overview-invalid-error">
           <span class="u-visually-hidden">Error:</span> Invalid error description
@@ -617,7 +617,7 @@ Out of the box, Odyssey supports input types for `text`, `email`, `search`, `tel
   ```html
   <fieldset class="ods-fieldset">
     <div class="ods-fieldset-flex">
-      <input class="ods-text-input" type="text" name="example-11" id="example-11" spellcheck="false" value="" data-invalid required>
+      <input class="ods-text-input is-ods-input-invalid" type="text" name="example-11" id="example-11" spellcheck="false" value="" required>
       <label class="ods-label" for="example-11">Field label</label>
       <aside class="ods-field--error" id="overview-invalid-error">
         <span class="u-visually-hidden">Error:</span> Invalid error description

--- a/packages/odyssey/src/scss/abstracts/_mixins.scss
+++ b/packages/odyssey/src/scss/abstracts/_mixins.scss
@@ -26,6 +26,8 @@
   box-shadow: 0 0 0 $radius $outline-cv;
 }
 
+/* stylelint-disable no-descending-specificity */
+
 @mixin input-baseline {
   display: block;
   position: relative;
@@ -73,7 +75,8 @@
     }
   }
 
-  &[data-invalid] {
+  &:invalid,
+  &.is-ods-input-invalid {
     border-color: $color-danger-base;
 
     &:focus {

--- a/packages/odyssey/src/scss/components/_checkbox.scss
+++ b/packages/odyssey/src/scss/components/_checkbox.scss
@@ -107,7 +107,8 @@
     }
   }
 
-  &[data-invalid] {
+  &:invalid,
+  &.is-ods-checkbox-invalid {
     + .ods-checkbox--label {
       color: $text-danger;
 

--- a/packages/odyssey/src/scss/components/_radio-button.scss
+++ b/packages/odyssey/src/scss/components/_radio-button.scss
@@ -64,7 +64,8 @@
     }
   }
 
-  &[data-invalid] {
+  &:invalid,
+  &.is-ods-radio-invalid {
     &:hover:not(:checked) + .ods-radio--label::before {
       border-color: $color-danger-dark;
     }

--- a/packages/odyssey/src/scss/vendors-ext/_choices-ext.scss
+++ b/packages/odyssey/src/scss/vendors-ext/_choices-ext.scss
@@ -71,7 +71,7 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
     }
   }
 
-  [data-invalid] & {
+  .is-ods-select-invalid & {
     &:focus,
     &.is-ods-select-focused {
       @include outline($focus-ring-danger);
@@ -239,13 +239,13 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   }
 
   .is-ods-select-open &,
-  [data-invalid] .is-ods-select-open & {
+  .is-ods-select-invalid .is-ods-select-open & {
     border-radius: $base-border-radius $base-border-radius 0 0;
     border-bottom-color: $border-color-ui;
   }
 
   .is-ods-select-flipped.is-ods-select-open &,
-  [data-invalid] .is-ods-select-flipped.is-ods-select-open & {
+  .is-ods-select-invalid .is-ods-select-flipped.is-ods-select-open & {
     border-radius: 0 0 $base-border-radius $base-border-radius;
     border-top-color: $border-color-ui;
     border-bottom-color: $color-primary-base;
@@ -408,11 +408,11 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
     }
   }
 
-  [data-invalid] .is-ods-select-focused & {
+  .is-ods-select-invalid .is-ods-select-focused & {
     @include outline($focus-ring-danger);
   }
 
-  [data-invalid] .is-ods-select-open & {
+  .is-ods-select-invalid .is-ods-select-open & {
     border-color: $color-danger-base;
   }
 }


### PR DESCRIPTION
This PR removes the reliance on `data-invalid` in favor of the `:invalid` state with class names as a fallback.

Docs note: @arnoldsandoval-okta currently, in Firefox + VuePress, `:enabled:required:empty` fields are marked as `:invalid` *before* a user interacts with the form, leading to a full page of errors on load. This does not occur on CodePen or in a plain HTML page. For now, I've removed the `required` attribute from doc examples that were causing this issue.