### PR TITLE
feat(odyssey-react): add TextArea component

### DIFF
--- a/packages/odyssey-react/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/odyssey-react/src/components/TextArea/TextArea.stories.tsx
@@ -29,6 +29,7 @@ export default {
     readonly: { control: 'boolean' },
     defaultValue: { control: 'text' },
     hint: { control: 'text' },
+    optionalLabel: { control: 'text' },
     placeholder: { control: 'text' },
     value: { control: 'text' },
     id: { control: 'text' },

--- a/packages/odyssey-react/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/odyssey-react/src/components/TextArea/TextArea.stories.tsx
@@ -1,0 +1,52 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import type { Story } from "@storybook/react";
+import React from "react";
+import TextArea from ".";
+import type { Props } from ".";
+
+export default {
+  title: `Components/TextArea`,
+  component: TextArea,
+  args: {
+    label: 'Field Label',
+    defaultValue: ' ',
+    hint: 'Descriptive field hint'
+  },
+  argTypes: {
+    required: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    readonly: { control: 'boolean' },
+    defaultValue: { control: 'text' },
+    hint: { control: 'text' },
+    placeholder: { control: 'text' },
+    value: { control: 'text' },
+    id: { control: 'text' },
+    name: { control: 'text' },
+    onChange: { control: false },
+    onBlur: { control: false },
+    onFocus: { control: false }
+  },
+  parameters: {
+    controls: {
+      sort: 'requiredFirst'
+    }
+  }
+};
+
+const Template: Story<Props> = (props) => (
+  <TextArea {...props} />
+);
+
+export const Default = Template.bind({});
+Default.storyName = 'TextArea';

--- a/packages/odyssey-react/src/components/TextArea/TextArea.test.tsx
+++ b/packages/odyssey-react/src/components/TextArea/TextArea.test.tsx
@@ -1,0 +1,127 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import type { EventType } from "@testing-library/dom";
+import TextArea from ".";
+
+const textBox = 'textbox';
+const label = 'Destination';
+
+describe("TextArea", () => {
+  it('renders into the document', () => {
+    const { getByRole } = render(
+      <TextArea label={label} />
+    );
+
+    expect(getByRole(textBox)).toBeInTheDocument();
+  });
+
+  it('renders a provided id associating the input and label', () => {
+    const { getByRole, getByText } = render(
+      <TextArea label={label} id="foo" />
+    );
+
+    expect(getByRole(textBox)).toHaveAttribute('id', 'foo');
+    expect(getByText(label)).toHaveAttribute('for', 'foo');
+  });
+
+  it('renders a generated id associating the input and label', () => {
+    const { getByLabelText } = render(
+      <TextArea label={label} />
+    );
+
+    expect(getByLabelText(label)).toBe;
+  });
+
+  it('renders a provided name for the input', () => {
+    const { getByRole } = render(
+      <TextArea label={label} name="bar" />
+    );
+
+    expect(getByRole(textBox)).toHaveAttribute('name', 'bar');
+  });
+
+  it('renders a provided hint', () => {
+    const hint = 'Look here';
+
+    const { getByText } = render(
+      <TextArea label={label} hint={hint} />
+    );
+
+    expect(getByText(hint)).toBeInTheDocument();
+  });
+
+  it.each([
+    ['disabled'],
+    ['readonly'],
+    ['required']
+  ])('renders %s attribute', (attr: string) => {
+    const { getByRole } = render(
+      <TextArea label={label} {...{ [attr]: true }} />
+    );
+
+    expect(getByRole(textBox)).toHaveAttribute(attr);
+  });
+
+  it('invokes onChange with expected args when change input event fires', () => {
+    const handle = jest.fn();
+
+    const { getByRole } = render(
+      <TextArea onChange={handle} label={label} />
+    );
+
+    fireEvent.change(
+      getByRole(textBox),
+      { target: { value: 'new' } }
+    );
+
+    expect(handle).toHaveBeenCalledTimes(1);
+    expect(handle).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: 'change' }),
+      'new'
+    );
+  });
+
+  it.each<[string, EventType]>([
+    ['onBlur', 'blur'],
+    ['onFocus', 'focus'],
+  ])('invokes %s with expected args when %s input event fires', (prop, type) => {
+    const handle = jest.fn();
+
+    const { getByRole } = render(
+      <TextArea {...{ [prop]: handle }} label={label} />
+    );
+
+    fireEvent[type].call(
+      fireEvent,
+      getByRole(textBox),
+    );
+
+    expect(handle).toHaveBeenCalledTimes(1);
+    expect(handle).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type }),
+    );
+  });
+
+  it('invokes textareaRef with expected args after render', () => {
+    const handle = jest.fn();
+
+    const { getByRole } = render(
+      <TextArea textareaRef={handle} label={label} />
+    );
+
+    expect(handle).toHaveBeenCalledTimes(1);
+    expect(handle).toHaveBeenLastCalledWith(getByRole(textBox));
+  });
+});

