### PR TITLE
feat: status - utilize logical props to enable RTL

### DIFF
--- a/packages/odyssey/src/scss/components/_status.scss
+++ b/packages/odyssey/src/scss/components/_status.scss
@@ -14,13 +14,13 @@ $status-indicator-size: 1em / 2;
 
 .ods-status--label {
   display: block;
-  margin-bottom: $spacing-xs;
+  margin-block-end: $spacing-xs;
   font-weight: 600;
 }
 
 .ods-status--value {
   position: relative;
-  padding-left: $status-indicator-size + $spacing-xs-em;
+  padding-inline-start: $status-indicator-size + $spacing-xs-em;
   background-color: transparent;
   color: $text-body;
 
@@ -31,7 +31,7 @@ $status-indicator-size: 1em / 2;
     left: 0;
     width: $status-indicator-size;
     height: $status-indicator-size;
-    margin-right: $spacing-xs;
+    margin-inline-end: $spacing-xs;
     transform: translateY(-50%);
     border-radius: 1em;
     background-color: cv('gray', '600');


### PR DESCRIPTION
To test [CSS Logical Properties](https://css-tricks.com/css-logical-properties/) as an RTL styling solution, this refactors Status use logical properties instead of directional ones. 

Because logicals are unsupported in IE11, we would need to add [PostCSS Logical](https://github.com/csstools/postcss-logical) to our PostCSS config in scenarios where support is required. The output here is similar to how we handle vendor-prefixing and alternate property names.

If we want to enforce this across the codebase, [stylelint-use-logical](https://github.com/csstools/stylelint-use-logical) will enable us to do so.