### PR TITLE
refactor(odyssey-react): cleanup Tooltip component

### DIFF
--- a/packages/odyssey-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/odyssey-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -10,22 +10,26 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Story } from "@storybook/react";
+import type { Story } from "@storybook/react";
 import { action } from '@storybook/addon-actions';
 import React from "react";
-import Tooltip, { TooltipProps } from "./Tooltip";
+import Tooltip from ".";
+import type { Props } from ".";
 
 import { Button } from '../../';
 
 export default {
   title: `Components/Tooltip`,
   component: Tooltip,
-  parameters:{
-    layout:'centered',
+  parameters: {
+    layout: 'centered',
+    controls: {
+      sort: 'requiredFirst'
+    },
   }
 };
 
-const Template: Story<TooltipProps> = () => (
+const Template: Story<Props> = () => (
   <>
     <Tooltip label="Top tooltip label" position="top">
       <Button variant="primary" onClick={action('Top button clicked')}>Top</Button>
@@ -40,6 +44,6 @@ const Template: Story<TooltipProps> = () => (
       <Button onClick={action('Left button clicked')} variant="clear">Left</Button>
     </Tooltip>
   </>
-)
+);
 
 export const Default = Template.bind({});

--- a/packages/odyssey-react/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/odyssey-react/src/components/Tooltip/Tooltip.test.tsx
@@ -12,28 +12,37 @@
 
 import React from "react";
 import { render } from "@testing-library/react";
-import Tooltip from "./Tooltip";
+import Tooltip from ".";
 
-const tooltipLabel = "Tooltip label"
+const label = "label";
+const tooltip = "tooltip";
 
 describe("Tooltip", () => {
-  it("should render the tooltip", () => {
-    const { getByTestId } = render(
-      <Tooltip label={tooltipLabel} position="top">
+  it("renders the tooltip", () => {
+    const { getByRole } = render(
+      <Tooltip label={label} position="top">
         <button>Top</button>
       </Tooltip>
     );
 
-    expect(getByTestId('ods-tooltip')).toBeInTheDocument();
+    expect(getByRole(tooltip)).toBeInTheDocument();
   });
 
-  it("should render the tooltip label", () => {
-    const { getByTestId } = render(
-      <Tooltip label={tooltipLabel} position="top">
+  it("renders the tooltip label", () => {
+    const { getByRole } = render(
+      <Tooltip label={label} position="top">
         <button>Top</button>
       </Tooltip>
     );
-    const label = getByTestId('ods-tooltip').querySelector('[role="tooltip"]');
-    expect(label).toHaveTextContent(tooltipLabel)
+    expect(getByRole(tooltip)).toHaveTextContent(label);
+  });
+
+  it("renders children as expected", () => {
+    const child = "foo";
+    const { getByText } = render(
+      <Tooltip label={label} position="top" children={child} />
+    );
+
+    expect(getByText(child)).toBeInTheDocument();
   });
 });

--- a/packages/odyssey-react/src/components/Tooltip/index.tsx
+++ b/packages/odyssey-react/src/components/Tooltip/index.tsx
@@ -10,43 +10,44 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import React, { ReactNode, FunctionComponent } from 'react'
+import React from 'react';
+import type { ReactNode, FunctionComponent } from 'react';
 import className from 'classnames';
 
-export type TooltipProps = {
+export type Props = {
+  /**
+   * Content to be rendered that needs a tooltip label
+   */
   children: ReactNode,
 
   /**
-   * The position the tooltip will be displayed.
+   * The position the tooltip will be displayed
    * @default top
    */
   position: 'top' | 'right' | 'bottom' | 'left',
 
   /**
-   * The position the tooltip will be displayed.
+   * The position the tooltip will be displayed
    */
-  label: string
-}
+  label: string;
+};
 
 /**
  * A transient element that provides additional context for an element when it receives hover or focus.
- * 
- * @component
- * @example <Tooltip position="top" label="The tooltip text content">...</Tooltip>
  */
-const Tooltip: FunctionComponent<TooltipProps> = ({ position = 'top', label, children }) => {
+const Tooltip: FunctionComponent<Props> = ({ position = 'top', label, children }) => {
   const componentClass = className('ods-tooltip', {
     [`is-ods-tooltip-${position}`]: position
   });
 
   return (
-    <span className="has-ods-tooltip" data-testid="ods-tooltip">
+    <span className="has-ods-tooltip">
       {children}
-      <aside id="edit-label" className={componentClass} role="tooltip">
+      <aside className={componentClass} role="tooltip">
         {label}
       </aside>
     </span>
-  )
+  );
 };
 
 export default Tooltip;

--- a/packages/odyssey-react/src/index.ts
+++ b/packages/odyssey-react/src/index.ts
@@ -11,6 +11,6 @@
  */
 
 import Button from './components/Button/Button';
-import Tooltip from './components/Tooltip/Tooltip';
+import Tooltip from './components/Tooltip';
 
 export { Button, Tooltip };


### PR DESCRIPTION
This PR performs a bit of cleanup for our `<Tooltip />` component

![tooltip](https://user-images.githubusercontent.com/63716167/120858369-b20a3100-c550-11eb-9ecb-1f8f16537322.gif)