--- a/packages/odyssey-react/src/components/TextArea/index.tsx
+++ b/packages/odyssey-react/src/components/TextArea/index.tsx
@@ -17,7 +17,7 @@ import type {
   ChangeEvent,
   RefCallback,
 } from 'react';
-import { oid } from '../../utils';
+import { useOid } from '../../utils';
 
 export type Props = {
   /**
@@ -122,6 +122,8 @@ const TextArea: FunctionComponent<Props> = (props) => {
     value,
   } = props;
 
+  const oid = useOid(id);
+
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
       onChange?.(event, event.target.value);
@@ -135,7 +137,7 @@ const TextArea: FunctionComponent<Props> = (props) => {
         <textarea
           className="ods-text-input ods-text-area"
           disabled={disabled}
-          id={id || oid()}
+          id={oid}
           name={name}
           onChange={handleChange}
           onBlur={onBlur}
@@ -153,7 +155,7 @@ const TextArea: FunctionComponent<Props> = (props) => {
         <label
           children={label}
           className="ods-label"
-          htmlFor={id}
+          htmlFor={oid}
         />
       </div>
     </fieldset>

--- a/packages/odyssey-react/src/components/TextArea/index.tsx
+++ b/packages/odyssey-react/src/components/TextArea/index.tsx
@@ -1,0 +1,163 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import React, { useCallback } from 'react';
+import type {
+  FunctionComponent,
+  FocusEventHandler,
+  ChangeEvent,
+  RefCallback,
+} from 'react';
+import { oid } from '../../utils';
+
+export type Props = {
+  /**
+   * The underlying textarea element id attribute. Automatically generated if not provided
+   */
+  id?: string,
+
+  /**
+   * The form field label
+   */
+  label: string,
+
+  /**
+   * Callback to provide a reference to the underlying textarea element
+   * @param {Object} instance the textarea element or null
+   */
+  textareaRef?: RefCallback<HTMLTextAreaElement>,
+
+
+  /**
+   * The underlying textarea element name attribute
+   */
+  name?: string,
+
+  /**
+   * The underlying textarea element required attribute
+   * @default true
+   */
+  required?: boolean,
+
+  /**
+   * The underlying textarea element disabled attribute
+   * @default false
+   */
+  disabled?: boolean,
+
+  /**
+   * The underlying textarea element readonly attribute
+   * @default false
+   */
+  readonly?: boolean,
+
+  /**
+   * Text to display as a hint
+   */
+  hint?: string,
+
+  /**
+   * The underlying textarea element placeholder attribute
+   */
+  placeholder?: string,
+
+  /**
+   * The textarea element value for controlled components
+   */
+  value?: string,
+
+  /**
+   * The initial textarea element value for uncontrolled components
+   */
+  defaultValue?: string,
+
+  /**
+   * Callback executed when the textarea fires a blur event
+   * @param {Object} event the event object
+   */
+  onBlur?: FocusEventHandler<HTMLTextAreaElement>,
+
+  /**
+   * Callback executed when the textarea fires a change event
+   * @param {Object} event the event object
+   * @param {string} value the string value of the textarea
+   */
+  onChange?: (event: ChangeEvent<HTMLTextAreaElement>, value: string) => void,
+
+  /**
+  * Callback executed when the textarea fires a focus event
+  * @param {Object} event the event object
+  */
+  onFocus?: FocusEventHandler<HTMLTextAreaElement>,
+};
+
+
+/**
+ * TextArea allows users to edit and input data.
+ */
+const TextArea: FunctionComponent<Props> = (props) => {
+  const {
+    defaultValue,
+    disabled = false,
+    hint,
+    id,
+    label,
+    name,
+    onBlur,
+    onChange,
+    onFocus,
+    placeholder,
+    readonly = false,
+    required = true,
+    textareaRef,
+    value,
+  } = props;
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      onChange?.(event, event.target.value);
+    },
+    [onChange]
+  );
+
+  return (
+    <fieldset className="ods-fieldset">
+      <div className="ods-fieldset-flex">
+        <textarea
+          className="ods-text-input ods-text-area"
+          disabled={disabled}
+          id={id || oid()}
+          name={name}
+          onChange={handleChange}
+          onBlur={onBlur}
+          onFocus={onFocus}
+          placeholder={placeholder}
+          readOnly={readonly}
+          ref={textareaRef}
+          required={required}
+          defaultValue={defaultValue}
+          value={value}
+        />
+        <aside className="ods-field--hint"
+          children={hint}
+        />
+        <label
+          children={label}
+          className="ods-label"
+          htmlFor={id}
+        />
+      </div>
+    </fieldset>
+  );
+};
+
+export default TextArea;

