### PR TITLE
Status HTML Refactor

### DIFF
--- a/packages/docs/components/status.md
+++ b/packages/docs/components/status.md
@@ -51,14 +51,14 @@ This is the default variant.
 </Description>
 
 <Visual>
-  <dl class="ods-status">
-    <dt class="ods-status--label">
+  <div class="ods-status">
+    <span class="ods-status--label">
       Propulsion systems
-    </dt>
-    <dd class="ods-status--value">
+    </span>
+    <span class="ods-status--value">
       Engines offline
-    </dd>
-  </dl>
+    </span>
+  </div>
 </Visual>
 
 ### Success
@@ -70,14 +70,14 @@ Success Statuses are green and should be used to indicate states like "Complete"
 </Description>
 
 <Visual>
-  <dl class="ods-status is-ods-status-success">
-    <dt class="ods-status--label">
+  <div class="ods-status is-ods-status-success">
+    <span class="ods-status--label">
       Propulsion systems
-    </dt>
-    <dd class="ods-status--value">
+    </span>
+    <span class="ods-status--value">
       Online
-    </dd>
-  </dl>
+    </span>
+  </div>
 </Visual>
 
 ### Caution
@@ -89,14 +89,14 @@ Caution Statuses are yellow and should be used to indicate states like "Attentio
 </Description>
 
 <Visual>
-  <dl class="ods-status is-ods-status-caution">
-    <dt class="ods-status--label">
+  <div class="ods-status is-ods-status-caution">
+    <span class="ods-status--label">
       Propulsion systems
-    </dt>
-    <dd class="ods-status--value">
+    </span>
+    <span class="ods-status--value">
       Check engine
-    </dd>
-  </dl>
+    </span>
+  </div>
 </Visual>
 
 ### Danger
@@ -108,14 +108,14 @@ Danger Statuses are red and should be used to indicate states like "Error", "Fai
 </Description>
 
 <Visual>
-  <dl class="ods-status is-ods-status-danger">
-    <dt class="ods-status--label">
+  <div class="ods-status is-ods-status-danger">
+    <span class="ods-status--label">
       Propulsion systems
-    </dt>
-    <dd class="ods-status--value">
+    </span>
+    <span class="ods-status--value">
       Warp core disruption
-    </dd>
-  </dl>
+    </span>
+  </div>
 </Visual>
 
 ## Usage
@@ -127,14 +127,14 @@ Use Status to communicate the state of a discrete item, such as a server or indi
 </Description>
 
 <Visual>
-  <dl class="ods-status is-ods-status-success">
-    <dt class="ods-status--label">
+  <div class="ods-status is-ods-status-success">
+    <span class="ods-status--label">
       Engine performance
-    </dt>
-    <dd class="ods-status--value">
+    </span>
+    <span class="ods-status--value">
       Nominal
-    </dd>
-  </dl>
+    </span>
+  </div>
 </Visual>
 
 ### Within Table
@@ -156,14 +156,14 @@ Statuses content should provide a quick overview. Limit Status descriptor and la
 </Description>
 
 <Visual>
-  <dl class="ods-status is-ods-status-success">
-    <dt class="ods-status--label">
+  <div class="ods-status is-ods-status-success">
+    <span class="ods-status--label">
       Warp drive status
-    </dt>
-    <dd class="ods-status--value">
+    </span>
+    <span class="ods-status--value">
       Engaged
-    </dd>
-  </dl>
+    </span>
+  </div>
 </Visual>
 
 ### Statuses without labels
@@ -175,14 +175,14 @@ Where necessary, labels may be hidden. If a label is not present, ensure the Sta
 </Description>
 
 <Visual>
-  <dl class="ods-status is-ods-status-success is-ods-status-label-hidden">
-    <dt class="ods-status--label">
+  <div class="ods-status is-ods-status-success is-ods-status-label-hidden">
+    <span class="ods-status--label">
       Warp drive status
-    </dt>
-    <dd class="ods-status--value">
+    </span>
+    <span class="ods-status--value">
       Warp drive engaged
-    </dd>
-  </dl>
+    </span>
+  </div>
 </Visual>
 
 :::
@@ -195,25 +195,25 @@ Where necessary, labels may be hidden. If a label is not present, ensure the Sta
 
 <figure class="docs-example">
   <div class="docs-example--rendered">
-    <dl class="ods-status">
-      <dt class="ods-status--label">
+    <div class="ods-status">
+      <span class="ods-status--label">
         Status label
-      </dt>
-      <dd class="ods-status--value">
+      </span>
+      <span class="ods-status--value">
         Neutral descriptor
-      </dd>
-    </dl>
+      </span>
+    </div>
   </div>
 
   ```html
-  <dl class="ods-status">
-    <dt class="ods-status--label">
+  <div class="ods-status">
+    <span class="ods-status--label">
       Status label
-    </dt>
-    <dd class="ods-status--value">
+    </span>
+    <span class="ods-status--value">
       Neutral descriptor
-    </dd>
-  </dl>
+    </span>
+  </div>
   ```
 </figure>
 
