### PR TITLE
feat(odyssey-react): add TextInput component

### DIFF
--- a/packages/odyssey-react/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.stories.tsx
@@ -1,0 +1,62 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import type { Story } from "@storybook/react";
+import React from "react";
+import TextInput from ".";
+import type { Props } from ".";
+
+export default {
+  title: `Components/TextInput`,
+  component: TextInput,
+  args: {
+    label: 'Destination',
+    optionalLabel: 'Optional'
+  },
+  argTypes: {
+    required: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    readonly: { control: 'boolean' },
+    defaultValue: { control: 'text' },
+    optionalLabel: { control: 'text' },
+    placeholder: { control: 'text' },
+    type: { control: 'radio' },
+    value: { control: 'text' },
+    id: { control: 'text' },
+    name: { control: 'text' },
+    onChange: { control: false },
+    onBlur: { control: false },
+    onFocus: { control: false }
+  },
+  parameters: {
+    controls: {
+      sort: 'requiredFirst'
+    }
+  }
+};
+
+const Template: Story<Props> = (props) => (
+  <TextInput {...props} />
+);
+
+export const Text = Template.bind({});
+Text.storyName = 'Text';
+Text.args = {
+  defaultValue: 'Jupiter',
+};
+
+export const Search = Template.bind({});
+Search.storyName = 'Search';
+Search.args = {
+  defaultValue: 'Search Planets',
+  type: 'search'
+};

--- a/packages/odyssey-react/src/components/TextInput/TextInput.test.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.test.tsx
@@ -1,0 +1,140 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import React from "react";
+import { render, fireEvent, within } from "@testing-library/react";
+import type { EventType } from "@testing-library/dom";
+import TextInput from ".";
+import type { Props } from ".";
+
+const textBox = 'textbox';
+const label = 'Destination';
+
+describe("TextInput", () => {
+  it('renders into the document', () => {
+    const { getByRole } = render(
+      <TextInput label={label} />
+    );
+
+    expect(getByRole(textBox)).toBeInTheDocument();
+  });
+
+  it('renders a provided id associating the input and label', () => {
+    const { getByRole, getByText } = render(
+      <TextInput label={label} id="foo" />
+    );
+
+    expect(getByRole(textBox)).toHaveAttribute('id', 'foo');
+    expect(getByText(label)).toHaveAttribute('for', 'foo');
+  });
+
+  it('renders a provided name for the input', () => {
+    const { getByRole } = render(
+      <TextInput label={label} name="bar" />
+    );
+
+    expect(getByRole(textBox)).toHaveAttribute('name', 'bar');
+  });
+
+  it('renders the optionalLabel when input is not required', () => {
+    const optionalLabel = 'Optional';
+
+    const { container } = render(
+      <TextInput label={label} optionalLabel={optionalLabel} required={false} />
+    );
+
+    expect(
+      within(container.querySelector('label') as HTMLElement).getByText(
+        optionalLabel
+      )
+    ).toBeInTheDocument();
+  });
+
+  it.each([
+    ['disabled'],
+    ['readonly'],
+    ['required']
+  ])('renders %s attribute', (attr: string) => {
+    const { getByRole } = render(
+      <TextInput label={label} {...{ [attr]: true }} />
+    );
+
+    expect(getByRole(textBox)).toHaveAttribute(attr);
+  });
+
+  it.each<[Props['type']]>([
+    [undefined],
+    ['text'],
+    ['email'],
+    ['url'],
+    ['tel'],
+    ['search'],
+    ['password']
+  ])('renders %s input type', (type) => {
+    const { getByLabelText } = render(
+      <TextInput label={label} type={type} />
+    );
+
+    expect(getByLabelText(label)).toHaveAttribute('type', type ?? 'text');
+  });
+
+  it('invokes onChange with expected args when change input event fires', () => {
+    const handle = jest.fn();
+
+    const { getByRole } = render(
+      <TextInput onChange={handle} label={label} />
+    );
+
+    fireEvent.change(
+      getByRole(textBox),
+      { target: { value: 'new' } }
+    );
+
+    expect(handle).toHaveBeenCalledTimes(1);
+    expect(handle).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: 'change' }),
+      'new'
+    );
+  });
+
+  it.each<[string, EventType]>([
+    ['onBlur', 'blur'],
+    ['onFocus', 'focus'],
+  ])('invokes %s with expected args when %s input event fires', (prop, type) => {
+    const handle = jest.fn();
+
+    const { getByRole } = render(
+      <TextInput {...{ [prop]: handle }} label={label} />
+    );
+
+    fireEvent[type].call(
+      fireEvent,
+      getByRole(textBox),
+    );
+
+    expect(handle).toHaveBeenCalledTimes(1);
+    expect(handle).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type }),
+    );
+  });
+
+  it('invokes inputRef with expected args after render', () => {
+    const handle = jest.fn();
+
+    const { getByRole } = render(
+      <TextInput inputRef={handle} label={label} />
+    );
+
+    expect(handle).toHaveBeenCalledTimes(1);
+    expect(handle).toHaveBeenLastCalledWith(getByRole(textBox));
+  });
+});