--- a/packages/odyssey-react/src/components/TextArea/index.tsx
+++ b/packages/odyssey-react/src/components/TextArea/index.tsx
@@ -66,6 +66,11 @@ export type Props = {
   hint?: string,
 
   /**
+   * Text to display when the form is optional, i.e. required prop is false
+   */
+  optionalLabel?: string,
+
+  /**
    * The underlying textarea element placeholder attribute
    */
   placeholder?: string,
@@ -115,6 +120,7 @@ const TextArea: FunctionComponent<Props> = (props) => {
     onBlur,
     onChange,
     onFocus,
+    optionalLabel,
     placeholder,
     readonly = false,
     required = true,
@@ -130,6 +136,16 @@ const TextArea: FunctionComponent<Props> = (props) => {
     },
     [onChange]
   );
+
+  const labelChildren = <>
+    {label}
+    { !required && optionalLabel &&
+      <span
+        className="ods-label--optional"
+        children={optionalLabel}
+      />
+    }
+  </>;
 
   return (
     <fieldset className="ods-fieldset">
@@ -153,7 +169,7 @@ const TextArea: FunctionComponent<Props> = (props) => {
           children={hint}
         />
         <label
-          children={label}
+          children={labelChildren}
           className="ods-label"
           htmlFor={oid}
         />

--- a/packages/odyssey-react/src/components/TextInput/TextInput.test.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.test.tsx
@@ -37,6 +37,14 @@ describe("TextInput", () => {
     expect(getByText(label)).toHaveAttribute('for', 'foo');
   });
 
+  it('renders a generated id associating the input and label', () => {
+    const { getByLabelText } = render(
+      <TextInput label={label} />
+    );
+
+    expect(getByLabelText(label)).toBe;
+  });
+
   it('renders a provided name for the input', () => {
     const { getByRole } = render(
       <TextInput label={label} name="bar" />

--- a/packages/odyssey-react/src/components/TextInput/index.tsx
+++ b/packages/odyssey-react/src/components/TextInput/index.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import React, { useMemo, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import type {
   FunctionComponent,
   FocusEventHandler,
@@ -18,7 +18,7 @@ import type {
   RefCallback,
   ReactNode
 } from 'react';
-import { oid } from '../../utils';
+import { useOid } from '../../utils';
 
 export type Props = {
   /**
@@ -135,7 +135,7 @@ const TextInput: FunctionComponent<Props> = (props) => {
   const {
     defaultValue,
     disabled = false,
-    id = useMemo(oid, []),
+    id,
     inputRef,
     label,
     name,
@@ -150,6 +150,8 @@ const TextInput: FunctionComponent<Props> = (props) => {
     value,
   } = props;
 
+  const oid = useOid(id);
+
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       onChange?.(event, event.target.value);
@@ -163,7 +165,7 @@ const TextInput: FunctionComponent<Props> = (props) => {
         <input
           className="ods-text-input"
           disabled={disabled}
-          id={id}
+          id={oid}
           name={name}
           onChange={handleChange}
           onBlur={onBlur}
@@ -179,7 +181,7 @@ const TextInput: FunctionComponent<Props> = (props) => {
         <label
           children={renderLabel(label, required, optionalLabel)}
           className="ods-label"
-          htmlFor={id}
+          htmlFor={oid}
         />
       </div>
     </fieldset>

--- a/packages/odyssey-react/src/components/TextInput/index.tsx
+++ b/packages/odyssey-react/src/components/TextInput/index.tsx
@@ -16,7 +16,6 @@ import type {
   FocusEventHandler,
   ChangeEvent,
   RefCallback,
-  ReactNode
 } from 'react';
 import { useOid } from '../../utils';
 
@@ -108,26 +107,6 @@ export type Props = {
 };
 
 
-function renderLabel(
-  label: string,
-  required: boolean,
-  optionalLabel?: string
-): ReactNode {
-  if (required || !optionalLabel) {
-    return <>{label}</>;
-  }
-  return (
-    <>
-      {label}
-      <span
-        className="ods-label--optional"
-        children={optionalLabel}
-      />
-    </>
-  );
-}
-
-
 /**
  * Text inputs allow users to edit and input data.
  */
@@ -159,6 +138,16 @@ const TextInput: FunctionComponent<Props> = (props) => {
     [onChange]
   );
 
+  const labelChildren = <>
+    {label}
+    { !required && optionalLabel &&
+      <span
+        className="ods-label--optional"
+        children={optionalLabel}
+      />
+    }
+  </>;
+
   return (
     <fieldset className="ods-fieldset">
       <div className="ods-fieldset-flex">
@@ -179,7 +168,7 @@ const TextInput: FunctionComponent<Props> = (props) => {
           value={value}
         />
         <label
-          children={renderLabel(label, required, optionalLabel)}
+          children={labelChildren}
           className="ods-label"
           htmlFor={oid}
         />

--- a/packages/odyssey-react/src/utils/index.ts
+++ b/packages/odyssey-react/src/utils/index.ts
@@ -10,5 +10,4 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import oid from './oid';
-export { oid };
+export { oid, useOid } from './oid';

--- a/packages/odyssey-react/src/utils/oid.test.ts
+++ b/packages/odyssey-react/src/utils/oid.test.ts
@@ -10,10 +10,10 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import oid from "./oid";
+import { oid, length } from "./oid";
 
 describe("oid", () => {
   it(`returns a nice id string`, () => {
-    expect(oid()).toHaveLength(6);
+    expect(oid()).toHaveLength(length);
   });
 });

--- a/packages/odyssey-react/src/utils/oid.ts
+++ b/packages/odyssey-react/src/utils/oid.ts
@@ -10,6 +10,13 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-type oid = () => string;
-const oid: oid = () => Math.random().toString(36).slice(2, 8);
-export default oid;
+import { useMemo } from 'react';
+
+export const length = 6;
+
+export const oid = (): string => Math.random().toString(36).slice(-length);
+
+export const useOid = (id?: string): string => {
+  const _oid = useMemo(oid, [oid]);
+  return id || _oid;
+};


### PR DESCRIPTION
This PR adds a new `<TextArea />` component

![text-area](https://user-images.githubusercontent.com/63716167/120800554-135ce080-c50e-11eb-95c9-a2cfd7327129.gif)

Additional commits included here:
* minor updates to our `oid` utility and exposing a `useOid` hook
* Refactoring TextInput logic for oid and rendering the label