@@ -221,25 +221,25 @@ Where necessary, labels may be hidden. If a label is not present, ensure the Sta
 
 <figure class="docs-example">
   <div class="docs-example--rendered">
-    <dl class="ods-status is-ods-status-success">
-      <dt class="ods-status--label">
+    <div class="ods-status is-ods-status-success">
+      <span class="ods-status--label">
         Status label
-      </dt>
-      <dd class="ods-status--value">
+      </span>
+      <span class="ods-status--value">
         Success descriptor
-      </dd>
-    </dl>
+      </span>
+    </div>
   </div>
 
   ```html
-  <dl class="ods-status is-ods-status-success">
-    <dt class="ods-status--label">
+  <div class="ods-status is-ods-status-success">
+    <span class="ods-status--label">
       Status label
-    </dt>
-    <dd class="ods-status--value">
+    </span>
+    <span class="ods-status--value">
       Success descriptor
-    </dd>
-  </dl>
+    </span>
+  </div>
   ```
 </figure>
 
@@ -247,25 +247,25 @@ Where necessary, labels may be hidden. If a label is not present, ensure the Sta
 
 <figure class="docs-example">
   <div class="docs-example--rendered">
-    <dl class="ods-status is-ods-status-caution">
-      <dt class="ods-status--label">
+    <div class="ods-status is-ods-status-caution">
+      <span class="ods-status--label">
         Status label
-      </dt>
-      <dd class="ods-status--value">
+      </span>
+      <span class="ods-status--value">
         Caution descriptor
-      </dd>
-    </dl>
+      </span>
+    </div>
   </div>
 
   ```html
-  <dl class="ods-status is-ods-status-caution">
-    <dt class="ods-status--label">
+  <div class="ods-status is-ods-status-caution">
+    <span class="ods-status--label">
       Status label
-    </dt>
-    <dd class="ods-status--value">
+    </span>
+    <span class="ods-status--value">
       Caution descriptor
-    </dd>
-  </dl>
+    </span>
+  </div>
   ```
 </figure>
 
@@ -273,25 +273,25 @@ Where necessary, labels may be hidden. If a label is not present, ensure the Sta
 
 <figure class="docs-example">
   <div class="docs-example--rendered">
-    <dl class="ods-status is-ods-status-danger">
-      <dt class="ods-status--label">
+    <div class="ods-status is-ods-status-danger">
+      <span class="ods-status--label">
         Status label
-      </dt>
-      <dd class="ods-status--value">
+      </span>
+      <span class="ods-status--value">
         Danger descriptor
-      </dd>
-    </dl>
+      </span>
+    </div>
   </div>
 
   ```html
-  <dl class="ods-status is-ods-status-danger">
-    <dt class="ods-status--label">
+  <div class="ods-status is-ods-status-danger">
+    <span class="ods-status--label">
       Status label
-    </dt>
-    <dd class="ods-status--value">
+    </span>
+    <span class="ods-status--value">
       Danger descriptor
-    </dd>
-  </dl>
+    </span>
+  </div>
   ```
 </figure>
 
@@ -307,59 +307,25 @@ Even if the label is hidden, it must be populated to ensure appropriate context 
 
 <figure class="docs-example">
   <div class="docs-example--rendered">
-    <dl class="ods-status is-ods-status-success is-ods-status-label-hidden">
-      <dt class="ods-status--label">
+    <div class="ods-status is-ods-status-success is-ods-status-label-hidden">
+      <span class="ods-status--label">
         Status label
-      </dt>
-      <dd class="ods-status--value">
+      </span>
+      <span class="ods-status--value">
         Status descriptor
-      </dd>
-    </dl>
+      </span>
+    </div>
   </div>
 
   ```html
-  <dl class="ods-status is-ods-status-success is-ods-status-label-hidden">
-    <dt class="ods-status--label">
+  <div class="ods-status is-ods-status-success is-ods-status-label-hidden">
+    <span class="ods-status--label">
       Status label
-    </dt>
-    <dd class="ods-status--value">
+    </span>
+    <span class="ods-status--value">
       Status descriptor
-    </dd>
-  </dl>
-  ```
-</figure>
-
-## Async Status changes
-
-<Description>
-
-If the current state of Status may change asynchronously while a user is visiting the page, utilize the `role="status"` attribute to ensure that assistive technologies correctly indicate this change.
-
-<strong>Note:</strong> This attribute must be present <em>before</em> the change occurs.
-
-</Description>
-
-<figure class="docs-example">
-  <div class="docs-example--rendered">
-    <dl class="ods-status is-ods-status-caution" role="status">
-      <dt class="ods-status--label">
-        Status label
-      </dt>
-      <dd class="ods-status--value">
-        Live Status descriptor
-      </dd>
-    </dl>
+    </span>
   </div>
-
-  ```html
-  <dl class="ods-status is-ods-status-caution" role="status">
-    <dt class="ods-status--label">
-      Status label
-    </dt>
-    <dd class="ods-status--value">
-      Live Status descriptor
-    </dd>
-  </dl>
   ```
 </figure>
 