--- a/packages/odyssey-react/src/components/TextInput/index.tsx
+++ b/packages/odyssey-react/src/components/TextInput/index.tsx
@@ -1,0 +1,189 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import React, { useMemo, useCallback } from 'react';
+import type {
+  FunctionComponent,
+  FocusEventHandler,
+  ChangeEvent,
+  RefCallback,
+  ReactNode
+} from 'react';
+import { oid } from '../../utils';
+
+export type Props = {
+  /**
+   * The underlying input element id attribute. Automatically generated if not provided
+   */
+  id?: string,
+
+  /**
+   * The underlying input element type
+   * @default text
+   */
+  type?: 'text' | 'email' | 'url' | 'tel' | 'search' | 'password',
+
+  /**
+   * The form field label
+   */
+  label: string,
+
+  /**
+   * Callback to provide a reference to the underlying input element
+   * @param {Object} instance the input element or null
+   */
+  inputRef?: RefCallback<HTMLInputElement>,
+
+
+  /**
+   * The underlying input element name attribute
+   */
+  name?: string,
+
+  /**
+   * The underlying input element required attribute
+   * @default true
+   */
+  required?: boolean,
+
+  /**
+   * The underlying input element disabled attribute
+   * @default false
+   */
+  disabled?: boolean,
+
+  /**
+   * The underlying input element readonly attribute
+   * @default false
+   */
+  readonly?: boolean,
+
+  /**
+   * Text to display when the form is optional, i.e. required prop is false
+   */
+  optionalLabel?: string,
+
+  /**
+   * The underlying input element placeholder attribute
+   */
+  placeholder?: string,
+
+  /**
+   * The input element value for controlled components
+   */
+  value?: string,
+
+  /**
+   * The initial input element value for uncontrolled components
+   */
+  defaultValue?: string,
+
+  /**
+   * Callback executed when the input fires a blur event
+   * @param {Object} event the event object
+   */
+  onBlur?: FocusEventHandler<HTMLInputElement>,
+
+  /**
+   * Callback executed when the input fires a change event
+   * @param {Object} event the event object
+   * @param {string} value the string value of the input
+   */
+  onChange?: (event: ChangeEvent<HTMLInputElement>, value: string) => void,
+
+  /**
+  * Callback executed when the input fires a focus event
+  * @param {Object} event the event object
+  */
+  onFocus?: FocusEventHandler<HTMLInputElement>,
+};
+
+
+function renderLabel(
+  label: string,
+  required: boolean,
+  optionalLabel?: string
+): ReactNode {
+  if (required || !optionalLabel) {
+    return <>{label}</>;
+  }
+  return (
+    <>
+      {label}
+      <span
+        className="ods-label--optional"
+        children={optionalLabel}
+      />
+    </>
+  );
+}
+
+
+/**
+ * Text inputs allow users to edit and input data.
+ */
+const TextInput: FunctionComponent<Props> = (props) => {
+  const {
+    defaultValue,
+    disabled = false,
+    id = useMemo(oid, []),
+    inputRef,
+    label,
+    name,
+    onBlur,
+    onChange,
+    onFocus,
+    optionalLabel,
+    placeholder,
+    readonly = false,
+    required = true,
+    type = 'text',
+    value,
+  } = props;
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onChange?.(event, event.target.value);
+    },
+    [onChange]
+  );
+
+  return (
+    <fieldset className="ods-fieldset">
+      <div className="ods-fieldset-flex">
+        <input
+          className="ods-text-input"
+          disabled={disabled}
+          id={id}
+          name={name}
+          onChange={handleChange}
+          onBlur={onBlur}
+          onFocus={onFocus}
+          placeholder={placeholder}
+          readOnly={readonly}
+          ref={inputRef}
+          required={required}
+          type={type}
+          defaultValue={defaultValue}
+          value={value}
+        />
+        <label
+          children={renderLabel(label, required, optionalLabel)}
+          className="ods-label"
+          htmlFor={id}
+        />
+      </div>
+    </fieldset>
+  );
+};
+
+export default TextInput;

--- a/packages/odyssey-react/src/utils/index.ts
+++ b/packages/odyssey-react/src/utils/index.ts
@@ -1,0 +1,14 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import oid from './oid';
+export { oid };

--- a/packages/odyssey-react/src/utils/oid.test.ts
+++ b/packages/odyssey-react/src/utils/oid.test.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import oid from "./oid";
+
+describe("oid", () => {
+  it(`returns a nice id string`, () => {
+    expect(oid()).toHaveLength(6);
+  });
+});

--- a/packages/odyssey-react/src/utils/oid.ts
+++ b/packages/odyssey-react/src/utils/oid.ts
@@ -1,0 +1,15 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+type oid = () => string;
+const oid: oid = () => Math.random().toString(36).slice(2, 8);
+export default oid;


### PR DESCRIPTION
This PR adds the baseline `<TextInput />` component. I plan to include separate components for the other variants not included with this work (`<TextArea />` etc).