--- a/packages/odyssey-react/src/components/Status/Status.stories.tsx
+++ b/packages/odyssey-react/src/components/Status/Status.stories.tsx
@@ -20,25 +20,20 @@ export default {
   argTypes: {
     labelHidden: {
       control: { type: "boolean" }
-    },
-    role: {
-      control: { type: "text" }
     }
   }
 };
 
-const Template: Story<StatusProps> = ({ 
+const Template: Story<StatusProps> = ({
   label,
   descriptor,
   labelHidden,
-  role,
-  variant 
+  variant
 }) => (
-  <Status 
+  <Status
     label={label}
     descriptor={descriptor}
     labelHidden={labelHidden}
-    role={role}
     variant={variant}
   />
 )

--- a/packages/odyssey-react/src/components/Status/Status.test.tsx
+++ b/packages/odyssey-react/src/components/Status/Status.test.tsx
@@ -20,8 +20,8 @@ const statusDescriptor = "Status Descriptor";
 describe("Status", () => {
   it("should render the status component", () => {
     const { getByTestId } = render(
-      <Status 
-        variant="neutral" 
+      <Status
+        variant="neutral"
         label={statusLabel}
         descriptor={statusDescriptor}
       />
@@ -29,11 +29,11 @@ describe("Status", () => {
 
     expect(getByTestId('ods-status')).toBeInTheDocument();
   });
-    
+
   it('should visually hide the label, but keep it in the DOM for assistive purposes', () => {
     const { getByTestId } = render(
-      <Status 
-        variant="danger" 
+      <Status
+        variant="danger"
         label={statusLabel}
         descriptor={statusDescriptor}
         labelHidden={true}
@@ -45,18 +45,5 @@ describe("Status", () => {
     expect(statusElement).toHaveClass("is-ods-status-label-hidden");
     expect(labelElement).toHaveTextContent(statusLabel)
     expect(labelElement).toBeVisible();
-  });
-
-  it('should apply an aria role of `status` when the `prop.role` is set', () => {
-    const { getByTestId } = render(
-      <Status 
-        label={statusLabel}
-        descriptor={statusDescriptor}
-        role="status"
-      />
-    );
-    const statusElement = getByTestId('ods-status');
-
-    expect(statusElement).toHaveAttribute('role', 'status');
   });
 });

--- a/packages/odyssey-react/src/components/Status/Status.test.tsx
+++ b/packages/odyssey-react/src/components/Status/Status.test.tsx
@@ -30,6 +30,18 @@ describe("Status", () => {
     expect(getByTestId('ods-status')).toBeInTheDocument();
   });
 
+  it('renders the appropriate role of "status"', () => {
+    const { getByRole } = render(
+      <Status
+        variant="success"
+        label={statusLabel}
+        descriptor={statusDescriptor}
+      />
+    );
+
+    expect(getByRole("status")).toBeInTheDocument;
+  });
+
   it('should visually hide the label, but keep it in the DOM for assistive purposes', () => {
     const { getByTestId } = render(
       <Status

--- a/packages/odyssey-react/src/components/Status/Status.tsx
+++ b/packages/odyssey-react/src/components/Status/Status.tsx
@@ -19,7 +19,7 @@ export type StatusProps = {
    * The status label.
    */
   label: string,
-  
+
   /**
    * Visually hides the status label.
    */
@@ -31,11 +31,6 @@ export type StatusProps = {
   descriptor: string,
 
   /**
-   * aria-role to be applied to the status element when it's descriptor is expected to change asynchronously.
-   */
-  role?: 'status',
-
-  /**
    * The visual variant to be displayed to the user.
    * @default neutral
    */
@@ -43,20 +38,17 @@ export type StatusProps = {
 }
 
 /**
- * Status is used to inform users by providing feedback on system states. Status can display broad 
+ * Status is used to inform users by providing feedback on system states. Status can display broad
  * operational states as well as granular states like user status.
- * 
+ *
  * @component
- * @todo [OKTA-398175](https://oktainc.atlassian.net/browse/OKTA-398175) - Move away from definition 
- * lists Status component HTML
  * @example <Status label={label} descriptor={descriptor} />
  */
 const Status: FunctionComponent<StatusProps> = (props) => {
-  const { 
+  const {
     label,
     descriptor,
     labelHidden = false,
-    role,
     variant = "neutral",
   } = props;
 
@@ -66,14 +58,14 @@ const Status: FunctionComponent<StatusProps> = (props) => {
   });
 
   return (
-    <dl className={componentClass} role={role} data-testid="ods-status">
-      <dt className="ods-status--label">
+    <div className={componentClass} role="status" data-testid="ods-status">
+      <span className="ods-status--label">
         {label}
-      </dt>
-      <dd className="ods-status--value">
+      </span>
+      <span className="ods-status--value">
         {descriptor}
-      </dd>
-    </dl>
+      </span>
+    </div>
   )
 };
 


### PR DESCRIPTION
This refactors our Status component (both packages) to utilize a `div/span` relationship instead of `dl/dd/dt`, as the latter was too verbose for screen readers. This also makes the `role="status"` attribute non-optional.