### PR TITLE
Cross-package RTL Support via Logical CSS Properties & Values

### DIFF
--- a/packages/odyssey-react/.storybook/main.js
+++ b/packages/odyssey-react/.storybook/main.js
@@ -16,5 +16,6 @@ module.exports = {
     "@storybook/addon-essentials",
     "@storybook/preset-scss",
     "@storybook/addon-a11y",
+    "@pxblue/storybook-rtl-addon/register"
   ]
 }

--- a/packages/odyssey-react/.storybook/main.js
+++ b/packages/odyssey-react/.storybook/main.js
@@ -15,7 +15,6 @@ module.exports = {
     "@storybook/addon-links",
     "@storybook/addon-essentials",
     "@storybook/preset-scss",
-    "@storybook/addon-a11y",
-    "@pxblue/storybook-rtl-addon/register"
+    "@storybook/addon-a11y"
   ]
 }

--- a/packages/odyssey-react/package.json
+++ b/packages/odyssey-react/package.json
@@ -8,6 +8,7 @@
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
+    "@pxblue/storybook-rtl-addon": "^1.0.1",
     "classnames": "^2.3.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"

--- a/packages/odyssey-react/package.json
+++ b/packages/odyssey-react/package.json
@@ -8,7 +8,6 @@
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
-    "@pxblue/storybook-rtl-addon": "^1.0.1",
     "classnames": "^2.3.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"

--- a/packages/odyssey-stylelint/package.json
+++ b/packages/odyssey-stylelint/package.json
@@ -14,7 +14,8 @@
     "stylelint-config-property-sort-order-smacss": "^7.1.0",
     "stylelint-config-sass-guidelines": "^5.0.0",
     "stylelint-config-standard": "^18.2.0",
-    "stylelint-scss": "^3.2.0"
+    "stylelint-scss": "^3.2.0",
+    "stylelint-use-logical": "^1.1.0"
   },
   "devDependencies": {
     "jest": "^26.6.3",

--- a/packages/odyssey-stylelint/package.json
+++ b/packages/odyssey-stylelint/package.json
@@ -15,7 +15,7 @@
     "stylelint-config-sass-guidelines": "^5.0.0",
     "stylelint-config-standard": "^18.2.0",
     "stylelint-scss": "^3.2.0",
-    "stylelint-use-logical": "^1.1.0"
+    "stylelint-use-logical-spec": "^3.2.0"
   },
   "devDependencies": {
     "jest": "^26.6.3",

--- a/packages/odyssey-stylelint/package.json
+++ b/packages/odyssey-stylelint/package.json
@@ -9,11 +9,11 @@
     "test": "jest"
   },
   "dependencies": {
-    "stylelint": "^13.13.1",
+    "stylelint": "^9.3.0",
     "stylelint-checkstyle-formatter": "^0.1.1",
     "stylelint-config-property-sort-order-smacss": "^7.1.0",
-    "stylelint-config-sass-guidelines": "^8.0.0",
-    "stylelint-config-standard": "^22.0.0",
+    "stylelint-config-sass-guidelines": "^5.0.0",
+    "stylelint-config-standard": "^18.2.0",
     "stylelint-scss": "^3.19.0",
     "stylelint-use-logical-spec": "^3.2.0"
   },

--- a/packages/odyssey-stylelint/package.json
+++ b/packages/odyssey-stylelint/package.json
@@ -9,12 +9,12 @@
     "test": "jest"
   },
   "dependencies": {
-    "stylelint": "^9.3.0",
+    "stylelint": "^13.13.1",
     "stylelint-checkstyle-formatter": "^0.1.1",
     "stylelint-config-property-sort-order-smacss": "^7.1.0",
-    "stylelint-config-sass-guidelines": "^5.0.0",
-    "stylelint-config-standard": "^18.2.0",
-    "stylelint-scss": "^3.2.0",
+    "stylelint-config-sass-guidelines": "^8.0.0",
+    "stylelint-config-standard": "^22.0.0",
+    "stylelint-scss": "^3.19.0",
     "stylelint-use-logical-spec": "^3.2.0"
   },
   "devDependencies": {

--- a/packages/odyssey-stylelint/src/index.js
+++ b/packages/odyssey-stylelint/src/index.js
@@ -36,6 +36,7 @@ module.exports = {
     'color-hex-length': 'long',
     'declaration-no-important': true,
     'max-nesting-depth': [ 3, { ignoreAtRules: [ 'media', 'supports', 'include' ] } ],
+    'property-disallowed-list': ['border-radius'],
     'order/properties-alphabetical-order': null,
     'scss/at-else-closing-brace-newline-after': 'always-last-in-chain',
     'scss/at-else-closing-brace-space-after': 'always-intermediate',

--- a/packages/odyssey-stylelint/src/index.js
+++ b/packages/odyssey-stylelint/src/index.js
@@ -43,6 +43,6 @@ module.exports = {
     'scss/at-if-closing-brace-newline-after': 'always-last-in-chain',
     'scss/at-if-closing-brace-space-after': 'always-intermediate',
     'selector-type-no-unknown': [ true, { ignore: [ 'custom-elements' ], } ],
-    'liberty/use-logical-spec': true
+    'liberty/use-logical-spec': [ true, { except: ['height', 'min-height', 'max-height', 'width', 'min-width', 'max-width'] } ]
   }
 }

--- a/packages/odyssey-stylelint/src/index.js
+++ b/packages/odyssey-stylelint/src/index.js
@@ -36,7 +36,7 @@ module.exports = {
     'color-hex-length': 'long',
     'declaration-no-important': true,
     'max-nesting-depth': [ 3, { ignoreAtRules: [ 'media', 'supports', 'include' ] } ],
-    'property-disallowed-list': ['border-radius'],
+    'property-disallowed-list': ['border-radius', 'margin', 'padding'],
     'order/properties-alphabetical-order': null,
     'scss/at-else-closing-brace-newline-after': 'always-last-in-chain',
     'scss/at-else-closing-brace-space-after': 'always-intermediate',

--- a/packages/odyssey-stylelint/src/index.js
+++ b/packages/odyssey-stylelint/src/index.js
@@ -13,7 +13,8 @@
 module.exports = {
   plugins: [
     require.resolve('./rules'),
-    'stylelint-scss'
+    'stylelint-scss',
+    'stylelint-use-logical'
   ],
   extends: [
     'stylelint-config-standard',
@@ -41,6 +42,7 @@ module.exports = {
     'scss/at-else-empty-line-before': 'never',
     'scss/at-if-closing-brace-newline-after': 'always-last-in-chain',
     'scss/at-if-closing-brace-space-after': 'always-intermediate',
-    'selector-type-no-unknown': [ true, { ignore: [ 'custom-elements' ] } ]
+    'selector-type-no-unknown': [ true, { ignore: [ 'custom-elements' ], } ],
+    "csstools/use-logical": true
   }
 }

--- a/packages/odyssey-stylelint/src/index.js
+++ b/packages/odyssey-stylelint/src/index.js
@@ -36,7 +36,7 @@ module.exports = {
     'color-hex-length': 'long',
     'declaration-no-important': true,
     'max-nesting-depth': [ 3, { ignoreAtRules: [ 'media', 'supports', 'include' ] } ],
-    'property-disallowed-list': ['border-radius', 'margin', 'padding'],
+    'property-blacklist': ['border-radius', 'margin', 'padding'],
     'order/properties-alphabetical-order': null,
     'scss/at-else-closing-brace-newline-after': 'always-last-in-chain',
     'scss/at-else-closing-brace-space-after': 'always-intermediate',

--- a/packages/odyssey-stylelint/src/index.js
+++ b/packages/odyssey-stylelint/src/index.js
@@ -14,7 +14,7 @@ module.exports = {
   plugins: [
     require.resolve('./rules'),
     'stylelint-scss',
-    'stylelint-use-logical'
+    'stylelint-use-logical-spec'
   ],
   extends: [
     'stylelint-config-standard',
@@ -43,6 +43,6 @@ module.exports = {
     'scss/at-if-closing-brace-newline-after': 'always-last-in-chain',
     'scss/at-if-closing-brace-space-after': 'always-intermediate',
     'selector-type-no-unknown': [ true, { ignore: [ 'custom-elements' ], } ],
-    "csstools/use-logical": true
+    'liberty/use-logical-spec': true
   }
 }

--- a/packages/odyssey/src/scss/abstracts/_mixins.scss
+++ b/packages/odyssey/src/scss/abstracts/_mixins.scss
@@ -14,12 +14,39 @@
   position: absolute;
   width: 1px;
   height: 1px;
-  margin: -1px;
-  padding: 0;
+  margin-block: -1px;
+  margin-inline: -1px;
+  padding-block: 0;
+  padding-inline: 0;
   overflow: hidden;
   clip: rect(0 0 0 0);
   border: 0;
 }
+
+/* stylelint-disable liberty/use-logical-spec */
+
+@mixin border-radius( $all, $top-right: $all, $bottom-right: $all, $bottom-left: $all, $top-left: $all ) {
+  border-start-start-radius: $top-left;
+  border-start-end-radius: $top-right;
+  border-end-end-radius: $bottom-right;
+  border-end-start-radius: $bottom-left;
+
+  @supports not (border-end-end-radius: 1px) {
+    border-top-left-radius: $top-left;
+    border-top-right-radius: $top-right;
+    border-bottom-right-radius: $bottom-right;
+    border-bottom-left-radius: $bottom-left;
+
+    [dir='rtl'] & {
+      border-top-left-radius: $top-right;
+      border-top-right-radius: $top-left;
+      border-bottom-right-radius: $bottom-left;
+      border-bottom-left-radius: $bottom-right;
+    }
+  }
+}
+
+/* stylelint-enable liberty/use-logical-spec */
 
 @mixin outline($outline-cv: $focus-ring-primary, $radius: 4px) {
   outline: 0;
@@ -29,17 +56,20 @@
 /* stylelint-disable no-descending-specificity */
 
 @mixin input-baseline {
+  @include border-radius($base-border-radius);
+
   display: block;
   position: relative;
   width: 100%;
   max-width: $max-line-length;
-  margin: 0;
-  padding: $spacing-xs-em $spacing-s-em;
+  margin-block: 0;
+  margin-inline: 0;
+  padding-block: $spacing-xs-em;
+  padding-inline: $spacing-s-em;
   transition-property: border-color, background-color, box-shadow;
   transition-duration: $base-duration;
   transition-timing-function: $base-timing;
   border: 1px solid $border-color-ui;
-  border-radius: $base-border-radius;
   background-color: $white;
   box-shadow: 0 0 0 0 cv('blue', '000');
   color: $text-body;

--- a/packages/odyssey/src/scss/abstracts/_tokens.scss
+++ b/packages/odyssey/src/scss/abstracts/_tokens.scss
@@ -12,7 +12,7 @@
 
 // Typography
 $body-font-family: 'Public Sans', '-apple-system',  'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
-$mono-font-family: 'Inconsolata', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+$mono-font-family: 'Inconsolata', 'SFMono-Regular', consolas, 'Liberation Mono', menlo, courier, monospace;
 
 $base-font-size: 16px;
 $scale-ratio: 1.1487;

--- a/packages/odyssey/src/scss/abstracts/_tokens.scss
+++ b/packages/odyssey/src/scss/abstracts/_tokens.scss
@@ -12,7 +12,7 @@
 
 // Typography
 $body-font-family: 'Public Sans', '-apple-system',  'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
-$mono-font-family: 'Inconsolata', 'SFMono-Regular', consolas, 'Liberation Mono', menlo, courier, monospace;
+$mono-font-family: 'Inconsolata', 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo', 'Courier', monospace;
 
 $base-font-size: 16px;
 $scale-ratio: 1.1487;

--- a/packages/odyssey/src/scss/base/_iconography.scss
+++ b/packages/odyssey/src/scss/base/_iconography.scss
@@ -12,7 +12,7 @@
 
 .ods-icon {
   position: relative;
-  top: -0.05em;
+  inset-block-start: -0.05em;
   width: 1em;
   height: 1em;
   vertical-align: middle;

--- a/packages/odyssey/src/scss/base/_reset.scss
+++ b/packages/odyssey/src/scss/base/_reset.scss
@@ -104,8 +104,10 @@ time,
 mark,
 audio,
 video {
-  margin: 0;
-  padding: 0;
+  margin-block: 0;
+  margin-inline: 0;
+  padding-block: 0;
+  padding-inline: 0;
   border: 0;
   font: inherit;
   font-size: 100%;

--- a/packages/odyssey/src/scss/base/_typography-header.scss
+++ b/packages/odyssey/src/scss/base/_typography-header.scss
@@ -16,7 +16,9 @@ h3,
 h4,
 h5,
 h6 {
-  margin: 0 0 $spacing-xs-em;
+  margin-block-start: 0;
+  margin-block-end: $spacing-xs-em;
+  margin-inline: 0;
   color: $text-heading;
   font-weight: 600;
 }

--- a/packages/odyssey/src/scss/base/_typography-link.scss
+++ b/packages/odyssey/src/scss/base/_typography-link.scss
@@ -28,10 +28,10 @@ a {
     content: '';
     display: inline-block;
     position: relative;
-    top: -0.1em;
+    inset-block-start: -0.1em;
     width: 1em;
     height: 1em;
-    margin-left: 0.2em;
+    margin-inline-start: 0.2em;
     background-image: get-icon('external', $color-primary-base);
     background-repeat: no-repeat;
     vertical-align: middle;

--- a/packages/odyssey/src/scss/base/_typography-list.scss
+++ b/packages/odyssey/src/scss/base/_typography-list.scss
@@ -20,12 +20,12 @@ ul {
 
     li {
       &:last-child {
-        margin-bottom: 0;
+        margin-block-end: 0;
       }
     }
 
     &:last-child {
-      margin-bottom: 0;
+      margin-block-end: 0;
     }
   }
 }
@@ -49,7 +49,7 @@ dl:not([class]) {
   padding: 0;
 
   &:last-child {
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 
   dt {

--- a/packages/odyssey/src/scss/base/_typography-list.scss
+++ b/packages/odyssey/src/scss/base/_typography-list.scss
@@ -14,8 +14,12 @@ ol,
 ul {
   &:not([class]) {
     max-width: $max-line-length;
-    margin: 0 0 $type-margin 0;
-    padding: 0 0 0 $spacing-m;
+    margin-block-start: 0;
+    margin-block-end: $type-margin;
+    margin-inline: 0;
+    padding-block: 0;
+    padding-inline-start: $spacing-m;
+    padding-inline-end: 0;
     list-style-position: outside;
 
     li {
@@ -45,8 +49,11 @@ dl:not([class]) {
   grid-gap: $spacing-xs $spacing-m;
   grid-template-columns: repeat(2, minmax(min-content, max-content));
   max-width: $max-line-length;
-  margin: 0 0 $type-margin 0;
-  padding: 0;
+  margin-block-start: 0;
+  margin-block-end: $type-margin;
+  margin-inline: 0;
+  padding-block: 0;
+  padding-inline: 0;
 
   &:last-child {
     margin-block-end: 0;

--- a/packages/odyssey/src/scss/base/_typography-text.scss
+++ b/packages/odyssey/src/scss/base/_typography-text.scss
@@ -11,7 +11,7 @@
  */
 
 abbr {
-  border-bottom: 1px dashed $color-primary-dark;
+  border-block-end: 1px dashed $color-primary-dark;
   text-decoration: none;
 }
 
@@ -20,7 +20,7 @@ address {
   margin: 0 0 $type-margin;
 
   &:last-child {
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 }
 
@@ -56,10 +56,10 @@ blockquote {
   max-width: $max-line-length;
   margin: 0 0 $type-margin;
   padding: 0 0 0 $spacing-s;
-  border-left: 3px solid $border-color-display;
+  border-inline-start: 3px solid $border-color-display;
 
   &:last-child {
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 }
 
@@ -72,7 +72,7 @@ p {
   }
 
   &:last-child {
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 }
 
@@ -83,7 +83,7 @@ pre {
   tab-size: 2;
 
   &:last-child {
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 }
 

--- a/packages/odyssey/src/scss/base/_typography-text.scss
+++ b/packages/odyssey/src/scss/base/_typography-text.scss
@@ -17,7 +17,9 @@ abbr {
 
 address {
   max-width: $max-line-length;
-  margin: 0 0 $type-margin;
+  margin-block-start: 0;
+  margin-block-end: $type-margin;
+  margin-inline: 0;
 
   &:last-child {
     margin-block-end: 0;
@@ -54,8 +56,12 @@ sub {
 
 blockquote {
   max-width: $max-line-length;
-  margin: 0 0 $type-margin;
-  padding: 0 0 0 $spacing-s;
+  margin-block-start: 0;
+  margin-block-end: $type-margin;
+  margin-inline: 0;
+  padding-block: 0;
+  padding-inline-end: 0;
+  padding-inline-start: $spacing-s;
   border-inline-start: 3px solid $border-color-display;
 
   &:last-child {
@@ -65,7 +71,9 @@ blockquote {
 
 p {
   max-width: $max-line-length;
-  margin: 0 0 $type-margin;
+  margin-block-start: 0;
+  margin-block-end: $type-margin;
+  margin-inline: 0;
 
   details & {
     font-size: ms(0);
@@ -77,7 +85,9 @@ p {
 }
 
 pre {
-  margin: 0 0 $type-margin;
+  margin-block-start: 0;
+  margin-block-end: $type-margin;
+  margin-inline: 0;
   font-family: $mono-font-family;
   white-space: pre-wrap;
   tab-size: 2;
@@ -146,7 +156,8 @@ ins::after {
 
 kbd {
   display: inline-block;
-  padding: 0 $spacing-xs;
+  padding-block: 0;
+  padding-inline: $spacing-xs;
   border: 1px solid cv('gray', '200');
   border-radius: $base-border-radius;
   background: cv('gray', '000');
@@ -176,7 +187,8 @@ s {
 }
 
 samp {
-  padding: 0 0.5ch;
+  padding-block: 0;
+  padding-inline: 0.5ch;
   background-color: cv('gray', '000');
   box-shadow: 0 1px 0 cv('gray', '200');
   font-family: $mono-font-family;
@@ -207,7 +219,8 @@ summary {
 }
 
 hr {
-  margin: $spacing-s 0;
+  margin-block: $spacing-s;
+  margin-inline: 0;
   border-width: 1px;
   border-style: solid;
   border-color: cv('gray', '200');

--- a/packages/odyssey/src/scss/base/_typography-text.scss
+++ b/packages/odyssey/src/scss/base/_typography-text.scss
@@ -155,11 +155,12 @@ ins::after {
 }
 
 kbd {
+  @include border-radius($base-border-radius);
+
   display: inline-block;
   padding-block: 0;
   padding-inline: $spacing-xs;
   border: 1px solid cv('gray', '200');
-  border-radius: $base-border-radius;
   background: cv('gray', '000');
   box-shadow: 0 2px 0 cv('gray', '000'), 0 3px 0 cv('gray', '200');
   font-weight: 400;
@@ -208,7 +209,8 @@ details {
 }
 
 summary {
-  border-radius: $base-border-radius;
+  @include border-radius($base-border-radius);
+
   font-size: ms(1);
   font-weight: 600;
   cursor: default;

--- a/packages/odyssey/src/scss/components/_banner.scss
+++ b/packages/odyssey/src/scss/components/_banner.scss
@@ -57,8 +57,8 @@
 
 .ods-banner--dismiss {
   position: absolute;
-  top: 50%;
-  right: $spacing-m;
+  inset-block-start: 50%;
+  inset-inline-end: $spacing-m;
   margin: 0 0 0 $spacing-m;
   transform: translateY(-50%);
 }

--- a/packages/odyssey/src/scss/components/_banner.scss
+++ b/packages/odyssey/src/scss/components/_banner.scss
@@ -19,7 +19,8 @@
   align-items: center;
   justify-content: center;
   width: 100%;
-  padding: $spacing-s $spacing-m;
+  padding-block: $spacing-s;
+  padding-inline: $spacing-m;
 
   a {
     text-decoration: underline;
@@ -27,26 +28,30 @@
 }
 
 .is-ods-banner-dismissable {
-  padding: $spacing-s $spacing-l $spacing-s $spacing-m;
+  padding-block: $spacing-s;
+  padding-inline-start: $spacing-m;
+  padding-inline-end: $spacing-l;
 }
 
 .ods-banner--icon {
   grid-area: icon;
-  margin: 0 $spacing-s 0 0;
+  margin-inline-end: $spacing-s;
   font-size: $size-title-5;
   line-height: 1;
 }
 
 .ods-banner--title {
   grid-area: title;
-  margin: 0 $spacing-xs 0 0;
+  margin-block-end: 0;
+  margin-inline-end: $spacing-xs;
   font-size: $size-title-6;
 }
 
 .ods-banner--content {
   grid-area: content;
   max-width: 100%;
-  margin: 0 $spacing-m 0 0;
+  margin-block-end: 0;
+  margin-inline-end: $spacing-m;
 }
 
 .ods-banner--actions {
@@ -59,7 +64,7 @@
   position: absolute;
   inset-block-start: 50%;
   inset-inline-end: $spacing-m;
-  margin: 0 0 0 $spacing-m;
+  margin-inline-start: $spacing-m;
   transform: translateY(-50%);
 }
 

--- a/packages/odyssey/src/scss/components/_button-layout.scss
+++ b/packages/odyssey/src/scss/components/_button-layout.scss
@@ -13,14 +13,14 @@
 /* stylelint-disable-next-line no-descending-specificity */
 .ods-button {
   & + & {
-    margin-left: $spacing-s;
+    margin-inline-start: $spacing-s;
   }
 
   &.is-ods-button-full-width {
     margin: 0;
 
     &:not(:last-child) {
-      margin-bottom: $spacing-s;
+      margin-block-end: $spacing-s;
     }
   }
 }

--- a/packages/odyssey/src/scss/components/_button-layout.scss
+++ b/packages/odyssey/src/scss/components/_button-layout.scss
@@ -17,7 +17,8 @@
   }
 
   &.is-ods-button-full-width {
-    margin: 0;
+    margin-block: 0;
+    margin-inline: 0;
 
     &:not(:last-child) {
       margin-block-end: $spacing-s;

--- a/packages/odyssey/src/scss/components/_button.scss
+++ b/packages/odyssey/src/scss/components/_button.scss
@@ -11,15 +11,18 @@
  */
 
 .ods-button {
+  @include border-radius($base-border-radius);
+
   display: inline-block;
   position: relative;
-  margin: 0;
-  padding: $spacing-xs-em $spacing-s-em;
+  margin-block: 0;
+  margin-inline: 0;
+  padding-block: $spacing-xs-em;
+  padding-inline: $spacing-s-em;
   transition-property: color, background-color, border-color, box-shadow;
   transition-duration: 100ms;
   transition-timing-function: linear;
   border: 1px solid transparent;
-  border-radius: $base-border-radius;
   background-color: $color-primary-base;
   box-shadow: 0 0 0 0 $color-primary-light;
   color: $white;
@@ -123,7 +126,8 @@
 }
 
 .is-ods-button-dismiss {
-  padding: $spacing-xs-em / 2;
+  padding-block: ($spacing-xs-em / 2);
+  padding-inline: ($spacing-xs-em / 2);
   border: 0;
   background-color: transparent;
   color: inherit;

--- a/packages/odyssey/src/scss/components/_button.scss
+++ b/packages/odyssey/src/scss/components/_button.scss
@@ -51,7 +51,7 @@
 
 .ods-button--label {
   &:not(:only-child) {
-    margin-left: $spacing-xs;
+    margin-inline-start: $spacing-xs;
   }
 }
 

--- a/packages/odyssey/src/scss/components/_checkbox-layout.scss
+++ b/packages/odyssey/src/scss/components/_checkbox-layout.scss
@@ -12,6 +12,6 @@
 
 .ods-checkbox--label {
   &:last-child {
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 }

--- a/packages/odyssey/src/scss/components/_checkbox.scss
+++ b/packages/odyssey/src/scss/components/_checkbox.scss
@@ -196,6 +196,8 @@
 
   &::before,
   &::after {
+    @include border-radius($base-border-radius);
+
     content: '';
     display: block;
     position: absolute;
@@ -207,7 +209,6 @@
     transition-duration: $base-duration;
     transition-timing-function: $base-timing;
     border: 2px solid transparent;
-    border-radius: $base-border-radius;
   }
 
   // Box

--- a/packages/odyssey/src/scss/components/_checkbox.scss
+++ b/packages/odyssey/src/scss/components/_checkbox.scss
@@ -192,7 +192,7 @@
   padding-inline-start: 1em + $spacing-s-em;
   font-size: $size-body-base;
   font-weight: 400;
-  text-align: left;
+  text-align: start;
 
   &::before,
   &::after {

--- a/packages/odyssey/src/scss/components/_checkbox.scss
+++ b/packages/odyssey/src/scss/components/_checkbox.scss
@@ -188,8 +188,8 @@
 .ods-checkbox--label {
   display: block;
   position: relative;
-  margin-bottom: $spacing-xs;
-  padding-left: 1em + $spacing-s-em;
+  margin-block-end: $spacing-xs;
+  padding-inline-start: 1em + $spacing-s-em;
   font-size: $size-body-base;
   font-weight: 400;
   text-align: left;
@@ -199,8 +199,8 @@
     content: '';
     display: block;
     position: absolute;
-    top: 50%;
-    left: 0;
+    inset-block-start: 50%;
+    inset-inline-start: 0;
     width: 1em;
     height: 1em;
     transition-property: border-color, background, opacity, box-shadow;

--- a/packages/odyssey/src/scss/components/_forms-context.scss
+++ b/packages/odyssey/src/scss/components/_forms-context.scss
@@ -12,7 +12,8 @@
 
 .ods-modal {
   .ods-form {
-    padding: 0;
+    padding-block: 0;
+    padding-inline: 0;
     border: 0;
   }
 

--- a/packages/odyssey/src/scss/components/_forms.scss
+++ b/packages/odyssey/src/scss/components/_forms.scss
@@ -11,11 +11,15 @@
  */
 
 .ods-form {
+  @include border-radius($base-border-radius);
+
   max-width: calc(#{$max-line-length} + #{$spacing-m} + #{$spacing-m} + 2px);
-  margin: 0 0 $spacing-m;
-  padding: $spacing-m;
+  margin-block-start: 0;
+  margin-block-end: $spacing-m;
+  margin-inline: 0;
+  padding-block: $spacing-m;
+  padding-inline: $spacing-m;
   border: 1px solid $border-color-display;
-  border-radius: $base-border-radius;
 
   &:last-child {
     margin-block-end: 0;
@@ -26,12 +30,16 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin: 0 0 $spacing-s;
+  margin-block-start: 0;
+  margin-block-end: $spacing-s;
+  margin-inline: 0;
 }
 
 .ods-form--title {
-  margin: $spacing-xs-em;
-  padding: 0;
+  margin-block: $spacing-xs-em;
+  margin-inline: $spacing-xs-em;
+  padding-block: 0;
+  padding-inline: 0;
   color: $text-heading;
   font-size: $size-title-4;
   font-weight: 600;

--- a/packages/odyssey/src/scss/components/_forms.scss
+++ b/packages/odyssey/src/scss/components/_forms.scss
@@ -18,7 +18,7 @@
   border-radius: $base-border-radius;
 
   &:last-child {
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 }
 
@@ -43,7 +43,7 @@
   justify-content: flex-end;
 
   &:not(:last-child) {
-    margin-bottom: $spacing-s;
+    margin-block-end: $spacing-s;
   }
 
   [data-readonly] & {

--- a/packages/odyssey/src/scss/components/_infobox.scss
+++ b/packages/odyssey/src/scss/components/_infobox.scss
@@ -29,7 +29,7 @@
   }
 
   &:not(:last-child) {
-    margin-bottom: $spacing-m;
+    margin-block-end: $spacing-m;
   }
 }
 
@@ -50,7 +50,7 @@
   grid-area: content;
 
   &:not(:last-child) {
-    margin-bottom: $spacing-xs;
+    margin-block-end: $spacing-xs;
   }
 }
 

--- a/packages/odyssey/src/scss/components/_infobox.scss
+++ b/packages/odyssey/src/scss/components/_infobox.scss
@@ -11,6 +11,8 @@
  */
 
 .ods-infobox {
+  @include border-radius($base-border-radius);
+
   display: grid;
   grid-template-areas:
     'icon title'
@@ -19,9 +21,9 @@
   grid-template-columns: max-content 1fr;
   width: 100%;
   max-width: calc(#{$max-line-length} + #{$spacing-m} + #{$spacing-m});
-  padding: $spacing-m;
+  padding-block: $spacing-m;
+  padding-inline: $spacing-m;
   column-gap: $spacing-s;
-  border-radius: $base-border-radius;
 
   a {
     color: $text-body;

--- a/packages/odyssey/src/scss/components/_input-field-layout.scss
+++ b/packages/odyssey/src/scss/components/_input-field-layout.scss
@@ -11,9 +11,12 @@
  */
 
 .ods-fieldset {
-  margin: 0 0 $spacing-s;
+  margin-block-start: 0;
+  margin-block-end: $spacing-s;
+  margin-inline: 0;
 
   &:last-child {
-    margin: 0;
+    margin-block: 0;
+    margin-inline: 0;
   }
 }

--- a/packages/odyssey/src/scss/components/_input-field.scss
+++ b/packages/odyssey/src/scss/components/_input-field.scss
@@ -16,7 +16,7 @@
 }
 
 .ods-field--hint {
-  margin-bottom: $spacing-xs;
+  margin-block-end: $spacing-xs;
   color: $text-body;
 
   .ods-text-input:disabled ~ &,
@@ -28,7 +28,7 @@
 .ods-field--error {
   display: flex;
   align-items: center;
-  margin-top: $spacing-xs;
+  margin-block-start: $spacing-xs;
   color: $text-danger;
 }
 
@@ -52,7 +52,7 @@
   .ods-label,
   .ods-input-legend {
     order: 1;
-    margin-bottom: $spacing-xs;
+    margin-block-end: $spacing-xs;
   }
 
   .ods-number-input,
@@ -71,10 +71,10 @@
   /* stylelint-disable-next-line no-descending-specificity  */
   .ods-field--hint {
     order: 2;
-    margin-bottom: $spacing-xs;
+    margin-block-end: $spacing-xs;
 
     + .ods-label {
-      margin-bottom: 0;
+      margin-block-end: 0;
     }
   }
 
@@ -92,7 +92,7 @@
   }
 
   .ods-text-input {
-    border-right: 0;
+    border-inline-end: 0;
     border-radius: $base-border-radius 0 0 $base-border-radius;
 
     &:focus {

--- a/packages/odyssey/src/scss/components/_input-field.scss
+++ b/packages/odyssey/src/scss/components/_input-field.scss
@@ -88,12 +88,18 @@
   max-width: $max-line-length;
 
   .ods-button {
-    border-radius: 0 $base-border-radius $base-border-radius 0;
+    border-start-start-radius: 0;
+    border-start-end-radius: $base-border-radius;
+    border-end-start-radius: 0;
+    border-end-end-radius: $base-border-radius;
   }
 
   .ods-text-input {
     border-inline-end: 0;
-    border-radius: $base-border-radius 0 0 $base-border-radius;
+    border-start-start-radius: $base-border-radius;
+    border-start-end-radius: 0;
+    border-end-start-radius: $base-border-radius;
+    border-end-end-radius: 0;
 
     &:focus {
       z-index: 1;
@@ -110,7 +116,9 @@
 }
 
 .ods-group-legend {
-  margin: 0 0 $spacing-xs-em;
+  margin-block-start: 0;
+  margin-block-end: $spacing-xs-em;
+  margin-inline: 0;
   color: $text-heading;
   font-size: $size-title-5;
   font-weight: 600;

--- a/packages/odyssey/src/scss/components/_input-field.scss
+++ b/packages/odyssey/src/scss/components/_input-field.scss
@@ -65,7 +65,8 @@
   }
 
   .ods-input--unavailable {
-    margin: 0;
+    margin-block: 0;
+    margin-inline: 0;
   }
 
   /* stylelint-disable-next-line no-descending-specificity  */
@@ -109,7 +110,9 @@
 
 /* stylelint-disable-next-line no-descending-specificity  */
 .ods-input-legend {
-  margin: 0 0 $spacing-xs-em;
+  margin-block-start: 0;
+  margin-block-end: $spacing-xs-em;
+  margin-inline: 0;
   color: $text-heading;
   font-size: $size-body-base;
   font-weight: 600;

--- a/packages/odyssey/src/scss/components/_modal.scss
+++ b/packages/odyssey/src/scss/components/_modal.scss
@@ -24,12 +24,15 @@
 }
 
 .ods-modal--dialog {
+  @include border-radius($base-border-radius);
+
   position: relative;
   max-width: calc(#{$max-line-length} + #{$spacing-m} + #{$spacing-m});
   max-height: calc(100vh - #{$spacing-m});
-  padding: $spacing-m  $spacing-m 0;
+  padding-block-start: $spacing-m;
+  padding-block-end: 0;
+  padding-inline: $spacing-m;
   overflow-y: auto;
-  border-radius: $base-border-radius;
   background-color: $white;
 }
 
@@ -53,7 +56,9 @@
 }
 
 .ods-modal--content {
-  padding: $spacing-xs 0 $spacing-l;
+  padding-block-start: $spacing-xs;
+  padding-block-end: $spacing-l;
+  padding-inline: 0;
   font-size: $size-body-base;
 }
 

--- a/packages/odyssey/src/scss/components/_modal.scss
+++ b/packages/odyssey/src/scss/components/_modal.scss
@@ -14,10 +14,10 @@
   display: flex;
   position: fixed;
   z-index: 10;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  inset-block-start: 0;
+  inset-inline-end: 0;
+  inset-block-end: 0;
+  inset-inline-start: 0;
   align-items: center;
   justify-content: center;
   background: rgba(cv('gray', '900'), 0.75);
@@ -40,12 +40,12 @@
 
 .ods-modal--dismiss {
   align-self: flex-end;
-  margin-bottom: $spacing-xs;
+  margin-block-end: $spacing-xs;
 }
 
 .ods-modal--title {
-  margin-top: 0;
-  margin-bottom: 0;
+  margin-block-start: 0;
+  margin-block-end: 0;
   color: $text-heading;
   font-size: $size-title-4;
   font-weight: 600;
@@ -60,7 +60,7 @@
 .ods-modal--footer {
   display: flex;
   justify-content: flex-end;
-  padding-bottom: $spacing-m;
+  padding-block-end: $spacing-m;
 }
 
 // Animations

--- a/packages/odyssey/src/scss/components/_radio-button-layout.scss
+++ b/packages/odyssey/src/scss/components/_radio-button-layout.scss
@@ -12,6 +12,6 @@
 
 .ods-radio--label {
   &:last-child {
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 }

--- a/packages/odyssey/src/scss/components/_radio-button.scss
+++ b/packages/odyssey/src/scss/components/_radio-button.scss
@@ -134,8 +134,8 @@
 .ods-radio--label {
   display: block;
   position: relative;
-  margin-bottom: $spacing-xs;
-  padding-left: 1em + $spacing-s-em;
+  margin-block-end: $spacing-xs;
+  padding-inline-start: 1em + $spacing-s-em;
   font-size: $size-body-base;
   font-weight: 400;
   text-align: left;
@@ -145,8 +145,8 @@
     content: '';
     display: block;
     position: absolute;
-    top: 50%;
-    left: 0;
+    inset-block-start: 50%;
+    inset-inline-start: 0;
     width: 1em;
     height: 1em;
     transition-property: border-color, background, opacity, box-shadow;

--- a/packages/odyssey/src/scss/components/_radio-button.scss
+++ b/packages/odyssey/src/scss/components/_radio-button.scss
@@ -138,7 +138,7 @@
   padding-inline-start: 1em + $spacing-s-em;
   font-size: $size-body-base;
   font-weight: 400;
-  text-align: left;
+  text-align: start;
 
   &::before,
   &::after {

--- a/packages/odyssey/src/scss/components/_radio-button.scss
+++ b/packages/odyssey/src/scss/components/_radio-button.scss
@@ -142,6 +142,8 @@
 
   &::before,
   &::after {
+    @include border-radius(1.125rem);
+
     content: '';
     display: block;
     position: absolute;
@@ -153,7 +155,6 @@
     transition-duration: $base-duration;
     transition-timing-function: $base-timing;
     border: 2px solid transparent;
-    border-radius: 1.125rem;
   }
 
   // Box

--- a/packages/odyssey/src/scss/components/_select.scss
+++ b/packages/odyssey/src/scss/components/_select.scss
@@ -20,7 +20,8 @@
   appearance: none;
 
   option {
-    padding: 0;
+    padding-block: 0;
+    padding-inline: 0;
   }
 
   &[multiple] {

--- a/packages/odyssey/src/scss/components/_status-layout.scss
+++ b/packages/odyssey/src/scss/components/_status-layout.scss
@@ -11,9 +11,9 @@
  */
 
 .ods-status {
-  margin-bottom: $spacing-m;
+  margin-block-end: $spacing-m;
 
   &:last-child {
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 }

--- a/packages/odyssey/src/scss/components/_status.scss
+++ b/packages/odyssey/src/scss/components/_status.scss
@@ -25,6 +25,8 @@ $status-indicator-size: 1em / 2;
   color: $text-body;
 
   &::before {
+    @include border-radius(1em);
+
     content: '';
     position: absolute;
     inset-block-start: 50%;
@@ -33,7 +35,6 @@ $status-indicator-size: 1em / 2;
     height: $status-indicator-size;
     margin-inline-end: $spacing-xs;
     transform: translateY(-50%);
-    border-radius: 1em;
     background-color: cv('gray', '600');
   }
 }

--- a/packages/odyssey/src/scss/components/_status.scss
+++ b/packages/odyssey/src/scss/components/_status.scss
@@ -14,24 +14,24 @@ $status-indicator-size: 1em / 2;
 
 .ods-status--label {
   display: block;
-  margin-bottom: $spacing-xs;
+  margin-block-end: $spacing-xs;
   font-weight: 600;
 }
 
 .ods-status--value {
   position: relative;
-  padding-left: $status-indicator-size + $spacing-xs-em;
+  padding-inline-start: $status-indicator-size + $spacing-xs-em;
   background-color: transparent;
   color: $text-body;
 
   &::before {
     content: '';
     position: absolute;
-    top: 50%;
-    left: 0;
+    inset-block-start: 50%;
+    inset-inline-start: 0;
     width: $status-indicator-size;
     height: $status-indicator-size;
-    margin-right: $spacing-xs;
+    margin-inline-end: $spacing-xs;
     transform: translateY(-50%);
     border-radius: 1em;
     background-color: cv('gray', '600');

--- a/packages/odyssey/src/scss/components/_tab.scss
+++ b/packages/odyssey/src/scss/components/_tab.scss
@@ -18,8 +18,10 @@
 .ods-tabs--tab {
   display: inline-block;
   position: relative;
-  margin: 0;
-  padding: $spacing-s $spacing-s;
+  margin-block: 0;
+  margin-inline: 0;
+  padding-block: $spacing-s;
+  padding-inline: $spacing-s;
   border: 0;
   background: none;
   color: $text-body;
@@ -41,7 +43,8 @@
 }
 
 .ods-tabs--tabpanel [role='tabpanel'] {
-  padding: $spacing-l 0;
+  padding-block: $spacing-l;
+  padding-inline: 0;
 
   &:focus {
     outline: none;

--- a/packages/odyssey/src/scss/components/_tab.scss
+++ b/packages/odyssey/src/scss/components/_tab.scss
@@ -12,7 +12,7 @@
 
 .ods-tabs--tablist {
   position: relative;
-  border-bottom: 1px solid $border-color-display;
+  border-block-end: 1px solid $border-color-display;
 }
 
 .ods-tabs--tab {
@@ -31,8 +31,8 @@
     &::before {
       content: '';
       position: absolute;
-      bottom: -1px;
-      left: 0;
+      inset-block-end: -1px;
+      inset-inline-start: 0;
       width: 100%;
       height: 3px;
       background: $color-primary-base;

--- a/packages/odyssey/src/scss/components/_table.scss
+++ b/packages/odyssey/src/scss/components/_table.scss
@@ -14,7 +14,8 @@
 
 .ods-table {
   width: auto;
-  margin: 0;
+  margin-block: 0;
+  margin-inline: 0;
   border-spacing: 0;
   border-collapse: collapse;
   line-height: $title-line-height;
@@ -30,7 +31,8 @@
   td,
   th {
     max-width: $max-line-length;
-    padding: $spacing-s;
+    padding-block: $spacing-s;
+    padding-inline: $spacing-s;
     text-align: start;
     vertical-align: baseline;
     overflow-wrap: break-word;
@@ -90,7 +92,8 @@
     position: relative;
     align-items: center;
     width: 100%;
-    padding: 0;
+    padding-block: 0;
+    padding-inline: 0;
     border: 0;
     background: none;
     font-family: inherit;
@@ -178,7 +181,8 @@
   overflow-x: auto;
 
   &:last-child {
-    margin: 0;
+    margin-block: 0;
+    margin-inline: 0;
   }
 
   .ods-table--figcaption {

--- a/packages/odyssey/src/scss/components/_table.scss
+++ b/packages/odyssey/src/scss/components/_table.scss
@@ -76,7 +76,8 @@
       tr {
         td {
           max-width: 100%;
-          padding: $spacing-l $spacing-xl;
+          padding-block: $spacing-l;
+          padding-inline: $spacing-xl;
           background: cv('gray', '000');
           color: $text-sub;
           text-align: center;
@@ -102,7 +103,9 @@
   .is-ods-table-unsorted,
   .is-ods-table-asc,
   .is-ods-table-desc {
-    padding: 0 calc(1em + #{$spacing-s}) 0 0;
+    padding-block: 0;
+    padding-inline-start: 0;
+    padding-inline-end: calc(1em + #{$spacing-s});
 
     &::after {
       content: '';
@@ -111,7 +114,9 @@
       inset-inline-end: 0;
       width: 1em;
       height: 1em;
-      margin: 0 0 0 $spacing-s;
+      margin-block: 0;
+      margin-inline-start: $spacing-s;
+      margin-inline-end: 0;
       transform: translateY(-50%) scale(0.75);
       background-repeat: no-repeat;
       background-position: center;
@@ -166,7 +171,9 @@
 
 .ods-table--figure {
   max-width: 100%;
-  margin: 0 0 $type-margin;
+  margin-block-start: 0;
+  margin-block-end: $type-margin;
+  margin-inline: 0;
   // OQ: Type margin or fixed margin?
   overflow-x: auto;
 

--- a/packages/odyssey/src/scss/components/_table.scss
+++ b/packages/odyssey/src/scss/components/_table.scss
@@ -31,7 +31,7 @@
   th {
     max-width: $max-line-length;
     padding: $spacing-s;
-    text-align: left;
+    text-align: start;
     vertical-align: baseline;
     overflow-wrap: break-word;
   }
@@ -144,7 +144,7 @@
   }
 
   .is-ods-table-num {
-    text-align: right;
+    text-align: end;
     font-feature-settings: 'lnum', 'tnum';
   }
 
@@ -179,7 +179,7 @@
     color: $text-heading;
     font-size: $size-title-4;
     font-weight: 600;
-    text-align: left;
+    text-align: start;
   }
 }
 

--- a/packages/odyssey/src/scss/components/_table.scss
+++ b/packages/odyssey/src/scss/components/_table.scss
@@ -20,7 +20,7 @@
   line-height: $title-line-height;
 
   &:only-child {
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 
   caption {
@@ -43,25 +43,25 @@
 
   thead {
     th {
-      border-top: 1px solid $border-color-display;
-      border-bottom: 1px solid $border-color-display;
+      border-block-start: 1px solid $border-color-display;
+      border-block-end: 1px solid $border-color-display;
     }
   }
 
   tbody {
     [rowspan] {
-      border-bottom: 1px solid $border-color-display;
+      border-block-end: 1px solid $border-color-display;
     }
 
     tr {
       td,
       th {
-        border-bottom: 1px solid $border-color-display;
+        border-block-end: 1px solid $border-color-display;
       }
 
       &:first-child {
         [rowspan] {
-          border-top: 0;
+          border-block-start: 0;
         }
       }
     }
@@ -107,8 +107,8 @@
     &::after {
       content: '';
       position: absolute;
-      top: 50%;
-      right: 0;
+      inset-block-start: 50%;
+      inset-inline-end: 0;
       width: 1em;
       height: 1em;
       margin: 0 0 0 $spacing-s;
@@ -153,7 +153,7 @@
   }
 
   .is-ods-table-checkbox {
-    padding-right: 0;
+    padding-inline-end: 0;
 
     .u-visually-hidden {
       display: inline-block;
@@ -175,7 +175,7 @@
   }
 
   .ods-table--figcaption {
-    margin-bottom: $spacing-xs-em;
+    margin-block-end: $spacing-xs-em;
     color: $text-heading;
     font-size: $size-title-4;
     font-weight: 600;

--- a/packages/odyssey/src/scss/components/_tag.scss
+++ b/packages/odyssey/src/scss/components/_tag.scss
@@ -11,10 +11,15 @@
  */
 
 .ods-tag {
+  @include border-radius($base-border-radius);
+
   display: inline-block;
-  margin: 0 $spacing-xs $spacing-xs 0;
-  padding: 0 $spacing-xs-em;
-  border-radius: $base-border-radius;
+  margin-block-start: 0;
+  margin-block-end: $spacing-xs;
+  margin-inline-start: 0;
+  margin-inline-end: $spacing-xs;
+  padding-block: 0;
+  padding-inline: $spacing-xs-em;
   background: cv('gray', '100');
   color: $text-body;
 }

--- a/packages/odyssey/src/scss/components/_tag.scss
+++ b/packages/odyssey/src/scss/components/_tag.scss
@@ -21,7 +21,7 @@
 
 .ods-tag--list {
   display: inline-block;
-  margin-bottom: -$spacing-xs;
-  margin-left: $spacing-xs;
+  margin-block-end: -$spacing-xs;
+  margin-inline-start: $spacing-xs;
   list-style-type: none;
 }

--- a/packages/odyssey/src/scss/components/_text-input.scss
+++ b/packages/odyssey/src/scss/components/_text-input.scss
@@ -31,6 +31,10 @@
     &::-ms-reveal {
       display: none;
     }
+
+    [dir='rtl'] & {
+      background-position: right $spacing-s center;
+    }
   }
 }
 
@@ -38,5 +42,7 @@
   min-width: $spacing-m;
   max-width: $max-line-length;
   min-height: $spacing-m * 2;
-  padding: $spacing-xs-em $spacing-s-em $spacing-s-em;
+  padding-block-start: $spacing-xs-em;
+  padding-block-end: $spacing-s-em;
+  padding-inline: $spacing-s-em;
 }

--- a/packages/odyssey/src/scss/components/_text-input.scss
+++ b/packages/odyssey/src/scss/components/_text-input.scss
@@ -14,7 +14,7 @@
   @include input-baseline;
 
   &[type='search'] {
-    padding-left: ms(1) + $spacing-s + $spacing-xs;
+    padding-inline-start: ms(1) + $spacing-s + $spacing-xs;
     background-image: get-icon('search', $text-body);
     background-repeat: no-repeat;
     background-position: left $spacing-s center;

--- a/packages/odyssey/src/scss/components/_toast-pen.scss
+++ b/packages/odyssey/src/scss/components/_toast-pen.scss
@@ -14,8 +14,8 @@
   display: grid;
   position: fixed;
   z-index: 1;
-  right: $spacing-m;
-  bottom: $spacing-m;
+  inset-inline-end: $spacing-m;
+  inset-block-end: $spacing-m;
   grid-gap: $spacing-s 0;
   grid-template-columns: minmax(min-content, max-content);
   max-height: 100vh;

--- a/packages/odyssey/src/scss/components/_toast.scss
+++ b/packages/odyssey/src/scss/components/_toast.scss
@@ -41,7 +41,7 @@
   }
 
   &:last-child {
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 }
 
@@ -54,7 +54,7 @@
 
 .ods-toast--title {
   margin: 0;
-  padding-right: $spacing-m;
+  padding-inline-end: $spacing-m;
   color: $white;
   font-size: $size-body-base;
   font-weight: 600;
@@ -63,15 +63,15 @@
 
 .ods-toast--dismiss {
   position: absolute;
-  top: $spacing-xs;
-  right: $spacing-xs;
-  margin-bottom: 0;
+  inset-block-start: $spacing-xs;
+  inset-inline-end: $spacing-xs;
+  margin-block-end: 0;
   border: 0;
 }
 
 .ods-toast--body {
   grid-column: 2;
-  margin-bottom: 0;
+  margin-block-end: 0;
   font-size: $size-body-base;
 }
 

--- a/packages/odyssey/src/scss/components/_toast.scss
+++ b/packages/odyssey/src/scss/components/_toast.scss
@@ -11,18 +11,20 @@
  */
 
 .ods-toast {
+  @include border-radius($base-border-radius);
+
   display: grid;
   position: relative;
   grid-gap: 0 $spacing-s;
   grid-template-columns: min-content 1fr min-content;
   align-items: start;
   max-width: $max-line-length;
-  padding: $spacing-m $spacing-s;
+  padding-block: $spacing-m;
+  padding-inline: $spacing-s;
   animation-name: ods-toast-in, ods-toast-out;
   animation-duration: 300ms, 1000ms;
   animation-delay: 0s, 5300ms;
   border: 0;
-  border-radius: $base-border-radius;
   background-color: cv('blue', '900');
   box-shadow: 0 8px 12px rgba(cv('gray', '900'), 0.12);
   color: $white;
@@ -53,7 +55,8 @@
 }
 
 .ods-toast--title {
-  margin: 0;
+  margin-block: 0;
+  margin-inline: 0;
   padding-inline-end: $spacing-m;
   color: $white;
   font-size: $size-body-base;

--- a/packages/odyssey/src/scss/components/_tooltip.scss
+++ b/packages/odyssey/src/scss/components/_tooltip.scss
@@ -57,86 +57,86 @@
 }
 
 .is-ods-tooltip-top {
-  bottom: calc(100% + #{$spacing-s});
-  left: 50%;
+  inset-block-end: calc(100% + #{$spacing-s});
+  inset-inline-start: 50%;
   transform: translateX(-50%);
 
   &::after,
   &::before {
-    top: 100%;
-    left: 50%;
+    inset-block-start: 100%;
+    inset-inline-start: 50%;
     transform: translateX(-50%);
   }
 
   &::after {
-    border-top-color: cv('gray', '900');
+    border-block-start-color: cv('gray', '900');
   }
 
   &::before {
-    border-top-color: cv('gray', '900');
+    border-block-start-color: cv('gray', '900');
   }
 }
 
 .is-ods-tooltip-right {
-  top: 50%;
-  left: calc(100% + #{$spacing-s});
+  inset-block-start: 50%;
+  inset-inline-start: calc(100% + #{$spacing-s});
   transform: translateY(-50%);
 
   &::after,
   &::before {
-    top: 50%;
-    right: 100%;
+    inset-block-start: 50%;
+    inset-inline-end: 100%;
     transform: translateY(-50%);
   }
 
   &::after {
-    border-right-color: cv('gray', '900');
+    border-inline-end-color: cv('gray', '900');
   }
 
   &::before {
-    border-right-color: cv('gray', '900');
+    border-inline-end-color: cv('gray', '900');
   }
 }
 
 .is-ods-tooltip-bottom {
-  top: calc(100% + #{$spacing-s});
-  left: 50%;
+  inset-block-start: calc(100% + #{$spacing-s});
+  inset-inline-start: 50%;
   transform: translateX(-50%);
 
   &::after,
   &::before {
-    bottom: 100%;
-    left: 50%;
+    inset-block-end: 100%;
+    inset-inline-start: 50%;
     transform: translateX(-50%);
   }
 
   &::after {
-    border-bottom-color: cv('gray', '900');
+    border-block-end-color: cv('gray', '900');
   }
 
   &::before {
-    border-bottom-color: cv('gray', '900');
+    border-block-end-color: cv('gray', '900');
   }
 }
 
 .is-ods-tooltip-left {
-  top: 50%;
-  right: calc(100% + #{$spacing-s});
+  inset-block-start: 50%;
+  inset-inline-end: calc(100% + #{$spacing-s});
   transform: translateY(-50%);
 
   &::after,
   &::before {
-    top: 50%;
-    left: 100%;
+    inset-block-start: 50%;
+    inset-inline-start: 100%;
     transform: translateY(-50%);
   }
 
   &::after {
-    border-left-color: cv('gray', '900');
+    border-inline-start-color: cv('gray', '900');
   }
 
   &::before {
-    border-left-color: cv('gray', '900');
+    border-inline-start-color: cv('gray', '900');
   }
 }
 
@@ -151,7 +151,7 @@
     visibility: hidden;
     position: fixed;
     z-index: 1;
-    bottom: 0;
+    inset-block-end: 0;
     width: 100vw;
     border: 0;
     border-radius: 0;
@@ -182,16 +182,16 @@
   .is-ods-tooltip-right,
   .is-ods-tooltip-bottom,
   .is-ods-tooltip-left {
-    top: 0;
-    right: unset;
-    bottom: unset;
-    left: 0;
+    inset-block-start: 0;
+    inset-inline-end: unset;
+    inset-block-end: unset;
+    inset-inline-start: 0;
     transform: none;
 
     &::after,
     &::before {
-      top: 100%;
-      left: 50%;
+      inset-block-start: 100%;
+      inset-inline-start: 50%;
       transform: translateX(-50%);
       border: 0;
     }

--- a/packages/odyssey/src/scss/components/_tooltip.scss
+++ b/packages/odyssey/src/scss/components/_tooltip.scss
@@ -14,6 +14,8 @@
 // Not ready for general use.
 
 .ods-tooltip {
+  @include border-radius($base-border-radius);
+
   display: block;
   visibility: hidden;
   position: absolute;
@@ -22,7 +24,6 @@
   padding-inline: $spacing-s;
   transition: opacity $base-duration $base-timing 1s;
   border: 1px solid cv('gray', '900');
-  border-radius: $base-border-radius;
   opacity: 0;
   background: cv('gray', '900');
   color: cv('gray', '000');
@@ -166,6 +167,8 @@
 
 @media only screen and (max-width: 40rem) {
   .ods-tooltip {
+    @include border-radius(0);
+
     display: block;
     visibility: hidden;
     position: fixed;
@@ -173,7 +176,6 @@
     inset-block-end: 0;
     width: 100vw;
     border: 0;
-    border-radius: 0;
     opacity: 0;
     font-size: $size-body-caption;
     white-space: wrap;

--- a/packages/odyssey/src/scss/components/_tooltip.scss
+++ b/packages/odyssey/src/scss/components/_tooltip.scss
@@ -18,7 +18,8 @@
   visibility: hidden;
   position: absolute;
   z-index: 1;
-  padding: $spacing-xs $spacing-s;
+  padding-block: $spacing-xs;
+  padding-inline: $spacing-s;
   transition: opacity $base-duration $base-timing 1s;
   border: 1px solid cv('gray', '900');
   border-radius: $base-border-radius;
@@ -75,6 +76,15 @@
   &::before {
     border-block-start-color: cv('gray', '900');
   }
+
+  [dir='rtl'] & {
+    transform: translateX(50%);
+
+    &::after,
+    &::before {
+      transform: translateX(50%);
+    }
+  }
 }
 
 .is-ods-tooltip-right {
@@ -116,6 +126,15 @@
 
   &::before {
     border-block-end-color: cv('gray', '900');
+  }
+
+  [dir='rtl'] & {
+    transform: translateX(50%);
+
+    &::after,
+    &::before {
+      transform: translateX(50%);
+    }
   }
 }
 
@@ -194,6 +213,10 @@
       inset-inline-start: 50%;
       transform: translateX(-50%);
       border: 0;
+
+      [dir='rtl'] & {
+        transform: translateX(50%);
+      }
     }
   }
 }

--- a/packages/odyssey/src/scss/vendors-ext/_choices-ext.scss
+++ b/packages/odyssey/src/scss/vendors-ext/_choices-ext.scss
@@ -26,7 +26,8 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   &:focus,
   &.is-ods-select-focused,
   .is-ods-select-focus & {
-    border-radius: $base-border-radius;
+    @include border-radius($base-border-radius);
+
     outline: none;
     box-shadow: 0 0 0 4px $color-primary-light;
 
@@ -75,8 +76,8 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
     &:focus,
     &.is-ods-select-focused {
       @include outline($focus-ring-danger);
+      @include border-radius($base-border-radius);
 
-      border-radius: $base-border-radius;
       outline: none;
 
       &.is-ods-select-open {
@@ -104,14 +105,19 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   .ods-select--input {
     display: inline-block;
     width: 100%;
-    margin: 0 0 $spacing-xs;
-    padding: 0;
+    margin-block-start: 0;
+    margin-block-end: $spacing-xs;
+    margin-inline: 0;
+    padding-block: 0;
+    padding-inline: 0;
     border-block-end: 0;
     background-color: transparent;
     vertical-align: top;
   }
 
   .ods-select--button {
+    @include border-radius(10em);
+
     position: absolute;
     inset-block-start: 50%;
     inset-inline-end: 0;
@@ -119,8 +125,8 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
     height: 20px;
     margin-block-start: -$spacing-s;
     margin-inline-end: 25px;
-    padding: 0;
-    border-radius: 10em;
+    padding-block: 0;
+    padding-inline: 0;
     opacity: 0.25;
     background-image: $choices-icon-cross-inverse;
     background-size: 8px;
@@ -188,6 +194,8 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   }
 
   .ods-select--button {
+    @include border-radius(100%);
+
     display: inline-block;
     position: relative;
     width: 1em;
@@ -196,8 +204,8 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
     margin-inline-end: 0;
     margin-block-end: 0;
     margin-inline-start: $spacing-s;
-    padding: 0;
-    border-radius: 100%;
+    padding-block: 0;
+    padding-inline: 0;
     opacity: 1;
     background-color: cv('blue', '400');
     background-image: get-icon('close', $white);
@@ -213,6 +221,8 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
 }
 
 .ods-select--inner {
+  @include border-radius($base-border-radius);
+
   display: inline-block;
   width: 100%;
   padding-block: $spacing-xs-em;
@@ -222,7 +232,6 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   transition-duration: $base-duration;
   transition-timing-function: $base-timing;
   border: 1px solid $border-color-ui;
-  border-radius: $base-border-radius;
   background-color: $white;
   box-shadow: 0 0 0 0 $color-primary-light;
   color: $text-body;
@@ -260,7 +269,8 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
 }
 
 .ods-select--list {
-  margin: 0;
+  margin-block: 0;
+  margin-inline: 0;
   padding-inline-start: 0;
   list-style: none;
 }
@@ -283,13 +293,14 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   display: inline;
 
   .ods-select--item {
+    @include border-radius(1em);
+
     display: inline-block;
     margin-inline-end: $spacing-xs;
     margin-block-end: $spacing-xs;
     padding-block: 0;
     padding-inline: $spacing-s;
     border: 1px solid $color-primary-light;
-    border-radius: 1em;
     background-color: cv('blue', '000');
     color: $text-body;
     font-size: $size-body-base;
@@ -468,6 +479,8 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
 }
 
 .ods-select--input {
+  @include border-radius(0);
+
   display: inline-block;
   max-width: 100%;
   margin-block-end: 5px;
@@ -475,7 +488,6 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   padding-inline-start: 2px;
   padding-inline-end: 0;
   border: 0;
-  border-radius: 0;
   background-color: $white;
   vertical-align: baseline;
 

--- a/packages/odyssey/src/scss/vendors-ext/_choices-ext.scss
+++ b/packages/odyssey/src/scss/vendors-ext/_choices-ext.scss
@@ -40,7 +40,7 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   }
 
   &:last-child {
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 
   &.is-ods-select-open {
@@ -106,19 +106,19 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
     width: 100%;
     margin: 0 0 $spacing-xs;
     padding: 0;
-    border-bottom: 0;
+    border-block-end: 0;
     background-color: transparent;
     vertical-align: top;
   }
 
   .ods-select--button {
     position: absolute;
-    top: 50%;
-    right: 0;
+    inset-block-start: 50%;
+    inset-inline-end: 0;
     width: 20px;
     height: 20px;
-    margin-top: -$spacing-s;
-    margin-right: 25px;
+    margin-block-start: -$spacing-s;
+    margin-inline-end: 25px;
     padding: 0;
     border-radius: 10em;
     opacity: 0.25;
@@ -142,8 +142,8 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   &::after {
     content: '';
     position: absolute;
-    top: 50%;
-    right: $spacing-s-em;
+    inset-block-start: 50%;
+    inset-inline-end: $spacing-s-em;
     width: $size-body-caption;
     height: $size-body-caption;
     transform: translateY(-50%);
@@ -161,15 +161,15 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
 
   &[dir='rtl'] {
     &::after {
-      right: auto;
-      left: 11.5px;
+      inset-inline-end: auto;
+      inset-inline-start: 11.5px;
     }
 
     .ods-select--button {
-      right: auto;
-      left: 0;
-      margin-right: 0;
-      margin-left: 25px;
+      inset-inline-end: auto;
+      inset-inline-start: 0;
+      margin-inline-end: 0;
+      margin-inline-start: 25px;
     }
   }
 }
@@ -183,7 +183,7 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
 .ods-select[data-type*='select-multiple'],
 .ods-select[data-type*='text'] {
   .ods-select--inner {
-    padding-bottom: 0;
+    padding-block-end: 0;
     cursor: text;
   }
 
@@ -192,10 +192,10 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
     position: relative;
     width: 1em;
     height: 1em;
-    margin-top: 0;
-    margin-right: 0;
-    margin-bottom: 0;
-    margin-left: $spacing-s;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: $spacing-s;
     padding: 0;
     border-radius: 100%;
     opacity: 1;
@@ -241,20 +241,20 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   .is-ods-select-open &,
   .is-ods-select-invalid .is-ods-select-open & {
     border-radius: $base-border-radius $base-border-radius 0 0;
-    border-bottom-color: $border-color-ui;
+    border-block-end-color: $border-color-ui;
   }
 
   .is-ods-select-flipped.is-ods-select-open &,
   .is-ods-select-invalid .is-ods-select-flipped.is-ods-select-open & {
     border-radius: 0 0 $base-border-radius $base-border-radius;
-    border-top-color: $border-color-ui;
-    border-bottom-color: $color-primary-base;
+    border-block-start-color: $border-color-ui;
+    border-block-end-color: $color-primary-base;
   }
 }
 
 .ods-select--list {
   margin: 0;
-  padding-left: 0;
+  padding-inline-start: 0;
   list-style: none;
 }
 
@@ -263,8 +263,8 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   width: 100%;
 
   [dir='rtl'] & {
-    //padding-right: 4px;
-    //padding-left: 16px;
+    //padding-inline-end: 4px;
+    //padding-inline-start: 16px;
   }
 
   .ods-select--item {
@@ -277,8 +277,8 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
 
   .ods-select--item {
     display: inline-block;
-    margin-right: $spacing-xs;
-    margin-bottom: $spacing-xs;
+    margin-inline-end: $spacing-xs;
+    margin-block-end: $spacing-xs;
     padding: 0 $spacing-s;
     border: 1px solid $color-primary-light;
     border-radius: 1em;
@@ -291,12 +291,12 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
     vertical-align: middle;
 
     &[data-deletable] {
-      padding-right: $spacing-xs;
+      padding-inline-end: $spacing-xs;
     }
 
     [dir='rtl'] & {
-      margin-right: 0;
-      margin-left: $spacing-xs;
+      margin-inline-end: 0;
+      margin-inline-start: $spacing-xs;
     }
 
     &.is-ods-select-highlighted {
@@ -314,13 +314,13 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   visibility: hidden;
   position: absolute;
   z-index: 1;
-  top: 100%;
+  inset-block-start: 100%;
   width: 100%;
   overflow: hidden;
   border: 1px solid $border-color-ui;
-  border-top-width: 0;
-  border-bottom-right-radius: $base-border-radius;
-  border-bottom-left-radius: $base-border-radius;
+  border-block-start-width: 0;
+  border-block-end-right-radius: $base-border-radius;
+  border-block-end-left-radius: $base-border-radius;
   background-color: $white;
   word-break: break-all;
   will-change: visibility;
@@ -340,10 +340,10 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   }
 
   .is-ods-select-flipped & {
-    top: auto;
-    bottom: 100%;
-    border-bottom: 0;
-    border-top-width: 1px;
+    inset-block-start: auto;
+    inset-block-end: 100%;
+    border-block-end: 0;
+    border-block-start-width: 1px;
     border-radius: $base-border-radius $base-border-radius 0 0;
   }
 
@@ -375,26 +375,26 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
 
   .ods-select--item--selectable {
     @media (min-width: 640px) {
-      padding-right: 100px;
+      padding-inline-end: 100px;
 
       &::after {
         content: attr(data-select-text);
         position: absolute;
-        top: 50%;
-        right: $spacing-s;
+        inset-block-start: 50%;
+        inset-inline-end: $spacing-s;
         transform: translateY(-50%);
         opacity: 0;
         font-size: $size-body-caption;
       }
 
       [dir='rtl'] & {
-        padding-right: $spacing-s;
-        padding-left: 100px;
+        padding-inline-end: $spacing-s;
+        padding-inline-start: 100px;
         text-align: right;
 
         &::after {
-          right: auto;
-          left: $spacing-s;
+          inset-inline-end: auto;
+          inset-inline-start: $spacing-s;
         }
       }
     }
@@ -454,7 +454,7 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
 .ods-select--input {
   display: inline-block;
   max-width: 100%;
-  margin-bottom: 5px;
+  margin-block-end: 5px;
   padding: 4px 0 4px 2px;
   border: 0;
   border-radius: 0;
@@ -466,8 +466,8 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   }
 
   [dir='rtl'] & {
-    padding-right: 2px;
-    padding-left: 0;
+    padding-inline-end: 2px;
+    padding-inline-start: 0;
   }
 }
 

--- a/packages/odyssey/src/scss/vendors-ext/_choices-ext.scss
+++ b/packages/odyssey/src/scss/vendors-ext/_choices-ext.scss
@@ -365,7 +365,7 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
     font-size: $size-body-base;
 
     [dir='rtl'] & {
-      text-align: right;
+      text-align: end;
     }
 
     &:empty {
@@ -390,7 +390,7 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
       [dir='rtl'] & {
         padding-inline-end: $spacing-s;
         padding-inline-start: 100px;
-        text-align: right;
+        text-align: end;
 
         &::after {
           inset-inline-end: auto;

--- a/packages/odyssey/src/scss/vendors-ext/_choices-ext.scss
+++ b/packages/odyssey/src/scss/vendors-ext/_choices-ext.scss
@@ -215,7 +215,8 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
 .ods-select--inner {
   display: inline-block;
   width: 100%;
-  padding: $spacing-xs-em $spacing-s-em;
+  padding-block: $spacing-xs-em;
+  padding-inline: $spacing-s-em;
   overflow: hidden;
   transition-property: border-color, background-color, box-shadow;
   transition-duration: $base-duration;
@@ -240,13 +241,19 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
 
   .is-ods-select-open &,
   .is-ods-select-invalid .is-ods-select-open & {
-    border-radius: $base-border-radius $base-border-radius 0 0;
+    border-start-start-radius: $base-border-radius;
+    border-start-end-radius: $base-border-radius;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border-block-end-color: $border-color-ui;
   }
 
   .is-ods-select-flipped.is-ods-select-open &,
   .is-ods-select-invalid .is-ods-select-flipped.is-ods-select-open & {
-    border-radius: 0 0 $base-border-radius $base-border-radius;
+    border-start-start-radius: 0;
+    border-start-end-radius: 0;
+    border-end-start-radius: $base-border-radius;
+    border-end-end-radius: $base-border-radius;
     border-block-start-color: $border-color-ui;
     border-block-end-color: $color-primary-base;
   }
@@ -279,7 +286,8 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
     display: inline-block;
     margin-inline-end: $spacing-xs;
     margin-block-end: $spacing-xs;
-    padding: 0 $spacing-s;
+    padding-block: 0;
+    padding-inline: $spacing-s;
     border: 1px solid $color-primary-light;
     border-radius: 1em;
     background-color: cv('blue', '000');
@@ -319,8 +327,10 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   overflow: hidden;
   border: 1px solid $border-color-ui;
   border-block-start-width: 0;
+  border-start-start-radius: 0;
+  border-start-end-radius: 0;
+  border-end-start-radius: $base-border-radius;
   border-end-end-radius: $base-border-radius;
-  border-start-end-radius: $base-border-radius;
   background-color: $white;
   word-break: break-all;
   will-change: visibility;
@@ -344,7 +354,10 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
     inset-block-end: 100%;
     border-block-end: 0;
     border-block-start-width: 1px;
-    border-radius: $base-border-radius $base-border-radius 0 0;
+    border-start-start-radius: $base-border-radius;
+    border-start-end-radius: $base-border-radius;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
   }
 
   .is-ods-select-flipped.is-ods-select-focused & {
@@ -361,7 +374,8 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
 
   .ods-select--item {
     position: relative;
-    padding: $spacing-xs	$spacing-s;
+    padding-block: $spacing-xs;
+    padding-inline: $spacing-s;
     font-size: $size-body-base;
 
     [dir='rtl'] & {
@@ -432,7 +446,9 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
 }
 
 .ods-select--heading {
-  padding: $spacing-s $spacing-s 0;
+  padding-block-start: $spacing-s;
+  padding-block-end: 0;
+  padding-inline: $spacing-s;
   color: $text-sub;
   font-size: $size-body-caption;
   font-weight: 600;
@@ -455,7 +471,9 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   display: inline-block;
   max-width: 100%;
   margin-block-end: 5px;
-  padding: 4px 0 4px 2px;
+  padding-block: 4px;
+  padding-inline-start: 2px;
+  padding-inline-end: 0;
   border: 0;
   border-radius: 0;
   background-color: $white;

--- a/packages/odyssey/src/scss/vendors-ext/_choices-ext.scss
+++ b/packages/odyssey/src/scss/vendors-ext/_choices-ext.scss
@@ -319,8 +319,8 @@ $choices-icon-cross-inverse: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEi
   overflow: hidden;
   border: 1px solid $border-color-ui;
   border-block-start-width: 0;
-  border-block-end-right-radius: $base-border-radius;
-  border-block-end-left-radius: $base-border-radius;
+  border-end-end-radius: $base-border-radius;
+  border-start-end-radius: $base-border-radius;
   background-color: $white;
   word-break: break-all;
   will-change: visibility;

--- a/packages/prism-theme-odyssey/src/theme.scss
+++ b/packages/prism-theme-odyssey/src/theme.scss
@@ -198,7 +198,7 @@ pre[class*='language-'] > code[class*='language-'] {
   position: absolute;
   z-index: 0;
   inset-inline-end: 0;
-  left: 0;
+  inset-inline-start: 0;
   margin-block-start: 1em;
   padding: inherit 0;
   background: var(--highlightBackground);

--- a/packages/prism-theme-odyssey/src/theme.scss
+++ b/packages/prism-theme-odyssey/src/theme.scss
@@ -48,7 +48,7 @@ code[class*='language-'] {
   font-family: 'Inconsolata', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
   font-size: var(--font-size);
   line-height: 1.5;
-  text-align: left;
+  text-align: start;
   text-shadow: none;
   word-break: normal;
   white-space: pre;

--- a/packages/prism-theme-odyssey/src/theme.scss
+++ b/packages/prism-theme-odyssey/src/theme.scss
@@ -87,8 +87,10 @@ code[class*='language-']::mozselection {
 /* stylelint-disable selector-no-qualifying-type, no-descending-specificity */
 pre[class*='language-'] {
   /* stylelint-enable selector-no-qualifying-type, no-descending-specificity */
-  margin: 0.5em 0;
-  padding: 1em;
+  margin-block: 0.5em;
+  margin-inline: 0;
+  padding-block: 1em;
+  padding-inline: 1em;
   overflow: auto;
   background: var(--blockBackground);
 }
@@ -96,8 +98,10 @@ pre[class*='language-'] {
 /* stylelint-disable selector-no-qualifying-type */
 :not(pre) > code[class*='language-'] {
   /* stylelint-enable selector-no-qualifying-type */
-  padding: 0.1em 0.3em;
-  border-radius: 0.3em;
+  @include border-radius(0.3em);
+
+  padding-block: 0.1em;
+  padding-inline: 0.3em;
   background: var(--inlineCodeBackground);
   color: var(--inlineCodeColor);
 }
@@ -200,7 +204,8 @@ pre[class*='language-'] > code[class*='language-'] {
   inset-inline-end: 0;
   inset-inline-start: 0;
   margin-block-start: 1em;
-  padding: inherit 0;
+  padding-block: inherit;
+  padding-inline: 0;
   background: var(--highlightBackground);
   box-shadow: inset 5px 0 0 var(--highlightAccent);
   line-height: inherit;

--- a/packages/prism-theme-odyssey/src/theme.scss
+++ b/packages/prism-theme-odyssey/src/theme.scss
@@ -197,9 +197,9 @@ pre[class*='language-'] > code[class*='language-'] {
 .line-highlight {
   position: absolute;
   z-index: 0;
-  right: 0;
+  inset-inline-end: 0;
   left: 0;
-  margin-top: 1em;
+  margin-block-start: 1em;
   padding: inherit 0;
   background: var(--highlightBackground);
   box-shadow: inset 5px 0 0 var(--highlightAccent);

--- a/packages/prism-theme-odyssey/src/utils/CustomPropertyInspector.js
+++ b/packages/prism-theme-odyssey/src/utils/CustomPropertyInspector.js
@@ -48,8 +48,8 @@ class CustomPropertyInspector {
     inspector.classList.add('custom-properties-inspector');
     inspector.style = `
       position: sticky;
-      top: 0;
-      border-right: 5px solid #f5f5f6;
+      inset-block-start: 0;
+      border-inline-end: 5px solid #f5f5f6;
       padding:  3.42857rem 1.71429rem;
       max-height: 100vh;
       overflow: scroll;
@@ -58,7 +58,7 @@ class CustomPropertyInspector {
 
     const inspectorTitle = document.createElement('h5');
     inspectorTitle.innerHTML = "Custom Properties Inspector";
-    inspectorTitle.style = "margin-bottom: 2rem;";
+    inspectorTitle.style = "margin-block-end: 2rem;";
     inspector.appendChild(inspectorTitle);
 
     const inspectorReset = document.createElement('button');

--- a/packages/vuepress-theme-odyssey/package.json
+++ b/packages/vuepress-theme-odyssey/package.json
@@ -10,14 +10,7 @@
     "eslint-config-vuepress": "^2.2.0",
     "html-loader": "^1.1.0",
     "node-sass": "4.13.1",
-    "sass-loader": "8.0.2",
-    "stylelint": "^13.13.1",
-    "stylelint-checkstyle-formatter": "^0.1.1",
-    "stylelint-config-recommended": "^5.0.0",
-    "stylelint-config-sass-guidelines": "^8.0.0",
-    "stylelint-config-standard": "^22.0.0",
-    "stylelint-order": "^4.1.0",
-    "stylelint-scss": "^3.19.0"
+    "sass-loader": "8.0.2"
   },
   "dependencies": {
     "@okta/odyssey": "^0.7.0",

--- a/packages/vuepress-theme-odyssey/package.json
+++ b/packages/vuepress-theme-odyssey/package.json
@@ -11,13 +11,13 @@
     "html-loader": "^1.1.0",
     "node-sass": "4.13.1",
     "sass-loader": "8.0.2",
-    "stylelint": "^9.3.0",
+    "stylelint": "^13.13.1",
     "stylelint-checkstyle-formatter": "^0.1.1",
-    "stylelint-config-recommended": "^2.1.0",
-    "stylelint-config-sass-guidelines": "^5.0.0",
-    "stylelint-config-standard": "^18.2.0",
-    "stylelint-order": "^0.8.1",
-    "stylelint-scss": "^3.2.0"
+    "stylelint-config-recommended": "^5.0.0",
+    "stylelint-config-sass-guidelines": "^8.0.0",
+    "stylelint-config-standard": "^22.0.0",
+    "stylelint-order": "^4.1.0",
+    "stylelint-scss": "^3.19.0"
   },
   "dependencies": {
     "@okta/odyssey": "^0.7.0",

--- a/packages/vuepress-theme-odyssey/styles/_shame.scss
+++ b/packages/vuepress-theme-odyssey/styles/_shame.scss
@@ -14,5 +14,5 @@
 // Can be removed when type scale / heading margins are fixed.
 
 h2 + .docskit-figure-anatomy {
-  //margin-top: $spacing-xs;
+  //margin-block-start: $spacing-xs;
 }

--- a/packages/vuepress-theme-odyssey/styles/abstracts/_functions.scss
+++ b/packages/vuepress-theme-odyssey/styles/abstracts/_functions.scss
@@ -11,7 +11,7 @@
  */
 
 $z-index: (
-  top: 9999,
+  inset-block-start: 9999,
   sidebar: 3,
   topbar: 2,
   base: 1,

--- a/packages/vuepress-theme-odyssey/styles/components/_DocsCard.scss
+++ b/packages/vuepress-theme-odyssey/styles/components/_DocsCard.scss
@@ -11,7 +11,7 @@
  */
 
 .docs-card {
-  @include border-radius(0, 0, 32px, 32px);
+  @include border-radius(0, 32px, 0, 32px);
 
   display: flex;
   position: relative;
@@ -41,7 +41,7 @@
     &::before {
       // NOTE: 32px is sort of an arbitrary value,
       // and only used within this component.
-      @include border-radius(0, 0, 32px, 32px);
+      @include border-radius(0, 32px, 0, 32px);
 
       content: '';
       display: block;

--- a/packages/vuepress-theme-odyssey/styles/components/_DocsCard.scss
+++ b/packages/vuepress-theme-odyssey/styles/components/_DocsCard.scss
@@ -11,12 +11,14 @@
  */
 
 .docs-card {
+  @include border-radius(0, 0, 32px, 32px);
+
   display: flex;
   position: relative;
   flex-direction: column;
-  padding: $spacing-l $spacing-m;
+  padding-block: $spacing-l;
+  padding-inline: $spacing-m;
   transition: 0.33s ease-in-out box-shadow;
-  border-radius: 0 32px;
   background-color: var(--docs-card-bg, $white);
   font-size: $size-body-base;
 
@@ -30,12 +32,17 @@
   }
 
   &.is-docs-card-transparent {
-    padding: 0;
+    padding-block: 0;
+    padding-inline: 0;
     background: transparent;
   }
 
   a {
     &::before {
+      // NOTE: 32px is sort of an arbitrary value,
+      // and only used within this component.
+      @include border-radius(0, 0, 32px, 32px);
+
       content: '';
       display: block;
       position: absolute;
@@ -43,10 +50,6 @@
       inset-inline-end: 0;
       inset-block-end: 0;
       inset-inline-start: 0;
-
-      // NOTE: 32px is sort of an arbitrary value,
-      // and only used within this component.
-      border-radius: 0 32px;
     }
   }
 

--- a/packages/vuepress-theme-odyssey/styles/components/_DocsCard.scss
+++ b/packages/vuepress-theme-odyssey/styles/components/_DocsCard.scss
@@ -39,10 +39,10 @@
       content: '';
       display: block;
       position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
+      inset-block-start: 0;
+      inset-inline-end: 0;
+      inset-block-end: 0;
+      inset-inline-start: 0;
 
       // NOTE: 32px is sort of an arbitrary value,
       // and only used within this component.
@@ -51,7 +51,7 @@
   }
 
   .docs-card--header-image {
-    margin-bottom: $spacing-m;
+    margin-block-end: $spacing-m;
 
     svg {
       height: auto;
@@ -60,7 +60,7 @@
 
   .docs-card--main {
     flex: 1;
-    margin-bottom: $spacing-l;
+    margin-block-end: $spacing-l;
     font-size: $size-body-base;
   }
 

--- a/packages/vuepress-theme-odyssey/styles/components/_DocsCardGroup.scss
+++ b/packages/vuepress-theme-odyssey/styles/components/_DocsCardGroup.scss
@@ -15,7 +15,7 @@
   grid-column-gap: $spacing-m;
   grid-row-gap: $spacing-l;
   grid-template-columns: repeat(auto-fit, minmax($max-line-length / 2, 1fr));
-  margin-bottom: $spacing-xl;
+  margin-block-end: $spacing-xl;
 
   &.is-2col {
     grid-template-columns: 1fr 1fr;

--- a/packages/vuepress-theme-odyssey/styles/components/_DocsLink.scss
+++ b/packages/vuepress-theme-odyssey/styles/components/_DocsLink.scss
@@ -14,7 +14,7 @@
 a.docs-link--underlined,
 a.docs-link--underlined:visited {
   /* stylelint-enable selector-no-qualifying-type */
-  border-bottom: 1px solid var(--docs-text-heading, #{$text-heading});
+  border-block-end: 1px solid var(--docs-text-heading, #{$text-heading});
   color: var(--docs-text-heading, #{$text-heading});
   text-decoration-color: var(--docs-text-heading, #{$text-heading});
   text-underline-offset: $spacing-xs;

--- a/packages/vuepress-theme-odyssey/styles/components/_DocsNav.scss
+++ b/packages/vuepress-theme-odyssey/styles/components/_DocsNav.scss
@@ -12,8 +12,9 @@
 
 // This selector is applied to the nav when it is overflowing
 .with-docs-subnav-indicator {
+  @include border-radius( 0 );
+
   transition: none;
-  border-radius: 0;
 
   &::before {
     content: '';
@@ -38,7 +39,8 @@
     display: block;
     align-items: center;
     justify-content: space-between;
-    padding: 0 $spacing-xs;
+    padding-block: 0;
+    padding-inline: $spacing-xs;
     font-size: $size-body-base;
     text-decoration: none;
   }
@@ -60,8 +62,9 @@
   a,
   /* stylelint-enable no-descending-specificity */
   a:visited {
-    padding: 0 $spacing-s;
+    padding-block: 0;
     padding-inline-start: $spacing-m;
+    padding-inline-end: $spacing-s;
   }
 
   a:hover {

--- a/packages/vuepress-theme-odyssey/styles/components/_DocsNav.scss
+++ b/packages/vuepress-theme-odyssey/styles/components/_DocsNav.scss
@@ -54,14 +54,14 @@
 
 .docs-nav--subnav {
   display: none;
-  margin-bottom: $spacing-s;
+  margin-block-end: $spacing-s;
 
   /* stylelint-disable no-descending-specificity */
   a,
   /* stylelint-enable no-descending-specificity */
   a:visited {
     padding: 0 $spacing-s;
-    padding-left: $spacing-m;
+    padding-inline-start: $spacing-m;
   }
 
   a:hover {
@@ -79,12 +79,12 @@
 }
 
 .docs-nav--item {
-  margin-bottom: $spacing-xs;
+  margin-block-end: $spacing-xs;
 
   &.docs-nav--item-with-subnav {
     .docs-nav--item-content {
       display: flex;
-      margin-bottom: $spacing-xs;
+      margin-block-end: $spacing-xs;
 
       a {
         flex: 1;
@@ -94,7 +94,7 @@
   }
 
   &:last-child {
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 }
 

--- a/packages/vuepress-theme-odyssey/styles/components/_DocsPageHeader.scss
+++ b/packages/vuepress-theme-odyssey/styles/components/_DocsPageHeader.scss
@@ -37,7 +37,7 @@
   &.is-page-header-base,
   &.is-page-header-components,
   &.is-page-header-icon {
-    @include border-radius(0, 0, 32px, 32px);
+    @include border-radius(0, 32px, 0, 32px);
 
     grid-template-columns: minmax(min-content, 50%) minmax(min-content, max-content);
     padding-block: $spacing-l;

--- a/packages/vuepress-theme-odyssey/styles/components/_DocsPageHeader.scss
+++ b/packages/vuepress-theme-odyssey/styles/components/_DocsPageHeader.scss
@@ -25,7 +25,8 @@
 
   .docs-page-header--lede {
     grid-column: 1 / 2;
-    margin: 0;
+    margin-block: 0;
+    margin-inline: 0;
     font-size: $size-body-lede;
 
     @include mq(l) {
@@ -36,9 +37,11 @@
   &.is-page-header-base,
   &.is-page-header-components,
   &.is-page-header-icon {
+    @include border-radius(0, 0, 32px, 32px);
+
     grid-template-columns: minmax(min-content, 50%) minmax(min-content, max-content);
-    padding: $spacing-l;
-    border-radius: 0 32px;
+    padding-block: $spacing-l;
+    padding-inline: $spacing-l;
 
     @include mq(l) {
       grid-template-columns: minmax(min-content, 45%) minmax(min-content, max-content);

--- a/packages/vuepress-theme-odyssey/styles/components/_DocsPageHeader.scss
+++ b/packages/vuepress-theme-odyssey/styles/components/_DocsPageHeader.scss
@@ -16,7 +16,7 @@
   grid-column-gap: $spacing-m;
   grid-template-columns: minmax(min-content, max-content) minmax(min-content, max-content);
   justify-content: space-between;
-  margin-bottom: $spacing-l;
+  margin-block-end: $spacing-l;
   font-size: $size-title-4;
 
   @include mq(m) {
@@ -56,7 +56,7 @@
         display: block;
         width: 50px;
         height: 116px;
-        margin-bottom: $spacing-s;
+        margin-block-end: $spacing-s;
         background-image: url('/images/index-base-m.svg');
         background-size: contain;
       }
@@ -74,7 +74,7 @@
         display: block;
         width: 90px;
         height: 116px;
-        margin-bottom: $spacing-s;
+        margin-block-end: $spacing-s;
         background-image: url('/images/index-components-m.svg');
         background-size: contain;
       }
@@ -92,7 +92,7 @@
         display: block;
         width: 90px;
         height: 116px;
-        margin-bottom: $spacing-s;
+        margin-block-end: $spacing-s;
         background-image: url('/images/index-icons-m.svg');
         background-size: contain;
       }

--- a/packages/vuepress-theme-odyssey/styles/components/_DocsPagination.scss
+++ b/packages/vuepress-theme-odyssey/styles/components/_DocsPagination.scss
@@ -11,9 +11,9 @@
  */
 
 .page-footer {
-  margin-top: $spacing-xl;
+  margin-block-start: $spacing-xl;
   padding: $spacing-m 0;
-  border-top: 2px solid var(--border-color-display, #{$border-color-display});
+  border-block-start: 2px solid var(--border-color-display, #{$border-color-display});
   text-align: center;
 
   &,

--- a/packages/vuepress-theme-odyssey/styles/components/_DocsPagination.scss
+++ b/packages/vuepress-theme-odyssey/styles/components/_DocsPagination.scss
@@ -12,7 +12,8 @@
 
 .page-footer {
   margin-block-start: $spacing-xl;
-  padding: $spacing-m 0;
+  padding-block: $spacing-m;
+  padding-inline: 0;
   border-block-start: 2px solid var(--border-color-display, #{$border-color-display});
   text-align: center;
 

--- a/packages/vuepress-theme-odyssey/styles/components/_DocsSidebar.scss
+++ b/packages/vuepress-theme-odyssey/styles/components/_DocsSidebar.scss
@@ -46,7 +46,7 @@ a.docs-site-title:visited {
     visibility: hidden;
     position: fixed;
     z-index: z-index(sidebar);
-    top: 0;
+    inset-block-start: 0;
     transform: translateX(-100%);
     transition: all 0.33s ease-in-out;
 
@@ -69,8 +69,8 @@ a.docs-site-title:visited {
   .docs-sidebar--action {
     display: none;
     position: absolute;
-    top: $spacing-s;
-    right: $spacing-s;
+    inset-block-start: $spacing-s;
+    inset-inline-end: $spacing-s;
     color: var(--docs-text-heading, #{$text-heading});
 
     @include mq(l) {
@@ -87,7 +87,7 @@ a.docs-site-title:visited {
   .docs-sidebar--content {
     display: grid;
     position: sticky;
-    top: 0;
+    inset-block-start: 0;
     grid-row-gap: $spacing-s;
     grid-template-areas: 'header' 'main' 'footer';
     grid-template-rows: auto 1fr auto;
@@ -108,7 +108,7 @@ a.docs-site-title:visited {
     overflow: scroll;
 
     &.is-overflowing {
-      border-bottom: 1px solid var(--border-color-display, #{$border-color-display});
+      border-block-end: 1px solid var(--border-color-display, #{$border-color-display});
     }
   }
 

--- a/packages/vuepress-theme-odyssey/styles/components/_DocsSidebar.scss
+++ b/packages/vuepress-theme-odyssey/styles/components/_DocsSidebar.scss
@@ -15,7 +15,8 @@ a.docs-site-title,
 a.docs-site-title:visited {
   /* stylelint-enable selector-no-qualifying-type */
   display: block;
-  padding: $spacing-xs $spacing-xs;
+  padding-block: $spacing-xs;
+  padding-inline: $spacing-xs;
   border: 0;
   color: var(--docs-text-heading, #{$text-heading});
   font-size: $size-title-4;
@@ -93,18 +94,22 @@ a.docs-site-title:visited {
     grid-template-rows: auto 1fr auto;
     height: 100vh;
     max-height: 100vh;
-    padding: $spacing-l;
+    padding-block: $spacing-l;
+    padding-inline: $spacing-l;
     background: var(--docs-sidebar-bg, #{$white});
   }
 
   .docs-sidebar--header {
     grid-area: header;
-    padding: 0 $spacing-xs 0;
+    padding-block: 0;
+    padding-inline: $spacing-xs;
   }
 
   .docs-sidebar--main {
     grid-area: main;
-    padding: $spacing-xs $spacing-xs $spacing-s;
+    padding-block-start: $spacing-xs;
+    padding-block-end: $spacing-s;
+    padding-inline: $spacing-xs;
     overflow: scroll;
 
     &.is-overflowing {
@@ -114,7 +119,9 @@ a.docs-site-title:visited {
 
   .docs-sidebar--footer {
     grid-area: footer;
-    padding: $spacing-xs $spacing-xs 0;
+    padding-block-start: $spacing-xs;
+    padding-block-end: 0;
+    padding-inline: $spacing-xs;
   }
 }
 

--- a/packages/vuepress-theme-odyssey/styles/components/_DocsTopbar.scss
+++ b/packages/vuepress-theme-odyssey/styles/components/_DocsTopbar.scss
@@ -15,7 +15,8 @@
   position: fixed;
   z-index: z-index(topbar);
   width: 100vw;
-  padding: $spacing-xs $spacing-m;
+  padding-block: $spacing-xs;
+  padding-inline: $spacing-m;
   border-block-end: 1px solid var(--border-color-display, #{$border-color-display});
   background: var(--docs-sidebar-bg, #{$white});
 
@@ -28,7 +29,8 @@
   }
 
   .docs-site-title {
-    padding: $spacing-xs;
+    padding-block: $spacing-xs;
+    padding-inline: $spacing-xs;
   }
 
   .docs-topbar--action {

--- a/packages/vuepress-theme-odyssey/styles/components/_DocsTopbar.scss
+++ b/packages/vuepress-theme-odyssey/styles/components/_DocsTopbar.scss
@@ -16,7 +16,7 @@
   z-index: z-index(topbar);
   width: 100vw;
   padding: $spacing-xs $spacing-m;
-  border-bottom: 1px solid var(--border-color-display, #{$border-color-display});
+  border-block-end: 1px solid var(--border-color-display, #{$border-color-display});
   background: var(--docs-sidebar-bg, #{$white});
 
   @include mq(l) {
@@ -32,12 +32,12 @@
   }
 
   .docs-topbar--action {
-    margin-right: $spacing-xs;
-    margin-left: -$spacing-s;
+    margin-inline-end: $spacing-xs;
+    margin-inline-start: -$spacing-s;
 
     svg {
       position: relative;
-      top: -0.1em;
+      inset-block-start: -0.1em;
       width: 1em;
       height: 1em;
       transform: scale(1.6);

--- a/packages/vuepress-theme-odyssey/styles/docskit/_Anatomy.scss
+++ b/packages/vuepress-theme-odyssey/styles/docskit/_Anatomy.scss
@@ -11,6 +11,8 @@
  */
 
 .docskit-figure-anatomy {
+  @include border-radius( $base-border-radius );
+
   display: flex;
   grid-column: 1 / 3;
   align-items: center;
@@ -18,7 +20,6 @@
   width: 100%;
   margin-block-end: $spacing-l;
   border: 1px solid var(--border-color-display, #{$border-color-display});
-  border-radius: $base-border-radius;
 
   img {
     user-select: none;

--- a/packages/vuepress-theme-odyssey/styles/docskit/_Anatomy.scss
+++ b/packages/vuepress-theme-odyssey/styles/docskit/_Anatomy.scss
@@ -16,7 +16,7 @@
   align-items: center;
   justify-content: center;
   width: 100%;
-  margin-bottom: $spacing-l;
+  margin-block-end: $spacing-l;
   border: 1px solid var(--border-color-display, #{$border-color-display});
   border-radius: $base-border-radius;
 

--- a/packages/vuepress-theme-odyssey/styles/docskit/_Description.scss
+++ b/packages/vuepress-theme-odyssey/styles/docskit/_Description.scss
@@ -11,7 +11,7 @@
  */
 
 .docskit--desc {
-  margin-bottom: 2em;
+  margin-block-end: 2em;
 
   p {
     grid-column: 1 / 1;
@@ -37,7 +37,7 @@
 
     .desc-counter--item {
       @include mq(m) {
-        margin-bottom: $spacing-m;
+        margin-block-end: $spacing-m;
       }
 
       &::marker {

--- a/packages/vuepress-theme-odyssey/styles/docskit/_Visual.scss
+++ b/packages/vuepress-theme-odyssey/styles/docskit/_Visual.scss
@@ -22,12 +22,14 @@
   }
 
   .docskit-visual--figure {
+    @include border-radius($base-border-radius);
+
     display: grid;
     position: relative;
     justify-content: center;
-    padding: $spacing-l $spacing-l;
+    padding-block: $spacing-l;
+    padding-inline: $spacing-l;
     border: 1px solid var(--border-color-display, #{$border-color-display});
-    border-radius: $base-border-radius;
   }
 
   &.layout-wide {
@@ -36,7 +38,8 @@
 
   &.theme-transparent {
     .docskit-visual--figure {
-      padding: 0;
+      padding-block: 0;
+      padding-inline: 0;
       border: 0;
     }
   }
@@ -50,6 +53,8 @@
     }
 
     &::after {
+      @include border-radius(0, 0, $base-border-radius, $base-border-radius);
+
       content: '';
       display: block;
       position: absolute;
@@ -57,7 +62,6 @@
       inset-block-end: 1px;
       inset-inline-start: 1px;
       height: 33%;
-      border-radius: 0 0 $base-border-radius $base-border-radius;
       background: linear-gradient(to top, rgba(255, 255, 255, 1) 33.33%, rgba(255, 255, 255, 0) 100%);
     }
   }
@@ -71,7 +75,10 @@
   &.is-docskit-visual-content-no-end {
     .docskit-visual--figure {
       grid-auto-columns: 1fr;
-      padding: $spacing-l 0 0 $spacing-l;
+      padding-block-start: $spacing-l;
+      padding-block-end: 0;
+      padding-inline-start: $spacing-l;
+      padding-inline-end: 0;
     }
   }
 

--- a/packages/vuepress-theme-odyssey/styles/docskit/_Visual.scss
+++ b/packages/vuepress-theme-odyssey/styles/docskit/_Visual.scss
@@ -12,11 +12,11 @@
 
 .docskit-visual {
   grid-column: 2 / 3;
-  margin-bottom: $spacing-m;
+  margin-block-end: $spacing-m;
 
   .docskit-visual--title {
     &::before {
-      margin-right: $spacing-xs;
+      margin-inline-end: $spacing-xs;
       font-size: $size-title-5;
     }
   }
@@ -46,16 +46,16 @@
     position: relative;
 
     .docskit-visual--figure {
-      padding-bottom: 0;
+      padding-block-end: 0;
     }
 
     &::after {
       content: '';
       display: block;
       position: absolute;
-      right: 1px;
-      bottom: 1px;
-      left: 1px;
+      inset-inline-end: 1px;
+      inset-block-end: 1px;
+      inset-inline-start: 1px;
       height: 33%;
       border-radius: 0 0 $base-border-radius $base-border-radius;
       background: linear-gradient(to top, rgba(255, 255, 255, 1) 33.33%, rgba(255, 255, 255, 0) 100%);

--- a/packages/vuepress-theme-odyssey/styles/docskit/_marker.scss
+++ b/packages/vuepress-theme-odyssey/styles/docskit/_marker.scss
@@ -16,8 +16,8 @@
   &::after {
     content: attr(data-marker-count);
     position: absolute;
-    top: 0;
-    left: 50%;
+    inset-block-start: 0;
+    inset-inline-start: 50%;
     width: $spacing-m-em;
     height: $spacing-m-em;
     transform: translateY(-75%) translateX(-50%);

--- a/packages/vuepress-theme-odyssey/styles/docskit/_marker.scss
+++ b/packages/vuepress-theme-odyssey/styles/docskit/_marker.scss
@@ -14,6 +14,8 @@
   position: relative;
 
   &::after {
+    @include border-radius(50%);
+
     content: attr(data-marker-count);
     position: absolute;
     inset-block-start: 0;
@@ -21,7 +23,6 @@
     width: $spacing-m-em;
     height: $spacing-m-em;
     transform: translateY(-75%) translateX(-50%);
-    border-radius: 50%;
     background-color: cv('turquoise', '500');
     color: $white;
     font-size: $size-body-caption;

--- a/packages/vuepress-theme-odyssey/styles/index.scss
+++ b/packages/vuepress-theme-odyssey/styles/index.scss
@@ -66,7 +66,7 @@ a:visited {
     flex: 1;
     justify-content: center;
     max-width: 100%;
-    margin-bottom: $spacing-l;
+    margin-block-end: $spacing-l;
     padding: $spacing-l * 2 $spacing-m 0;
 
     // TODO: We would like to remove this in the future
@@ -82,8 +82,8 @@ a:visited {
 .docs-skip-content {
   position: absolute;
   z-index: 20;
-  top: -3rem;
-  left: $spacing-xs;
+  inset-block-start: -3rem;
+  inset-inline-start: $spacing-xs;
   padding: $spacing-xs $spacing-s;
   overflow: hidden;
   transition: 0.15s ease-in-out;
@@ -92,7 +92,7 @@ a:visited {
   text-decoration: none;
 
   &:focus {
-    top: $spacing-xs;
+    inset-block-start: $spacing-xs;
     width: auto;
     height: auto;
   }
@@ -102,7 +102,7 @@ a:visited {
   @include mq(l) {
     position: sticky;
     z-index: z-index(topbar);
-    top: 0;
+    inset-block-start: 0;
   }
 }
 
@@ -117,8 +117,8 @@ h6 {
     position: absolute;
     width: $spacing-s-em;
     height: $spacing-s-em;
-    margin-top: $spacing-xs-em /2;
-    margin-left: -$spacing-m;
+    margin-block-start: $spacing-xs-em /2;
+    margin-inline-start: -$spacing-m;
     transition: 0.33s opacity  ease-in-out;
     opacity: 0;
     background-image: get-icon('anchor', var(--border-color-ui, #{$border-color-ui}));
@@ -142,7 +142,7 @@ h6 {
 
 .is-tab-small-sample {
   .ods-tabs--tabpanel [role='tabpanel'] {
-    padding-bottom: $spacing-s;
+    padding-block-end: $spacing-s;
   }
 }
 
@@ -269,7 +269,7 @@ h6 {
 
 .sample--emoji {
   display: inline-block;
-  margin-right: $spacing-xs;
+  margin-inline-end: $spacing-xs;
 }
 
 .sample--list {
@@ -367,15 +367,15 @@ $spacing-units: (
   .sample--type-#{$name} {
     position: relative;
     min-height: $base-font-size;
-    margin-bottom: $spacing-m;
+    margin-block-end: $spacing-m;
     padding: 0 0 0 $spacing-l;
     font-size: $value;
 
     &::before {
       content: 'ms(#{str-slice($name, 4)})';
       position: absolute;
-      top: 0;
-      left: 0;
+      inset-block-start: 0;
+      inset-inline-start: 0;
       font-size: $size-body-caption;
     }
   }
@@ -396,7 +396,7 @@ $spacing-units: (
 .help-icon {
   width: $spacing-l;
   height: $spacing-l;
-  margin-bottom: $spacing-m;
+  margin-block-end: $spacing-m;
 }
 
 .is-sample-absolute {

--- a/packages/vuepress-theme-odyssey/styles/index.scss
+++ b/packages/vuepress-theme-odyssey/styles/index.scss
@@ -67,7 +67,9 @@ a:visited {
     justify-content: center;
     max-width: 100%;
     margin-block-end: $spacing-l;
-    padding: $spacing-l * 2 $spacing-m 0;
+    padding-block-start: ($spacing-l * 2);
+    padding-block-end: 0;
+    padding-inline: $spacing-m;
 
     // TODO: We would like to remove this in the future
     // so that the grid width is determined by the content
@@ -84,7 +86,8 @@ a:visited {
   z-index: 20;
   inset-block-start: -3rem;
   inset-inline-start: $spacing-xs;
-  padding: $spacing-xs $spacing-s;
+  padding-block: $spacing-xs;
+  padding-inline: $spacing-s;
   overflow: hidden;
   transition: 0.15s ease-in-out;
   background: $white;
@@ -148,20 +151,24 @@ h6 {
 
 .is-tab-stacked-example {
   .ods-tabs [role='tabpanel'] {
-    padding: $spacing-l;
+    padding-block: $spacing-l;
+    padding-inline: $spacing-l;
   }
 
   .ods-tabs:first-child [role='tabpanel'] {
-    padding: $spacing-xs;
+    padding-block: $spacing-xs;
+    padding-inline: $spacing-xs;
   }
 }
 
 .sample-color {
+  @include border-radius($base-border-radius);
+
   display: inline-block;
   width: 1em;
   height: 1em;
-  margin: 0 auto;
-  border-radius: $base-border-radius;
+  margin-block: 0;
+  margin-inline: auto;
   vertical-align: middle;
 }
 
@@ -176,11 +183,13 @@ h6 {
 // Design Token Examples
 
 .sample-token {
+  @include border-radius($base-border-radius);
+
   display: block;
   width: 1em;
   height: 1em;
-  margin: 0 auto;
-  border-radius: $base-border-radius;
+  margin-block: 0;
+  margin-inline: auto;
 }
 
 // Token Examples: Color
@@ -368,7 +377,9 @@ $spacing-units: (
     position: relative;
     min-height: $base-font-size;
     margin-block-end: $spacing-m;
-    padding: 0 0 0 $spacing-l;
+    padding-block: 0;
+    padding-inline-start: $spacing-l;
+    padding-inline-end: 0;
     font-size: $value;
 
     &::before {
@@ -390,7 +401,8 @@ $spacing-units: (
 
 .sample--tip {
   display: inline-block;
-  margin: 0 $spacing-xs;
+  margin-block: 0;
+  margin-inline: $spacing-xs;
 }
 
 .help-icon {

--- a/packages/vuepress-theme-odyssey/styles/templates/_DocsTemplateComponent.scss
+++ b/packages/vuepress-theme-odyssey/styles/templates/_DocsTemplateComponent.scss
@@ -42,7 +42,7 @@
     }
 
     a {
-      margin-right: $spacing-s-em;
+      margin-inline-end: $spacing-s-em;
       padding: 0;
     }
   }
@@ -61,7 +61,7 @@
   svg {
     width: $spacing-m;
     height: $spacing-m;
-    margin-right: $spacing-xs;
+    margin-inline-end: $spacing-xs;
   }
 }
 
@@ -73,7 +73,7 @@
   grid-column: 1 / 3;
   width: 100%;
   max-width: calc((#{$max-line-length} * 2) + #{$spacing-l});
-  margin-bottom: $spacing-l;
+  margin-block-end: $spacing-l;
 
   .docs-example--rendered {
     position: relative;
@@ -96,7 +96,7 @@
   }
 
   .docs-example--rendered + div[class*='language-'] pre[class*='language-'] {
-    border-top: 0;
+    border-block-start: 0;
     border-radius: 0 0 6px 6px;
   }
   /* stylelint-enable */
@@ -105,17 +105,17 @@
 .docs-main--content-tabs > .ods-tabs--tablist {
   position: sticky;
   z-index: z-index(base);
-  top: 0;
-  margin-top: -$spacing-l;
-  padding-top: $spacing-l;
+  inset-block-start: 0;
+  margin-block-start: -$spacing-l;
+  padding-block-start: $spacing-l;
   background: var(--docs-page-bg, #{$white});
 
   @include mq(l) {
-    margin-top: -$spacing-m;
-    padding-top: $spacing-m;
+    margin-block-start: -$spacing-m;
+    padding-block-start: $spacing-m;
 
     .has-ods-beta-banner & {
-      top: ms(14);
+      inset-block-start: ms(14);
     }
   }
 }

--- a/packages/vuepress-theme-odyssey/styles/templates/_DocsTemplateComponent.scss
+++ b/packages/vuepress-theme-odyssey/styles/templates/_DocsTemplateComponent.scss
@@ -35,7 +35,8 @@
   font-size: $size-body-base;
 
   @include mq(m) {
-    margin: $spacing-m 0;
+    margin-block: $spacing-m;
+    margin-inline: 0;
 
     li {
       display: inline-block;
@@ -43,14 +44,16 @@
 
     a {
       margin-inline-end: $spacing-s-em;
-      padding: 0;
+      padding-block: 0;
+      padding-inline: 0;
     }
   }
 
   a {
     display: flex;
     align-items: center;
-    padding: $spacing-xs-em;
+    padding-block: $spacing-xs-em;
+    padding-inline: $spacing-xs-em;
     line-height: $base-line-height;
   }
 
@@ -76,10 +79,12 @@
   margin-block-end: $spacing-l;
 
   .docs-example--rendered {
+    @include border-radius(6px, 6px, 0, 0);
+
     position: relative;
-    padding: $spacing-l;
+    padding-block: $spacing-l;
+    padding-inline: $spacing-l;
     border: 1px solid var(--border-color-display, #{$border-color-display});
-    border-radius: 6px 6px 0 0;
 
     &.is-docs-example--rendered-tall {
       min-height: #{$spacing-l * 6};
@@ -88,8 +93,10 @@
 
   /* stylelint-disable */
   pre[class*='language-'] {
-    margin: 0;
-    padding: $spacing-m;
+    margin-block: 0;
+    margin-inline: 0;
+    padding-block: $spacing-m;
+    padding-inline: $spacing-m;
     overflow: scroll;
     border: 1px solid var(--border-color-display, #{$border-color-display});
     border-radius: 0 0 6px 6px;
@@ -126,9 +133,11 @@
 .docs-example {
   /* stylelint-enable no-duplicate-selectors */
   .ods-modal--overlay {
+    @include border-radius(6px, 6px, 0, 0);
+
     position: relative;
     z-index: auto;
-    padding: $spacing-xl $spacing-m;
-    border-radius: 6px 6px 0 0;
+    padding-block: $spacing-xl;
+    padding-inline: $spacing-m;
   }
 }

--- a/packages/vuepress-theme-odyssey/styles/templates/_DocsTemplateHome.scss
+++ b/packages/vuepress-theme-odyssey/styles/templates/_DocsTemplateHome.scss
@@ -15,12 +15,12 @@
   position: relative;
   grid-template-columns: 1fr 1fr 1fr 1fr;
   height: 360px;
-  margin-bottom: $spacing-l;
+  margin-block-end: $spacing-l;
 
   .docs-hero--content {
     z-index: z-index(base);
     grid-column: 1 / 3;
-    margin-right: $spacing-m;
+    margin-inline-end: $spacing-m;
     padding: $spacing-m $spacing-m;
 
     @include mq(l) {
@@ -29,7 +29,7 @@
 
     @include mq(m) {
       grid-column: 1 / 4;
-      margin-top: $spacing-m;
+      margin-block-start: $spacing-m;
       .docs-hero--title { font-size: $size-title-1; }
     }
 
@@ -40,7 +40,7 @@
   .docs-hero-moon {
     position: fixed;
     z-index: z-index(btm);
-    right: -25%;
+    inset-inline-end: -25%;
     width: 100%;
     max-width: 840px;
 
@@ -52,17 +52,17 @@
   .docs-hero-rocket {
     position: absolute;
     z-index: z-index(btm);
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
+    inset-block-start: 0;
+    inset-inline-end: 0;
+    inset-block-end: 0;
+    inset-inline-start: 0;
     overflow: hidden;
     border-radius: 0 0 0 32px;
 
     svg {
       position: absolute;
-      bottom: 0;
-      left: 0;
+      inset-block-end: 0;
+      inset-inline-start: 0;
       height: auto;
     }
 

--- a/packages/vuepress-theme-odyssey/styles/templates/_DocsTemplateHome.scss
+++ b/packages/vuepress-theme-odyssey/styles/templates/_DocsTemplateHome.scss
@@ -21,10 +21,12 @@
     z-index: z-index(base);
     grid-column: 1 / 3;
     margin-inline-end: $spacing-m;
-    padding: $spacing-m $spacing-m;
+    padding-block: $spacing-m;
+    padding-inline: $spacing-m;
 
     @include mq(l) {
-      margin: 0;
+      margin-block: 0;
+      margin-inline: 0;
     }
 
     @include mq(m) {
@@ -50,6 +52,8 @@
   }
 
   .docs-hero-rocket {
+    @include border-radius(0, 0, 0, 32px);
+
     position: absolute;
     z-index: z-index(btm);
     inset-block-start: 0;
@@ -57,7 +61,6 @@
     inset-block-end: 0;
     inset-inline-start: 0;
     overflow: hidden;
-    border-radius: 0 0 0 32px;
 
     svg {
       position: absolute;
@@ -78,7 +81,8 @@
 
 .docs-principle {
   position: relative;
-  margin: $spacing-xl 0;
+  margin-block: $spacing-xl;
+  margin-inline: 0;
 
   .docs-principle--title {
     @include is-visually-hidden;

--- a/packages/vuepress-theme-odyssey/styles/templates/_DocsTemplatePlain.scss
+++ b/packages/vuepress-theme-odyssey/styles/templates/_DocsTemplatePlain.scss
@@ -11,7 +11,11 @@
  */
 
 .docs-main--content.is-template-plain {
-  hr { margin: $spacing-m 0 $spacing-l; }
+  hr {
+    margin-block-start: $spacing-m;
+    margin-block-end: $spacing-l;
+    margin-inline: 0;
+  }
 
   .docs-page-header.is-page-header-icon + hr {
     display: none;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3448,6 +3448,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
+"@pxblue/storybook-rtl-addon@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@pxblue/storybook-rtl-addon/-/storybook-rtl-addon-1.0.1.tgz#97750f3907ec523e1a4a33f87512820cb4a3b042"
+  integrity sha512-N/HysEo6rK7f0Eqm4xt8nciZXwjdNscRD5hSYUZUZEn4EzdtqwqXSel8jfjUuZ9R6YCQ7+IIqdZsk6gHUlS+qw==
+
 "@reach/router@^1.3.4":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17661,10 +17661,10 @@ stylelint-scss@^3.2.0, stylelint-scss@^3.4.0:
     postcss-selector-parser "^6.0.2"
     postcss-value-parser "^4.1.0"
 
-stylelint-use-logical@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/stylelint-use-logical/-/stylelint-use-logical-1.1.0.tgz#f419386f48dae19fc59b024255c04f36738d879f"
-  integrity sha512-WwYAEoUNXxu4A9tZ+mPnvFSf3wKG9mY9+ZqnNjVHikfOQA4MTO6XeSC8BGCsY7LOG0GnDfmxMrRUJXFZRtaCmg==
+stylelint-use-logical-spec@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/stylelint-use-logical-spec/-/stylelint-use-logical-spec-3.2.0.tgz#ec74f3ab2a61374ca20bb3b7e9eec71c4190ffa7"
+  integrity sha512-3DRpU0HuLwHFGg4hZi1KHSH5sI/X0u4ZR2GA0lhavlcZvEDUkWRzqjA1Jh5I2nXi1KHqL7q/fM1lcKjWDbuqZA==
 
 stylelint@^9.3.0:
   version "9.10.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3448,11 +3448,6 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
-"@pxblue/storybook-rtl-addon@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@pxblue/storybook-rtl-addon/-/storybook-rtl-addon-1.0.1.tgz#97750f3907ec523e1a4a33f87512820cb4a3b042"
-  integrity sha512-N/HysEo6rK7f0Eqm4xt8nciZXwjdNscRD5hSYUZUZEn4EzdtqwqXSel8jfjUuZ9R6YCQ7+IIqdZsk6gHUlS+qw==
-
 "@reach/router@^1.3.4":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,13 @@
   dependencies:
     "@babel/highlight" "^7.12.13"
 
+"@babel/code-frame@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
+  integrity sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==
+  dependencies:
+    "@babel/highlight" "^7.14.5"
+
 "@babel/compat-data@^7.10.4", "@babel/compat-data@^7.11.0":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.11.0.tgz#e9f73efe09af1355b723a7f39b11bad637d7c99c"
@@ -36,6 +43,11 @@
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.14.0.tgz#a901128bce2ad02565df95e6ecbf195cf9465919"
   integrity sha512-vu9V3uMM/1o5Hl5OekMUowo3FqXLJSw+s+66nt0fSWVWTtmosdzn45JHOB3cPtZoe6CTBDzvSw0RdOY85Q37+Q==
+
+"@babel/compat-data@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.14.5.tgz#8ef4c18e58e801c5c95d3c1c0f2874a2680fadea"
+  integrity sha512-kixrYn4JwfAVPa0f2yfzc2AWti6WRRyO3XjWW5PJAvtE11qhSayrrcrEnee05KAtNaPC+EwehE8Qt1UedEVB8w==
 
 "@babel/core@7.12.9":
   version "7.12.9"
@@ -59,26 +71,25 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@>=7.2.2", "@babel/core@^7.11.0", "@babel/core@^7.8.4":
-  version "7.11.6"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.6.tgz#3a9455dc7387ff1bac45770650bc13ba04a15651"
-  integrity sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==
+"@babel/core@>=7.9.0":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.14.6.tgz#e0814ec1a950032ff16c13a2721de39a8416fcab"
+  integrity sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==
   dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/generator" "^7.11.6"
-    "@babel/helper-module-transforms" "^7.11.0"
-    "@babel/helpers" "^7.10.4"
-    "@babel/parser" "^7.11.5"
-    "@babel/template" "^7.10.4"
-    "@babel/traverse" "^7.11.5"
-    "@babel/types" "^7.11.5"
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.14.5"
+    "@babel/helper-compilation-targets" "^7.14.5"
+    "@babel/helper-module-transforms" "^7.14.5"
+    "@babel/helpers" "^7.14.6"
+    "@babel/parser" "^7.14.6"
+    "@babel/template" "^7.14.5"
+    "@babel/traverse" "^7.14.5"
+    "@babel/types" "^7.14.5"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
-    gensync "^1.0.0-beta.1"
+    gensync "^1.0.0-beta.2"
     json5 "^2.1.2"
-    lodash "^4.17.19"
-    resolve "^1.3.2"
-    semver "^5.4.1"
+    semver "^6.3.0"
     source-map "^0.5.0"
 
 "@babel/core@^7.1.0", "@babel/core@^7.7.5":
@@ -100,6 +111,28 @@
     gensync "^1.0.0-beta.2"
     json5 "^2.1.2"
     semver "^6.3.0"
+    source-map "^0.5.0"
+
+"@babel/core@^7.11.0", "@babel/core@^7.8.4":
+  version "7.11.6"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.6.tgz#3a9455dc7387ff1bac45770650bc13ba04a15651"
+  integrity sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.11.6"
+    "@babel/helper-module-transforms" "^7.11.0"
+    "@babel/helpers" "^7.10.4"
+    "@babel/parser" "^7.11.5"
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.11.5"
+    "@babel/types" "^7.11.5"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.2"
+    lodash "^4.17.19"
+    resolve "^1.3.2"
+    semver "^5.4.1"
     source-map "^0.5.0"
 
 "@babel/core@^7.12.10", "@babel/core@^7.14.3":
@@ -159,6 +192,15 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
+"@babel/generator@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.14.5.tgz#848d7b9f031caca9d0cd0af01b063f226f52d785"
+  integrity sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==
+  dependencies:
+    "@babel/types" "^7.14.5"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
 "@babel/helper-annotate-as-pure@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz#5bf0d495a3f757ac3bda48b5bf3b3ba309c72ba3"
@@ -208,6 +250,16 @@
     "@babel/compat-data" "^7.13.15"
     "@babel/helper-validator-option" "^7.12.17"
     browserslist "^4.14.5"
+    semver "^6.3.0"
+
+"@babel/helper-compilation-targets@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz#7a99c5d0967911e972fe2c3411f7d5b498498ecf"
+  integrity sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==
+  dependencies:
+    "@babel/compat-data" "^7.14.5"
+    "@babel/helper-validator-option" "^7.14.5"
+    browserslist "^4.16.6"
     semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.10.4", "@babel/helper-create-class-features-plugin@^7.10.5":
@@ -329,6 +381,15 @@
     "@babel/template" "^7.12.13"
     "@babel/types" "^7.14.2"
 
+"@babel/helper-function-name@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz#89e2c474972f15d8e233b52ee8c480e2cfcd50c4"
+  integrity sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.14.5"
+    "@babel/template" "^7.14.5"
+    "@babel/types" "^7.14.5"
+
 "@babel/helper-get-function-arity@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz#98c1cbea0e2332f33f9a4661b8ce1505b2c19ba2"
@@ -342,6 +403,13 @@
   integrity sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==
   dependencies:
     "@babel/types" "^7.12.13"
+
+"@babel/helper-get-function-arity@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz#25fbfa579b0937eee1f3b805ece4ce398c431815"
+  integrity sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==
+  dependencies:
+    "@babel/types" "^7.14.5"
 
 "@babel/helper-hoist-variables@^7.10.4":
   version "7.10.4"
@@ -358,6 +426,13 @@
     "@babel/traverse" "^7.13.15"
     "@babel/types" "^7.13.16"
 
+"@babel/helper-hoist-variables@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz#e0dd27c33a78e577d7c8884916a3e7ef1f7c7f8d"
+  integrity sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==
+  dependencies:
+    "@babel/types" "^7.14.5"
+
 "@babel/helper-member-expression-to-functions@^7.10.4", "@babel/helper-member-expression-to-functions@^7.10.5":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz#ae69c83d84ee82f4b42f96e2a09410935a8f26df"
@@ -372,6 +447,13 @@
   dependencies:
     "@babel/types" "^7.13.12"
 
+"@babel/helper-member-expression-to-functions@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.5.tgz#d5c70e4ad13b402c95156c7a53568f504e2fb7b8"
+  integrity sha512-UxUeEYPrqH1Q/k0yRku1JE7dyfyehNwT6SVkMHvYvPDv4+uu627VXBckVj891BO8ruKBkiDoGnZf4qPDD8abDQ==
+  dependencies:
+    "@babel/types" "^7.14.5"
+
 "@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.8.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz#4c5c54be04bd31670a7382797d75b9fa2e5b5620"
@@ -385,6 +467,13 @@
   integrity sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==
   dependencies:
     "@babel/types" "^7.13.12"
+
+"@babel/helper-module-imports@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz#6d1a44df6a38c957aa7c312da076429f11b422f3"
+  integrity sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==
+  dependencies:
+    "@babel/types" "^7.14.5"
 
 "@babel/helper-module-transforms@^7.10.4", "@babel/helper-module-transforms@^7.10.5", "@babel/helper-module-transforms@^7.11.0":
   version "7.11.0"
@@ -427,6 +516,20 @@
     "@babel/traverse" "^7.14.0"
     "@babel/types" "^7.14.0"
 
+"@babel/helper-module-transforms@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz#7de42f10d789b423eb902ebd24031ca77cb1e10e"
+  integrity sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.14.5"
+    "@babel/helper-replace-supers" "^7.14.5"
+    "@babel/helper-simple-access" "^7.14.5"
+    "@babel/helper-split-export-declaration" "^7.14.5"
+    "@babel/helper-validator-identifier" "^7.14.5"
+    "@babel/template" "^7.14.5"
+    "@babel/traverse" "^7.14.5"
+    "@babel/types" "^7.14.5"
+
 "@babel/helper-optimise-call-expression@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz#50dc96413d594f995a77905905b05893cd779673"
@@ -440,6 +543,13 @@
   integrity sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==
   dependencies:
     "@babel/types" "^7.12.13"
+
+"@babel/helper-optimise-call-expression@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz#f27395a8619e0665b3f0364cddb41c25d71b499c"
+  integrity sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==
+  dependencies:
+    "@babel/types" "^7.14.5"
 
 "@babel/helper-plugin-utils@7.10.4", "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.10.4"
@@ -507,6 +617,16 @@
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.12"
 
+"@babel/helper-replace-supers@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz#0ecc0b03c41cd567b4024ea016134c28414abb94"
+  integrity sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.14.5"
+    "@babel/helper-optimise-call-expression" "^7.14.5"
+    "@babel/traverse" "^7.14.5"
+    "@babel/types" "^7.14.5"
+
 "@babel/helper-simple-access@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz#0f5ccda2945277a2a7a2d3a821e15395edcf3461"
@@ -521,6 +641,13 @@
   integrity sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==
   dependencies:
     "@babel/types" "^7.13.12"
+
+"@babel/helper-simple-access@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz#66ea85cf53ba0b4e588ba77fc813f53abcaa41c4"
+  integrity sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==
+  dependencies:
+    "@babel/types" "^7.14.5"
 
 "@babel/helper-skip-transparent-expression-wrappers@^7.11.0":
   version "7.11.0"
@@ -550,6 +677,13 @@
   dependencies:
     "@babel/types" "^7.12.13"
 
+"@babel/helper-split-export-declaration@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz#22b23a54ef51c2b7605d851930c1976dd0bc693a"
+  integrity sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==
+  dependencies:
+    "@babel/types" "^7.14.5"
+
 "@babel/helper-validator-identifier@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
@@ -560,10 +694,20 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz#d26cad8a47c65286b15df1547319a5d0bcf27288"
   integrity sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==
 
+"@babel/helper-validator-identifier@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz#d0f0e277c512e0c938277faa85a3968c9a44c0e8"
+  integrity sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==
+
 "@babel/helper-validator-option@^7.12.17":
   version "7.12.17"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz#d1fbf012e1a79b7eebbfdc6d270baaf8d9eb9831"
   integrity sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==
+
+"@babel/helper-validator-option@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
+  integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
 
 "@babel/helper-wrap-function@^7.10.4":
   version "7.10.4"
@@ -603,6 +747,15 @@
     "@babel/traverse" "^7.14.0"
     "@babel/types" "^7.14.0"
 
+"@babel/helpers@^7.14.6":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.14.6.tgz#5b58306b95f1b47e2a0199434fa8658fa6c21635"
+  integrity sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==
+  dependencies:
+    "@babel/template" "^7.14.5"
+    "@babel/traverse" "^7.14.5"
+    "@babel/types" "^7.14.5"
+
 "@babel/highlight@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
@@ -618,6 +771,15 @@
   integrity sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.0"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.5.tgz#6861a52f03966405001f6aa534a01a24d99e8cd9"
+  integrity sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.5"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -640,6 +802,11 @@
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.5.tgz#b4af32ddd473c0bfa643bd7ff0728b8e71b81ea0"
   integrity sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==
+
+"@babel/parser@^7.14.5", "@babel/parser@^7.14.6":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.6.tgz#d85cc68ca3cac84eae384c06f032921f5227f4b2"
+  integrity sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.13.12":
   version "7.13.12"
@@ -1913,6 +2080,15 @@
     "@babel/parser" "^7.12.13"
     "@babel/types" "^7.12.13"
 
+"@babel/template@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.14.5.tgz#a9bc9d8b33354ff6e55a9c60d1109200a68974f4"
+  integrity sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/parser" "^7.14.5"
+    "@babel/types" "^7.14.5"
+
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.10.4", "@babel/traverse@^7.11.5":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.11.5.tgz#be777b93b518eb6d76ee2e1ea1d143daa11e61c3"
@@ -1953,6 +2129,21 @@
     "@babel/helper-split-export-declaration" "^7.12.13"
     "@babel/parser" "^7.14.2"
     "@babel/types" "^7.14.2"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.5.tgz#c111b0f58afab4fea3d3385a406f692748c59870"
+  integrity sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.14.5"
+    "@babel/helper-function-name" "^7.14.5"
+    "@babel/helper-hoist-variables" "^7.14.5"
+    "@babel/helper-split-export-declaration" "^7.14.5"
+    "@babel/parser" "^7.14.5"
+    "@babel/types" "^7.14.5"
     debug "^4.1.0"
     globals "^11.1.0"
 
@@ -2003,6 +2194,14 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.5.tgz#3bb997ba829a2104cedb20689c4a5b8121d383ff"
+  integrity sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.5"
     to-fast-properties "^2.0.0"
 
 "@base2/pretty-print-object@1.0.0":
@@ -4174,6 +4373,21 @@
     resolve-from "^5.0.0"
     store2 "^2.12.0"
 
+"@stylelint/postcss-css-in-js@^0.37.2":
+  version "0.37.2"
+  resolved "https://registry.yarnpkg.com/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.2.tgz#7e5a84ad181f4234a2480803422a47b8749af3d2"
+  integrity sha512-nEhsFoJurt8oUmieT8qy4nk81WRHmJynmVwn/Vts08PL9fhgIsMhk1GId5yAN643OzqEEb5S/6At2TZW7pqPDA==
+  dependencies:
+    "@babel/core" ">=7.9.0"
+
+"@stylelint/postcss-markdown@^0.36.2":
+  version "0.36.2"
+  resolved "https://registry.yarnpkg.com/@stylelint/postcss-markdown/-/postcss-markdown-0.36.2.tgz#0a540c4692f8dcdfc13c8e352c17e7bfee2bb391"
+  integrity sha512-2kGbqUVJUGE8dM+bMzXG/PYUWKkjLIkRLWNh39OaADkiabDRdw8ATFCgbMz5xdIcvwspPAluSL7uY+ZiTWdWmQ==
+  dependencies:
+    remark "^13.0.0"
+    unist-util-find-all-after "^3.0.2"
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
@@ -4536,22 +4750,6 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
-
-"@types/vfile-message@*":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/vfile-message/-/vfile-message-2.0.0.tgz#690e46af0fdfc1f9faae00cd049cc888957927d5"
-  integrity sha512-GpTIuDpb9u4zIO165fUy9+fXcULdD8HFRNli04GehoMVbeNq7D6OBnqSmg3lxZnC+UvgUhEWKxdKiwYUkGltIw==
-  dependencies:
-    vfile-message "*"
-
-"@types/vfile@^3.0.0":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/vfile/-/vfile-3.0.2.tgz#19c18cd232df11ce6fa6ad80259bc86c366b09b9"
-  integrity sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==
-  dependencies:
-    "@types/node" "*"
-    "@types/unist" "*"
-    "@types/vfile-message" "*"
 
 "@types/webpack-env@^1.16.0":
   version "1.16.0"
@@ -5647,11 +5845,6 @@ ast-types@^0.14.2:
   dependencies:
     tslib "^2.0.1"
 
-astral-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
-  integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
-
 astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
@@ -5706,7 +5899,7 @@ autocomplete.js@0.36.0:
   dependencies:
     immediate "^3.2.3"
 
-autoprefixer@^9.0.0, autoprefixer@^9.5.1, autoprefixer@^9.8.6:
+autoprefixer@^9.5.1, autoprefixer@^9.8.6:
   version "9.8.6"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.8.6.tgz#3b73594ca1bf9266320c5acf1588d74dea74210f"
   integrity sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==
@@ -5964,6 +6157,11 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
+balanced-match@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
+  integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
 
 base64-js@^1.0.2:
   version "1.3.1"
@@ -6606,7 +6804,7 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.5.tgz#ac82a944905a65ce204eb03023157edf29425c17"
   integrity sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.1, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.3.1, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -6642,7 +6840,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.1.0:
+chalk@^4.1.0, chalk@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
   integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
@@ -6654,11 +6852,6 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
-
-character-entities-html4@^1.0.0:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.4.tgz#0e64b0a3753ddbf1fdc044c5fd01d0199a02e125"
-  integrity sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==
 
 character-entities-legacy@^1.0.0:
   version "1.1.4"
@@ -6886,13 +7079,12 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
-clone-regexp@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/clone-regexp/-/clone-regexp-1.0.1.tgz#051805cd33173375d82118fc0918606da39fd60f"
-  integrity sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==
+clone-regexp@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/clone-regexp/-/clone-regexp-2.2.0.tgz#7d65e00885cd8796405c35a737e7a86b7429e36f"
+  integrity sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==
   dependencies:
-    is-regexp "^1.0.0"
-    is-supported-regexp-flag "^1.0.0"
+    is-regexp "^2.0.0"
 
 clone-response@^1.0.2:
   version "1.0.2"
@@ -9089,12 +9281,12 @@ execa@^4.0.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
-execall@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/execall/-/execall-1.0.0.tgz#73d0904e395b3cab0658b08d09ec25307f29bb73"
-  integrity sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=
+execall@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/execall/-/execall-2.0.0.tgz#16a06b5fe5099df7d00be5d9c06eecded1663b45"
+  integrity sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==
   dependencies:
-    clone-regexp "^1.0.0"
+    clone-regexp "^2.1.0"
 
 exit@^0.1.2:
   version "0.1.2"
@@ -9255,7 +9447,7 @@ fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.1.1:
+fast-glob@^3.1.1, fast-glob@^3.2.5:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
   integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
@@ -9281,6 +9473,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fastest-levenshtein@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
+  integrity sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==
 
 fastq@^1.6.0:
   version "1.11.0"
@@ -9342,13 +9539,6 @@ figures@^3.0.0:
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   dependencies:
     escape-string-regexp "^1.0.5"
-
-file-entry-cache@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-4.0.0.tgz#633567d15364aefe0b299e1e217735e8f3a9f6e8"
-  integrity sha512-AVSwsnbV8vH/UVbvgEhf3saVQXORNv0ZzSkvkhQIaia5Tia+JhGTaa/ePUSVoPHQyGayQNmYfkzFi3WZV5zcpA==
-  dependencies:
-    flat-cache "^2.0.1"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -9498,15 +9688,6 @@ findup-sync@^3.0.0:
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
 
-flat-cache@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
-  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
-  dependencies:
-    flatted "^2.0.0"
-    rimraf "2.6.3"
-    write "1.0.3"
-
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -9514,11 +9695,6 @@ flat-cache@^3.0.4:
   dependencies:
     flatted "^3.1.0"
     rimraf "^3.0.2"
-
-flatted@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
-  integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
 flatted@^3.1.0:
   version "3.1.1"
@@ -9865,7 +10041,7 @@ get-port@^4.2.0:
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-4.2.0.tgz#e37368b1e863b7629c43c5a323625f95cf24b119"
   integrity sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==
 
-get-stdin@8.0.0:
+get-stdin@8.0.0, get-stdin@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-8.0.0.tgz#cbad6a73feb75f6eeb22ba9e01f89aa28aa97a53"
   integrity sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==
@@ -10165,7 +10341,7 @@ globby@^7.1.1:
     pify "^3.0.0"
     slash "^1.0.0"
 
-globby@^9.0.0, globby@^9.2.0:
+globby@^9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
   integrity sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==
@@ -10193,7 +10369,7 @@ globule@^1.0.0:
     lodash "~4.17.10"
     minimatch "~3.0.2"
 
-gonzales-pe@^4.2.3:
+gonzales-pe@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/gonzales-pe/-/gonzales-pe-4.3.0.tgz#fe9dec5f3c557eead09ff868c65826be54d067b3"
   integrity sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==
@@ -10861,7 +11037,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.0.4, ignore@^5.1.1, ignore@^5.1.4:
+ignore@^5.1.1, ignore@^5.1.4, ignore@^5.1.8:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
@@ -10926,10 +11102,10 @@ import-lazy@^2.1.0:
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
   integrity sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=
 
-import-lazy@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-3.1.0.tgz#891279202c8a2280fdbd6674dbd8da1a1dfc67cc"
-  integrity sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==
+import-lazy@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
+  integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
 
 import-local@^1.0.0:
   version "1.0.0"
@@ -11140,11 +11316,6 @@ is-alphabetical@1.0.4, is-alphabetical@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz#9e7d6b94916be22153745d184c298cbf986a686d"
   integrity sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==
-
-is-alphanumeric@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz#4a9cef71daf4c001c1d81d63d140cf53fd6889f4"
-  integrity sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ=
 
 is-alphanumerical@^1.0.0:
   version "1.0.4"
@@ -11526,10 +11697,10 @@ is-regex@^1.1.2:
     call-bind "^1.0.2"
     has-symbols "^1.0.2"
 
-is-regexp@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
-  integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
+is-regexp@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-2.1.0.tgz#cd734a56864e23b956bf4e7c66c396a4c0b22c2d"
+  integrity sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==
 
 is-resolvable@^1.0.0:
   version "1.1.0"
@@ -11568,11 +11739,6 @@ is-string@^1.0.5:
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
   integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
 
-is-supported-regexp-flag@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz#21ee16518d2c1dd3edd3e9a0d57e50207ac364ca"
-  integrity sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==
-
 is-svg@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-3.0.0.tgz#9321dbd29c212e5ca99c4fa9794c714bcafa2f75"
@@ -11605,6 +11771,11 @@ is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-unicode-supported@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
+  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
 is-utf8@^0.2.0:
   version "0.2.1"
@@ -12412,10 +12583,10 @@ klona@^2.0.4:
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.4.tgz#7bb1e3affb0cb8624547ef7e8f6708ea2e39dfc0"
   integrity sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==
 
-known-css-properties@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.11.0.tgz#0da784f115ea77c76b81536d7052e90ee6c86a8a"
-  integrity sha512-bEZlJzXo5V/ApNNa5z375mJC6Nrz4vG43UgcSCrg2OHC+yuB6j0iDSrY7RQ/+PRofFB03wNIIt9iXIVLr4wc7w==
+known-css-properties@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.21.0.tgz#15fbd0bbb83447f3ce09d8af247ed47c68ede80d"
+  integrity sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw==
 
 language-subtag-registry@~0.3.2:
   version "0.3.21"
@@ -12484,11 +12655,6 @@ lerna@3.3.2:
     "@lerna/version" "^3.3.2"
     import-local "^1.0.0"
     npmlog "^4.1.2"
-
-leven@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
-  integrity sha1-wuep93IJTe6dNCAq6KzORoeHVYA=
 
 leven@^3.1.0:
   version "3.1.0"
@@ -12715,24 +12881,30 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.7.0, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.3, lodash@^4.17.5, lodash@^4.2.1, lodash@~4.17.10:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-log-symbols@^2.0.0, log-symbols@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
-  integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
+log-symbols@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
+  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
   dependencies:
-    chalk "^2.0.1"
+    chalk "^4.1.0"
+    is-unicode-supported "^0.1.0"
 
 loglevel@^1.6.8:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.0.tgz#728166855a740d59d38db01cf46f042caa041bb0"
   integrity sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ==
 
-longest-streak@^2.0.1:
+longest-streak@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
   integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
@@ -12935,11 +13107,6 @@ markdown-it@^8.4.1:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
-markdown-table@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
-  integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
-
 markdown-to-jsx@^6.11.4:
   version "6.11.4"
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz#b4528b1ab668aef7fe61c1535c27e837819392c5"
@@ -12953,7 +13120,7 @@ markdown-to-jsx@^7.1.0:
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.1.2.tgz#19d3da4cd8864045cdd13a0d179147fbd6a088d4"
   integrity sha512-O8DMCl32V34RrD+ZHxcAPc2+kYytuDIoQYjY36RVdsLK7uHjgNVvFec4yv0X6LgB4YEZgSvK5QtFi5YVqEpoMA==
 
-mathml-tag-names@^2.0.1:
+mathml-tag-names@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz#4ddadd67308e780cf16a47685878ee27b736a0a3"
   integrity sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==
@@ -12974,19 +13141,23 @@ mdast-squeeze-paragraphs@^4.0.0:
   dependencies:
     unist-util-remove "^2.0.0"
 
-mdast-util-compact@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mdast-util-compact/-/mdast-util-compact-1.0.4.tgz#d531bb7667b5123abf20859be086c4d06c894593"
-  integrity sha512-3YDMQHI5vRiS2uygEFYaqckibpJtKq5Sj2c8JioeOQBU6INpKbdWzfyLqFFnDwEcEnRFIdMsguzs5pC1Jp4Isg==
-  dependencies:
-    unist-util-visit "^1.1.0"
-
 mdast-util-definitions@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-4.0.0.tgz#c5c1a84db799173b4dcf7643cda999e440c24db2"
   integrity sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==
   dependencies:
     unist-util-visit "^2.0.0"
+
+mdast-util-from-markdown@^0.8.0:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz#d1ef2ca42bc377ecb0463a987910dae89bd9a28c"
+  integrity sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-string "^2.0.0"
+    micromark "~2.11.0"
+    parse-entities "^2.0.0"
+    unist-util-stringify-position "^2.0.0"
 
 mdast-util-to-hast@10.0.1:
   version "10.0.1"
@@ -13002,10 +13173,27 @@ mdast-util-to-hast@10.0.1:
     unist-util-position "^3.0.0"
     unist-util-visit "^2.0.0"
 
+mdast-util-to-markdown@^0.6.0:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz#b33f67ca820d69e6cc527a93d4039249b504bebe"
+  integrity sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    longest-streak "^2.0.0"
+    mdast-util-to-string "^2.0.0"
+    parse-entities "^2.0.0"
+    repeat-string "^1.0.0"
+    zwitch "^1.0.0"
+
 mdast-util-to-string@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz#27055500103f51637bd07d01da01eb1967a43527"
   integrity sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==
+
+mdast-util-to-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz#b8cfe6a713e1091cb5b728fc48885a4767f8b97b"
+  integrity sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==
 
 mdn-data@2.0.4:
   version "2.0.4"
@@ -13088,21 +13276,6 @@ meow@^4.0.0:
     redent "^2.0.0"
     trim-newlines "^2.0.0"
 
-meow@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-5.0.0.tgz#dfc73d63a9afc714a5e371760eb5c88b91078aa4"
-  integrity sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==
-  dependencies:
-    camelcase-keys "^4.0.0"
-    decamelize-keys "^1.0.0"
-    loud-rejection "^1.0.0"
-    minimist-options "^3.0.1"
-    normalize-package-data "^2.3.4"
-    read-pkg-up "^3.0.0"
-    redent "^2.0.0"
-    trim-newlines "^2.0.0"
-    yargs-parser "^10.0.0"
-
 meow@^7.0.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/meow/-/meow-7.1.1.tgz#7c01595e3d337fcb0ec4e8eed1666ea95903d306"
@@ -13127,6 +13300,24 @@ meow@^8.0.0:
   dependencies:
     "@types/minimist" "^1.2.0"
     camelcase-keys "^6.2.2"
+    decamelize-keys "^1.1.0"
+    hard-rejection "^2.1.0"
+    minimist-options "4.1.0"
+    normalize-package-data "^3.0.0"
+    read-pkg-up "^7.0.1"
+    redent "^3.0.0"
+    trim-newlines "^3.0.0"
+    type-fest "^0.18.0"
+    yargs-parser "^20.2.3"
+
+meow@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-9.0.0.tgz#cd9510bc5cac9dee7d03c73ee1f9ad959f4ea364"
+  integrity sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==
+  dependencies:
+    "@types/minimist" "^1.2.0"
+    camelcase-keys "^6.2.2"
+    decamelize "^1.2.0"
     decamelize-keys "^1.1.0"
     hard-rejection "^2.1.0"
     minimist-options "4.1.0"
@@ -13169,6 +13360,14 @@ microevent.ts@~0.1.1:
   resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"
   integrity sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==
 
+micromark@~2.11.0:
+  version "2.11.4"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-2.11.4.tgz#d13436138eea826383e822449c9a5c50ee44665a"
+  integrity sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==
+  dependencies:
+    debug "^4.0.0"
+    parse-entities "^2.0.0"
+
 micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -13188,7 +13387,7 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.2:
+micromatch@^4.0.2, micromatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
   integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
@@ -14416,18 +14615,6 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.5:
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
 
-parse-entities@^1.0.2, parse-entities@^1.1.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.2.tgz#c31bf0f653b6661354f8973559cb86dd1d5edf50"
-  integrity sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==
-  dependencies:
-    character-entities "^1.0.0"
-    character-entities-legacy "^1.0.0"
-    character-reference-invalid "^1.0.0"
-    is-alphanumerical "^1.0.0"
-    is-decimal "^1.0.0"
-    is-hexadecimal "^1.0.0"
-
 parse-entities@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-2.0.0.tgz#53c6eb5b9314a1f4ec99fa0fdf7ce01ecda0cbe8"
@@ -14642,7 +14829,7 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
-pify@^4.0.0, pify@^4.0.1:
+pify@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
@@ -14799,14 +14986,7 @@ postcss-html@^0.36.0:
   dependencies:
     htmlparser2 "^3.10.0"
 
-postcss-jsx@^0.36.0:
-  version "0.36.4"
-  resolved "https://registry.yarnpkg.com/postcss-jsx/-/postcss-jsx-0.36.4.tgz#37a68f300a39e5748d547f19a747b3257240bd50"
-  integrity sha512-jwO/7qWUvYuWYnpOb0+4bIIgJt7003pgU3P6nETBLaOyBXuTD55ho21xnals5nBrlpTIFodyd3/jBi6UO3dHvA==
-  dependencies:
-    "@babel/core" ">=7.2.2"
-
-postcss-less@^3.1.0:
+postcss-less@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/postcss-less/-/postcss-less-3.1.4.tgz#369f58642b5928ef898ffbc1a6e93c958304c5ad"
   integrity sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==
@@ -14841,14 +15021,6 @@ postcss-loader@^4.2.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
     semver "^7.3.4"
-
-postcss-markdown@^0.36.0:
-  version "0.36.0"
-  resolved "https://registry.yarnpkg.com/postcss-markdown/-/postcss-markdown-0.36.0.tgz#7f22849ae0e3db18820b7b0d5e7833f13a447560"
-  integrity sha512-rl7fs1r/LNSB2bWRhyZ+lM/0bwKv9fhl38/06gF6mKMo/NPnp55+K1dSTosSVjFZc0e1ppBlu+WT91ba0PMBfQ==
-  dependencies:
-    remark "^10.0.1"
-    unist-util-find-all-after "^1.0.2"
 
 postcss-media-query-parser@^0.2.3:
   version "0.2.3"
@@ -15077,44 +15249,34 @@ postcss-reduce-transforms@^4.0.2:
     postcss "^7.0.0"
     postcss-value-parser "^3.0.0"
 
-postcss-reporter@^6.0.0:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-reporter/-/postcss-reporter-6.0.1.tgz#7c055120060a97c8837b4e48215661aafb74245f"
-  integrity sha512-LpmQjfRWyabc+fRygxZjpRxfhRf9u/fdlKf4VHG4TSPbV2XNsuISzYW1KL+1aQzx53CAppa1bKG4APIB/DOXXw==
-  dependencies:
-    chalk "^2.4.1"
-    lodash "^4.17.11"
-    log-symbols "^2.2.0"
-    postcss "^7.0.7"
-
 postcss-resolve-nested-selector@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz#29ccbc7c37dedfac304e9fff0bf1596b3f6a0e4e"
   integrity sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=
 
-postcss-safe-parser@^4.0.0, postcss-safe-parser@^4.0.1:
+postcss-safe-parser@^4.0.1, postcss-safe-parser@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-4.0.2.tgz#a6d4e48f0f37d9f7c11b2a581bf00f8ba4870b96"
   integrity sha512-Uw6ekxSWNLCPesSv/cmqf2bY/77z11O7jZGPax3ycZMFU/oi2DMH9i89AdHc1tRwFg/arFoEwX0IS3LCUxJh1g==
   dependencies:
     postcss "^7.0.26"
 
-postcss-sass@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/postcss-sass/-/postcss-sass-0.3.5.tgz#6d3e39f101a53d2efa091f953493116d32beb68c"
-  integrity sha512-B5z2Kob4xBxFjcufFnhQ2HqJQ2y/Zs/ic5EZbCywCkxKd756Q40cIQ/veRDwSrw1BF6+4wUgmpm0sBASqVi65A==
+postcss-sass@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/postcss-sass/-/postcss-sass-0.4.4.tgz#91f0f3447b45ce373227a98b61f8d8f0785285a3"
+  integrity sha512-BYxnVYx4mQooOhr+zer0qWbSPYnarAy8ZT7hAQtbxtgVf8gy+LSLT/hHGe35h14/pZDTw1DsxdbrwxBN++H+fg==
   dependencies:
-    gonzales-pe "^4.2.3"
-    postcss "^7.0.1"
+    gonzales-pe "^4.3.0"
+    postcss "^7.0.21"
 
-postcss-scss@^2.0.0:
+postcss-scss@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-2.1.1.tgz#ec3a75fa29a55e016b90bf3269026c53c1d2b383"
   integrity sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==
   dependencies:
     postcss "^7.0.6"
 
-postcss-selector-parser@^3.0.0, postcss-selector-parser@^3.1.0:
+postcss-selector-parser@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz#b310f5c4c0fdaf76f94902bbaa30db6aa84f5270"
   integrity sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==
@@ -15133,13 +15295,13 @@ postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2:
     uniq "^1.0.1"
     util-deprecate "^1.0.2"
 
-postcss-sorting@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-sorting/-/postcss-sorting-3.1.0.tgz#af7c90ee73ad12569a57664eaf06735c2e25bec0"
-  integrity sha512-YCPTcJwGIInF1LpMD1lIYvMHTGUL4s97o/OraA6eKvoauhhk6vjwOWDDjm6uRKqug/kyDPMKEzmYZ6FtW6RDgw==
+postcss-selector-parser@^6.0.5:
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz#2c5bba8174ac2f6981ab631a42ab0ee54af332ea"
+  integrity sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==
   dependencies:
-    lodash "^4.17.4"
-    postcss "^6.0.13"
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
 
 postcss-sorting@^5.0.1:
   version "5.0.1"
@@ -15183,19 +15345,19 @@ postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
 
-postcss@^6.0.13, postcss@^6.0.14:
-  version "6.0.23"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
-  integrity sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==
-  dependencies:
-    chalk "^2.4.1"
-    source-map "^0.6.1"
-    supports-color "^5.4.0"
-
-postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.13, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.31, postcss@^7.0.32, postcss@^7.0.35, postcss@^7.0.5, postcss@^7.0.6, postcss@^7.0.7:
+postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.31, postcss@^7.0.32, postcss@^7.0.35, postcss@^7.0.5, postcss@^7.0.6:
   version "7.0.35"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.35.tgz#d2be00b998f7f211d8a276974079f2e92b970e24"
   integrity sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
+postcss@^7.0.21:
+  version "7.0.36"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.36.tgz#056f8cffa939662a8f5905950c07d5285644dfcb"
+  integrity sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
@@ -16164,26 +16326,12 @@ remark-parse@8.0.3:
     vfile-location "^3.0.0"
     xtend "^4.0.1"
 
-remark-parse@^6.0.0:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-6.0.3.tgz#c99131052809da482108413f87b0ee7f52180a3a"
-  integrity sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==
+remark-parse@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-9.0.0.tgz#4d20a299665880e4f4af5d90b7c7b8a935853640"
+  integrity sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==
   dependencies:
-    collapse-white-space "^1.0.2"
-    is-alphabetical "^1.0.0"
-    is-decimal "^1.0.0"
-    is-whitespace-character "^1.0.0"
-    is-word-character "^1.0.0"
-    markdown-escapes "^1.0.0"
-    parse-entities "^1.1.0"
-    repeat-string "^1.5.4"
-    state-toggle "^1.0.0"
-    trim "0.0.1"
-    trim-trailing-lines "^1.0.0"
-    unherit "^1.0.4"
-    unist-util-remove-position "^1.0.0"
-    vfile-location "^2.0.0"
-    xtend "^4.0.1"
+    mdast-util-from-markdown "^0.8.0"
 
 remark-slug@^6.0.0:
   version "6.0.0"
@@ -16201,34 +16349,21 @@ remark-squeeze-paragraphs@4.0.0:
   dependencies:
     mdast-squeeze-paragraphs "^4.0.0"
 
-remark-stringify@^6.0.0:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-6.0.4.tgz#16ac229d4d1593249018663c7bddf28aafc4e088"
-  integrity sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==
+remark-stringify@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-9.0.1.tgz#576d06e910548b0a7191a71f27b33f1218862894"
+  integrity sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==
   dependencies:
-    ccount "^1.0.0"
-    is-alphanumeric "^1.0.0"
-    is-decimal "^1.0.0"
-    is-whitespace-character "^1.0.0"
-    longest-streak "^2.0.1"
-    markdown-escapes "^1.0.0"
-    markdown-table "^1.1.0"
-    mdast-util-compact "^1.0.0"
-    parse-entities "^1.0.2"
-    repeat-string "^1.5.4"
-    state-toggle "^1.0.0"
-    stringify-entities "^1.0.1"
-    unherit "^1.0.4"
-    xtend "^4.0.1"
+    mdast-util-to-markdown "^0.6.0"
 
-remark@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/remark/-/remark-10.0.1.tgz#3058076dc41781bf505d8978c291485fe47667df"
-  integrity sha512-E6lMuoLIy2TyiokHprMjcWNJ5UxfGQjaMSMhV+f4idM625UjjK4j798+gPs5mfjzDE6vL0oFKVeZM6gZVSVrzQ==
+remark@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/remark/-/remark-13.0.0.tgz#d15d9bf71a402f40287ebe36067b66d54868e425"
+  integrity sha512-HDz1+IKGtOyWN+QgBiAT0kn+2s6ovOxHyPAFGKVE81VSzJ+mq7RwHFledEvB5F1p4iJvOah/LOKdFuzvRnNLCA==
   dependencies:
-    remark-parse "^6.0.0"
-    remark-stringify "^6.0.0"
-    unified "^7.0.0"
+    remark-parse "^9.0.0"
+    remark-stringify "^9.0.0"
+    unified "^9.1.0"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -16251,7 +16386,7 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
   integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
-repeat-string@^1.5.4, repeat-string@^1.6.1:
+repeat-string@^1.0.0, repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
@@ -16262,11 +16397,6 @@ repeating@^2.0.0:
   integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
   dependencies:
     is-finite "^1.0.0"
-
-replace-ext@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
-  integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
 
 request-promise-core@1.1.4:
   version "1.1.4"
@@ -16463,13 +16593,6 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   dependencies:
     glob "^7.1.3"
 
@@ -16930,15 +17053,6 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-slice-ansi@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
-  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
-  dependencies:
-    ansi-styles "^3.2.0"
-    astral-regex "^1.0.0"
-    is-fullwidth-code-point "^2.0.0"
-
 slice-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
@@ -17366,7 +17480,7 @@ string-width@^4.0.0, string-width@^4.1.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
-string-width@^4.2.0:
+string-width@^4.2.0, string-width@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
   integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
@@ -17451,16 +17565,6 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
-
-stringify-entities@^1.0.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-1.3.2.tgz#a98417e5471fd227b3e45d3db1861c11caf668f7"
-  integrity sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==
-  dependencies:
-    character-entities-html4 "^1.0.0"
-    character-entities-legacy "^1.0.0"
-    is-alphanumerical "^1.0.0"
-    is-hexadecimal "^1.0.0"
 
 strip-ansi@6.0.0, strip-ansi@^6.0.0:
   version "6.0.0"
@@ -17612,27 +17716,27 @@ stylelint-config-property-sort-order-smacss@^7.1.0:
     css-property-sort-order-smacss "~2.1.3"
     stylelint-order "^4.0.0"
 
-stylelint-config-recommended@^2.1.0, stylelint-config-recommended@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-2.2.0.tgz#46ab139db4a0e7151fd5f94af155512886c96d3f"
-  integrity sha512-bZ+d4RiNEfmoR74KZtCKmsABdBJr4iXRiCso+6LtMJPw5rd/KnxUWTxht7TbafrTJK1YRjNgnN0iVZaJfc3xJA==
+stylelint-config-recommended@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-5.0.0.tgz#fb5653f495a60b4938f2ad3e77712d9e1039ae78"
+  integrity sha512-c8aubuARSu5A3vEHLBeOSJt1udOdS+1iue7BmJDTSXoCBmfEQmmWX+59vYIj3NQdJBY6a/QRv1ozVFpaB9jaqA==
 
-stylelint-config-sass-guidelines@^5.0.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-sass-guidelines/-/stylelint-config-sass-guidelines-5.4.0.tgz#82f02ab6231f10564105d4fc192ca6cc75fede36"
-  integrity sha512-+etE2MuxbIy4GXdfqJS2y0/K6I04opnpiKFFmbICd8STxCiP/ZkNDBM3Os69ckr+dB2yIXnqMOwRtoMahS20Gg==
+stylelint-config-sass-guidelines@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-sass-guidelines/-/stylelint-config-sass-guidelines-8.0.0.tgz#e92279aa052a04e822dd096d7c46c8e37d4b3406"
+  integrity sha512-v21iDWtzpfhuKJlYKpoE1vjp+GT8Cr6ZBWwMx/jf+eCEblZgAIDVVjgAELoDLhVj17DcEFwlIKJBMfrdAmXg0Q==
   dependencies:
-    stylelint-order ">=1.0.0"
-    stylelint-scss "^3.4.0"
+    stylelint-order "^4.0.0"
+    stylelint-scss "^3.18.0"
 
-stylelint-config-standard@^18.2.0:
-  version "18.3.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-18.3.0.tgz#a2a1b788d2cf876c013feaff8ae276117a1befa7"
-  integrity sha512-Tdc/TFeddjjy64LvjPau9SsfVRexmTFqUhnMBrzz07J4p2dVQtmpncRF/o8yZn8ugA3Ut43E6o1GtjX80TFytw==
+stylelint-config-standard@^22.0.0:
+  version "22.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-22.0.0.tgz#c860be9a13ebbc1b084456fa10527bf13a44addf"
+  integrity sha512-uQVNi87SHjqTm8+4NIP5NMAyY/arXrBgimaaT7skvRfE9u3JKXRK9KBkbr4pVmeciuCcs64kAdjlxfq6Rur7Hw==
   dependencies:
-    stylelint-config-recommended "^2.2.0"
+    stylelint-config-recommended "^5.0.0"
 
-stylelint-order@>=1.0.0, stylelint-order@^4.0.0:
+stylelint-order@^4.0.0, stylelint-order@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/stylelint-order/-/stylelint-order-4.1.0.tgz#692d05b7d0c235ac66fcf5ea1d9e5f08a76747f6"
   integrity sha512-sVTikaDvMqg2aJjh4r48jsdfmqLT+nqB1MOsaBnvM3OwLx4S+WXcsxsgk5w18h/OZoxZCxuyXMh61iBHcj9Qiw==
@@ -17641,19 +17745,10 @@ stylelint-order@>=1.0.0, stylelint-order@^4.0.0:
     postcss "^7.0.31"
     postcss-sorting "^5.0.1"
 
-stylelint-order@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/stylelint-order/-/stylelint-order-0.8.1.tgz#35f71af3a15954154e0e99e5646ba3d6fbe34f8d"
-  integrity sha512-8mp1P2wnI9XShYXVXDsxVigE2eXnc0C2O4ktbwUvTBwjCP4xZskIbUVxp1evSG3OK4R7hXVNl/2BnJCZkrcc/w==
-  dependencies:
-    lodash "^4.17.4"
-    postcss "^6.0.14"
-    postcss-sorting "^3.1.0"
-
-stylelint-scss@^3.2.0, stylelint-scss@^3.4.0:
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-3.18.0.tgz#8f06371c223909bf3f62e839548af1badeed31e9"
-  integrity sha512-LD7+hv/6/ApNGt7+nR/50ft7cezKP2HM5rI8avIdGaUWre3xlHfV4jKO/DRZhscfuN+Ewy9FMhcTq0CcS0C/SA==
+stylelint-scss@^3.18.0, stylelint-scss@^3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-3.19.0.tgz#528006d5a4c5a0f1f4d709b02fd3f626ed66d742"
+  integrity sha512-Ic5bsmpS4wVucOw44doC1Yi9f5qbeVL4wPFiEOaUElgsOuLEN6Ofn/krKI8BeNL2gAn53Zu+IcVV4E345r6rBw==
   dependencies:
     lodash "^4.17.15"
     postcss-media-query-parser "^0.2.3"
@@ -17666,58 +17761,59 @@ stylelint-use-logical-spec@^3.2.0:
   resolved "https://registry.yarnpkg.com/stylelint-use-logical-spec/-/stylelint-use-logical-spec-3.2.0.tgz#ec74f3ab2a61374ca20bb3b7e9eec71c4190ffa7"
   integrity sha512-3DRpU0HuLwHFGg4hZi1KHSH5sI/X0u4ZR2GA0lhavlcZvEDUkWRzqjA1Jh5I2nXi1KHqL7q/fM1lcKjWDbuqZA==
 
-stylelint@^9.3.0:
-  version "9.10.1"
-  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-9.10.1.tgz#5f0ee3701461dff1d68284e1386efe8f0677a75d"
-  integrity sha512-9UiHxZhOAHEgeQ7oLGwrwoDR8vclBKlSX7r4fH0iuu0SfPwFaLkb1c7Q2j1cqg9P7IDXeAV2TvQML/fRQzGBBQ==
+stylelint@^13.13.1:
+  version "13.13.1"
+  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-13.13.1.tgz#fca9c9f5de7990ab26a00f167b8978f083a18f3c"
+  integrity sha512-Mv+BQr5XTUrKqAXmpqm6Ddli6Ief+AiPZkRsIrAoUKFuq/ElkUh9ZMYxXD0iQNZ5ADghZKLOWz1h7hTClB7zgQ==
   dependencies:
-    autoprefixer "^9.0.0"
-    balanced-match "^1.0.0"
-    chalk "^2.4.1"
-    cosmiconfig "^5.0.0"
-    debug "^4.0.0"
-    execall "^1.0.0"
-    file-entry-cache "^4.0.0"
-    get-stdin "^6.0.0"
+    "@stylelint/postcss-css-in-js" "^0.37.2"
+    "@stylelint/postcss-markdown" "^0.36.2"
+    autoprefixer "^9.8.6"
+    balanced-match "^2.0.0"
+    chalk "^4.1.1"
+    cosmiconfig "^7.0.0"
+    debug "^4.3.1"
+    execall "^2.0.0"
+    fast-glob "^3.2.5"
+    fastest-levenshtein "^1.0.12"
+    file-entry-cache "^6.0.1"
+    get-stdin "^8.0.0"
     global-modules "^2.0.0"
-    globby "^9.0.0"
+    globby "^11.0.3"
     globjoin "^0.1.4"
-    html-tags "^2.0.0"
-    ignore "^5.0.4"
-    import-lazy "^3.1.0"
+    html-tags "^3.1.0"
+    ignore "^5.1.8"
+    import-lazy "^4.0.0"
     imurmurhash "^0.1.4"
-    known-css-properties "^0.11.0"
-    leven "^2.1.0"
-    lodash "^4.17.4"
-    log-symbols "^2.0.0"
-    mathml-tag-names "^2.0.1"
-    meow "^5.0.0"
-    micromatch "^3.1.10"
+    known-css-properties "^0.21.0"
+    lodash "^4.17.21"
+    log-symbols "^4.1.0"
+    mathml-tag-names "^2.1.3"
+    meow "^9.0.0"
+    micromatch "^4.0.4"
     normalize-selector "^0.2.0"
-    pify "^4.0.0"
-    postcss "^7.0.13"
+    postcss "^7.0.35"
     postcss-html "^0.36.0"
-    postcss-jsx "^0.36.0"
-    postcss-less "^3.1.0"
-    postcss-markdown "^0.36.0"
+    postcss-less "^3.1.4"
     postcss-media-query-parser "^0.2.3"
-    postcss-reporter "^6.0.0"
     postcss-resolve-nested-selector "^0.1.1"
-    postcss-safe-parser "^4.0.0"
-    postcss-sass "^0.3.5"
-    postcss-scss "^2.0.0"
-    postcss-selector-parser "^3.1.0"
+    postcss-safe-parser "^4.0.2"
+    postcss-sass "^0.4.4"
+    postcss-scss "^2.1.1"
+    postcss-selector-parser "^6.0.5"
     postcss-syntax "^0.36.2"
-    postcss-value-parser "^3.3.0"
-    resolve-from "^4.0.0"
-    signal-exit "^3.0.2"
-    slash "^2.0.0"
+    postcss-value-parser "^4.1.0"
+    resolve-from "^5.0.0"
+    slash "^3.0.0"
     specificity "^0.4.1"
-    string-width "^3.0.0"
+    string-width "^4.2.2"
+    strip-ansi "^6.0.0"
     style-search "^0.1.0"
     sugarss "^2.0.0"
     svg-tags "^1.0.0"
-    table "^5.0.0"
+    table "^6.6.0"
+    v8-compile-cache "^2.3.0"
+    write-file-atomic "^3.0.3"
 
 stylus-loader@^3.0.2:
   version "3.0.2"
@@ -17754,7 +17850,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-supports-color@^5.3.0, supports-color@^5.4.0:
+supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -17832,17 +17928,7 @@ tabbable@^5.1.4:
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.5.tgz#efec48ede268d511c261e3b81facbb4782a35147"
   integrity sha512-oVAPrWgLLqrbvQE8XqcU7CVBq6SQbaIbHkhOca3u7/jzuQvyZycrUKPCGr04qpEIUslmUlULbSeN+m3QrKEykA==
 
-table@^5.0.0:
-  version "5.4.6"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
-  integrity sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
-  dependencies:
-    ajv "^6.10.2"
-    lodash "^4.17.14"
-    slice-ansi "^2.1.0"
-    string-width "^3.0.0"
-
-table@^6.0.9:
+table@^6.0.9, table@^6.6.0:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/table/-/table-6.7.1.tgz#ee05592b7143831a8c94f3cee6aae4c1ccef33e2"
   integrity sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==
@@ -18489,19 +18575,17 @@ unified@9.2.0:
     trough "^1.0.0"
     vfile "^4.0.0"
 
-unified@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-7.1.0.tgz#5032f1c1ee3364bd09da12e27fdd4a7553c7be13"
-  integrity sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==
+unified@^9.1.0:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.1.tgz#ae18d5674c114021bfdbdf73865ca60f410215a3"
+  integrity sha512-juWjuI8Z4xFg8pJbnEZ41b5xjGUWGHqXALmBZ3FC3WX0PIx1CZBIIJ6mXbYMcf6Yw4Fi0rFUTA1cdz/BglbOhA==
   dependencies:
-    "@types/unist" "^2.0.0"
-    "@types/vfile" "^3.0.0"
     bail "^1.0.0"
     extend "^3.0.0"
-    is-plain-obj "^1.1.0"
+    is-buffer "^2.0.0"
+    is-plain-obj "^2.0.0"
     trough "^1.0.0"
-    vfile "^3.0.0"
-    x-is-string "^0.1.0"
+    vfile "^4.0.0"
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -18549,22 +18633,17 @@ unist-builder@2.0.3, unist-builder@^2.0.0:
   resolved "https://registry.yarnpkg.com/unist-builder/-/unist-builder-2.0.3.tgz#77648711b5d86af0942f334397a33c5e91516436"
   integrity sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==
 
-unist-util-find-all-after@^1.0.2:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/unist-util-find-all-after/-/unist-util-find-all-after-1.0.5.tgz#5751a8608834f41d117ad9c577770c5f2f1b2899"
-  integrity sha512-lWgIc3rrTMTlK1Y0hEuL+k+ApzFk78h+lsaa2gHf63Gp5Ww+mt11huDniuaoq1H+XMK2lIIjjPkncxXcDp3QDw==
+unist-util-find-all-after@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/unist-util-find-all-after/-/unist-util-find-all-after-3.0.2.tgz#fdfecd14c5b7aea5e9ef38d5e0d5f774eeb561f6"
+  integrity sha512-xaTC/AGZ0rIM2gM28YVRAFPIZpzbpDtU3dRmp7EXlNVA8ziQc4hY3H7BHXM1J49nEmiqc3svnqMReW+PGqbZKQ==
   dependencies:
-    unist-util-is "^3.0.0"
+    unist-util-is "^4.0.0"
 
 unist-util-generated@^1.0.0:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-1.1.6.tgz#5ab51f689e2992a472beb1b35f2ce7ff2f324d4b"
   integrity sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg==
-
-unist-util-is@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
-  integrity sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
 
 unist-util-is@^4.0.0:
   version "4.1.0"
@@ -18575,13 +18654,6 @@ unist-util-position@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-3.1.0.tgz#1c42ee6301f8d52f47d14f62bbdb796571fa2d47"
   integrity sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==
-
-unist-util-remove-position@^1.0.0:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz#ec037348b6102c897703eee6d0294ca4755a2020"
-  integrity sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==
-  dependencies:
-    unist-util-visit "^1.1.0"
 
 unist-util-remove-position@^2.0.0:
   version "2.0.1"
@@ -18597,24 +18669,12 @@ unist-util-remove@^2.0.0:
   dependencies:
     unist-util-is "^4.0.0"
 
-unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
-  integrity sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==
-
 unist-util-stringify-position@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz#cce3bfa1cdf85ba7375d1d5b17bdc4cada9bd9da"
   integrity sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==
   dependencies:
     "@types/unist" "^2.0.2"
-
-unist-util-visit-parents@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
-  integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==
-  dependencies:
-    unist-util-is "^3.0.0"
 
 unist-util-visit-parents@^3.0.0:
   version "3.1.1"
@@ -18632,13 +18692,6 @@ unist-util-visit@2.0.3, unist-util-visit@^2.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
     unist-util-visit-parents "^3.0.0"
-
-unist-util-visit@^1.1.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
-  integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
-  dependencies:
-    unist-util-visit-parents "^2.0.0"
 
 universal-user-agent@^4.0.0:
   version "4.0.1"
@@ -18865,6 +18918,11 @@ v8-compile-cache@^2.1.1:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"
   integrity sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==
 
+v8-compile-cache@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
+  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
+
 v8-to-istanbul@^7.0.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-7.1.1.tgz#04bfd1026ba4577de5472df4f5e89af49de5edda"
@@ -18917,40 +18975,18 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vfile-location@^2.0.0:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.6.tgz#8a274f39411b8719ea5728802e10d9e0dff1519e"
-  integrity sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==
-
 vfile-location@^3.0.0, vfile-location@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-3.2.0.tgz#d8e41fbcbd406063669ebf6c33d56ae8721d0f3c"
   integrity sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA==
 
-vfile-message@*, vfile-message@^2.0.0:
+vfile-message@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-2.0.4.tgz#5b43b88171d409eae58477d13f23dd41d52c371a"
   integrity sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==
   dependencies:
     "@types/unist" "^2.0.0"
     unist-util-stringify-position "^2.0.0"
-
-vfile-message@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.1.1.tgz#5833ae078a1dfa2d96e9647886cd32993ab313e1"
-  integrity sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==
-  dependencies:
-    unist-util-stringify-position "^1.1.1"
-
-vfile@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/vfile/-/vfile-3.0.1.tgz#47331d2abe3282424f4a4bb6acd20a44c4121803"
-  integrity sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==
-  dependencies:
-    is-buffer "^2.0.0"
-    replace-ext "1.0.0"
-    unist-util-stringify-position "^1.0.0"
-    vfile-message "^1.0.0"
 
 vfile@^4.0.0:
   version "4.2.1"
@@ -19566,7 +19602,7 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, write-file-atomic@^2.4.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
-write-file-atomic@^3.0.0:
+write-file-atomic@^3.0.0, write-file-atomic@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
   integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
@@ -19608,13 +19644,6 @@ write-pkg@^3.1.0:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
 
-write@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
-  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
-  dependencies:
-    mkdirp "^0.5.1"
-
 ws@^6.2.1:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.2.tgz#dd5cdbd57a9979916097652d78f1cc5faea0c32e"
@@ -19626,11 +19655,6 @@ ws@^7.2.3, ws@^7.4.4:
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.5.tgz#a484dd851e9beb6fdb420027e3885e8ce48986c1"
   integrity sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==
-
-x-is-string@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
-  integrity sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=
 
 xdg-basedir@^4.0.0:
   version "4.0.0"
@@ -19694,13 +19718,6 @@ yargs-parser@5.0.0-security.0:
   dependencies:
     camelcase "^3.0.0"
     object.assign "^4.1.0"
-
-yargs-parser@^10.0.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
-  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
-  dependencies:
-    camelcase "^4.1.0"
 
 yargs-parser@^13.1.2:
   version "13.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,13 +23,6 @@
   dependencies:
     "@babel/highlight" "^7.12.13"
 
-"@babel/code-frame@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
-  integrity sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==
-  dependencies:
-    "@babel/highlight" "^7.14.5"
-
 "@babel/compat-data@^7.10.4", "@babel/compat-data@^7.11.0":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.11.0.tgz#e9f73efe09af1355b723a7f39b11bad637d7c99c"
@@ -43,11 +36,6 @@
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.14.0.tgz#a901128bce2ad02565df95e6ecbf195cf9465919"
   integrity sha512-vu9V3uMM/1o5Hl5OekMUowo3FqXLJSw+s+66nt0fSWVWTtmosdzn45JHOB3cPtZoe6CTBDzvSw0RdOY85Q37+Q==
-
-"@babel/compat-data@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.14.5.tgz#8ef4c18e58e801c5c95d3c1c0f2874a2680fadea"
-  integrity sha512-kixrYn4JwfAVPa0f2yfzc2AWti6WRRyO3XjWW5PJAvtE11qhSayrrcrEnee05KAtNaPC+EwehE8Qt1UedEVB8w==
 
 "@babel/core@7.12.9":
   version "7.12.9"
@@ -71,25 +59,26 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@>=7.2.2":
-  version "7.14.6"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.14.6.tgz#e0814ec1a950032ff16c13a2721de39a8416fcab"
-  integrity sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==
+"@babel/core@>=7.2.2", "@babel/core@^7.11.0", "@babel/core@^7.8.4":
+  version "7.11.6"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.6.tgz#3a9455dc7387ff1bac45770650bc13ba04a15651"
+  integrity sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==
   dependencies:
-    "@babel/code-frame" "^7.14.5"
-    "@babel/generator" "^7.14.5"
-    "@babel/helper-compilation-targets" "^7.14.5"
-    "@babel/helper-module-transforms" "^7.14.5"
-    "@babel/helpers" "^7.14.6"
-    "@babel/parser" "^7.14.6"
-    "@babel/template" "^7.14.5"
-    "@babel/traverse" "^7.14.5"
-    "@babel/types" "^7.14.5"
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.11.6"
+    "@babel/helper-module-transforms" "^7.11.0"
+    "@babel/helpers" "^7.10.4"
+    "@babel/parser" "^7.11.5"
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.11.5"
+    "@babel/types" "^7.11.5"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
-    gensync "^1.0.0-beta.2"
+    gensync "^1.0.0-beta.1"
     json5 "^2.1.2"
-    semver "^6.3.0"
+    lodash "^4.17.19"
+    resolve "^1.3.2"
+    semver "^5.4.1"
     source-map "^0.5.0"
 
 "@babel/core@^7.1.0", "@babel/core@^7.7.5":
@@ -111,28 +100,6 @@
     gensync "^1.0.0-beta.2"
     json5 "^2.1.2"
     semver "^6.3.0"
-    source-map "^0.5.0"
-
-"@babel/core@^7.11.0", "@babel/core@^7.8.4":
-  version "7.11.6"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.6.tgz#3a9455dc7387ff1bac45770650bc13ba04a15651"
-  integrity sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/generator" "^7.11.6"
-    "@babel/helper-module-transforms" "^7.11.0"
-    "@babel/helpers" "^7.10.4"
-    "@babel/parser" "^7.11.5"
-    "@babel/template" "^7.10.4"
-    "@babel/traverse" "^7.11.5"
-    "@babel/types" "^7.11.5"
-    convert-source-map "^1.7.0"
-    debug "^4.1.0"
-    gensync "^1.0.0-beta.1"
-    json5 "^2.1.2"
-    lodash "^4.17.19"
-    resolve "^1.3.2"
-    semver "^5.4.1"
     source-map "^0.5.0"
 
 "@babel/core@^7.12.10", "@babel/core@^7.14.3":
@@ -192,15 +159,6 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.14.5.tgz#848d7b9f031caca9d0cd0af01b063f226f52d785"
-  integrity sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==
-  dependencies:
-    "@babel/types" "^7.14.5"
-    jsesc "^2.5.1"
-    source-map "^0.5.0"
-
 "@babel/helper-annotate-as-pure@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz#5bf0d495a3f757ac3bda48b5bf3b3ba309c72ba3"
@@ -250,16 +208,6 @@
     "@babel/compat-data" "^7.13.15"
     "@babel/helper-validator-option" "^7.12.17"
     browserslist "^4.14.5"
-    semver "^6.3.0"
-
-"@babel/helper-compilation-targets@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz#7a99c5d0967911e972fe2c3411f7d5b498498ecf"
-  integrity sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==
-  dependencies:
-    "@babel/compat-data" "^7.14.5"
-    "@babel/helper-validator-option" "^7.14.5"
-    browserslist "^4.16.6"
     semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.10.4", "@babel/helper-create-class-features-plugin@^7.10.5":
@@ -381,15 +329,6 @@
     "@babel/template" "^7.12.13"
     "@babel/types" "^7.14.2"
 
-"@babel/helper-function-name@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz#89e2c474972f15d8e233b52ee8c480e2cfcd50c4"
-  integrity sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==
-  dependencies:
-    "@babel/helper-get-function-arity" "^7.14.5"
-    "@babel/template" "^7.14.5"
-    "@babel/types" "^7.14.5"
-
 "@babel/helper-get-function-arity@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz#98c1cbea0e2332f33f9a4661b8ce1505b2c19ba2"
@@ -403,13 +342,6 @@
   integrity sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==
   dependencies:
     "@babel/types" "^7.12.13"
-
-"@babel/helper-get-function-arity@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz#25fbfa579b0937eee1f3b805ece4ce398c431815"
-  integrity sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==
-  dependencies:
-    "@babel/types" "^7.14.5"
 
 "@babel/helper-hoist-variables@^7.10.4":
   version "7.10.4"
@@ -426,13 +358,6 @@
     "@babel/traverse" "^7.13.15"
     "@babel/types" "^7.13.16"
 
-"@babel/helper-hoist-variables@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz#e0dd27c33a78e577d7c8884916a3e7ef1f7c7f8d"
-  integrity sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==
-  dependencies:
-    "@babel/types" "^7.14.5"
-
 "@babel/helper-member-expression-to-functions@^7.10.4", "@babel/helper-member-expression-to-functions@^7.10.5":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz#ae69c83d84ee82f4b42f96e2a09410935a8f26df"
@@ -447,13 +372,6 @@
   dependencies:
     "@babel/types" "^7.13.12"
 
-"@babel/helper-member-expression-to-functions@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.5.tgz#d5c70e4ad13b402c95156c7a53568f504e2fb7b8"
-  integrity sha512-UxUeEYPrqH1Q/k0yRku1JE7dyfyehNwT6SVkMHvYvPDv4+uu627VXBckVj891BO8ruKBkiDoGnZf4qPDD8abDQ==
-  dependencies:
-    "@babel/types" "^7.14.5"
-
 "@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.8.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz#4c5c54be04bd31670a7382797d75b9fa2e5b5620"
@@ -467,13 +385,6 @@
   integrity sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==
   dependencies:
     "@babel/types" "^7.13.12"
-
-"@babel/helper-module-imports@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz#6d1a44df6a38c957aa7c312da076429f11b422f3"
-  integrity sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==
-  dependencies:
-    "@babel/types" "^7.14.5"
 
 "@babel/helper-module-transforms@^7.10.4", "@babel/helper-module-transforms@^7.10.5", "@babel/helper-module-transforms@^7.11.0":
   version "7.11.0"
@@ -516,20 +427,6 @@
     "@babel/traverse" "^7.14.0"
     "@babel/types" "^7.14.0"
 
-"@babel/helper-module-transforms@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz#7de42f10d789b423eb902ebd24031ca77cb1e10e"
-  integrity sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==
-  dependencies:
-    "@babel/helper-module-imports" "^7.14.5"
-    "@babel/helper-replace-supers" "^7.14.5"
-    "@babel/helper-simple-access" "^7.14.5"
-    "@babel/helper-split-export-declaration" "^7.14.5"
-    "@babel/helper-validator-identifier" "^7.14.5"
-    "@babel/template" "^7.14.5"
-    "@babel/traverse" "^7.14.5"
-    "@babel/types" "^7.14.5"
-
 "@babel/helper-optimise-call-expression@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz#50dc96413d594f995a77905905b05893cd779673"
@@ -543,13 +440,6 @@
   integrity sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==
   dependencies:
     "@babel/types" "^7.12.13"
-
-"@babel/helper-optimise-call-expression@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz#f27395a8619e0665b3f0364cddb41c25d71b499c"
-  integrity sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==
-  dependencies:
-    "@babel/types" "^7.14.5"
 
 "@babel/helper-plugin-utils@7.10.4", "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.10.4"
@@ -617,16 +507,6 @@
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.12"
 
-"@babel/helper-replace-supers@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz#0ecc0b03c41cd567b4024ea016134c28414abb94"
-  integrity sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==
-  dependencies:
-    "@babel/helper-member-expression-to-functions" "^7.14.5"
-    "@babel/helper-optimise-call-expression" "^7.14.5"
-    "@babel/traverse" "^7.14.5"
-    "@babel/types" "^7.14.5"
-
 "@babel/helper-simple-access@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz#0f5ccda2945277a2a7a2d3a821e15395edcf3461"
@@ -641,13 +521,6 @@
   integrity sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==
   dependencies:
     "@babel/types" "^7.13.12"
-
-"@babel/helper-simple-access@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz#66ea85cf53ba0b4e588ba77fc813f53abcaa41c4"
-  integrity sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==
-  dependencies:
-    "@babel/types" "^7.14.5"
 
 "@babel/helper-skip-transparent-expression-wrappers@^7.11.0":
   version "7.11.0"
@@ -677,13 +550,6 @@
   dependencies:
     "@babel/types" "^7.12.13"
 
-"@babel/helper-split-export-declaration@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz#22b23a54ef51c2b7605d851930c1976dd0bc693a"
-  integrity sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==
-  dependencies:
-    "@babel/types" "^7.14.5"
-
 "@babel/helper-validator-identifier@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
@@ -694,20 +560,10 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz#d26cad8a47c65286b15df1547319a5d0bcf27288"
   integrity sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==
 
-"@babel/helper-validator-identifier@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz#d0f0e277c512e0c938277faa85a3968c9a44c0e8"
-  integrity sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==
-
 "@babel/helper-validator-option@^7.12.17":
   version "7.12.17"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz#d1fbf012e1a79b7eebbfdc6d270baaf8d9eb9831"
   integrity sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==
-
-"@babel/helper-validator-option@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
-  integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
 
 "@babel/helper-wrap-function@^7.10.4":
   version "7.10.4"
@@ -747,15 +603,6 @@
     "@babel/traverse" "^7.14.0"
     "@babel/types" "^7.14.0"
 
-"@babel/helpers@^7.14.6":
-  version "7.14.6"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.14.6.tgz#5b58306b95f1b47e2a0199434fa8658fa6c21635"
-  integrity sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==
-  dependencies:
-    "@babel/template" "^7.14.5"
-    "@babel/traverse" "^7.14.5"
-    "@babel/types" "^7.14.5"
-
 "@babel/highlight@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
@@ -771,15 +618,6 @@
   integrity sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.0"
-    chalk "^2.0.0"
-    js-tokens "^4.0.0"
-
-"@babel/highlight@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.5.tgz#6861a52f03966405001f6aa534a01a24d99e8cd9"
-  integrity sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.14.5"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -802,11 +640,6 @@
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.5.tgz#b4af32ddd473c0bfa643bd7ff0728b8e71b81ea0"
   integrity sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==
-
-"@babel/parser@^7.14.5", "@babel/parser@^7.14.6":
-  version "7.14.6"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.6.tgz#d85cc68ca3cac84eae384c06f032921f5227f4b2"
-  integrity sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.13.12":
   version "7.13.12"
@@ -2080,15 +1913,6 @@
     "@babel/parser" "^7.12.13"
     "@babel/types" "^7.12.13"
 
-"@babel/template@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.14.5.tgz#a9bc9d8b33354ff6e55a9c60d1109200a68974f4"
-  integrity sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==
-  dependencies:
-    "@babel/code-frame" "^7.14.5"
-    "@babel/parser" "^7.14.5"
-    "@babel/types" "^7.14.5"
-
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.10.4", "@babel/traverse@^7.11.5":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.11.5.tgz#be777b93b518eb6d76ee2e1ea1d143daa11e61c3"
@@ -2129,21 +1953,6 @@
     "@babel/helper-split-export-declaration" "^7.12.13"
     "@babel/parser" "^7.14.2"
     "@babel/types" "^7.14.2"
-    debug "^4.1.0"
-    globals "^11.1.0"
-
-"@babel/traverse@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.5.tgz#c111b0f58afab4fea3d3385a406f692748c59870"
-  integrity sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==
-  dependencies:
-    "@babel/code-frame" "^7.14.5"
-    "@babel/generator" "^7.14.5"
-    "@babel/helper-function-name" "^7.14.5"
-    "@babel/helper-hoist-variables" "^7.14.5"
-    "@babel/helper-split-export-declaration" "^7.14.5"
-    "@babel/parser" "^7.14.5"
-    "@babel/types" "^7.14.5"
     debug "^4.1.0"
     globals "^11.1.0"
 
@@ -2194,14 +2003,6 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.19"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.5.tgz#3bb997ba829a2104cedb20689c4a5b8121d383ff"
-  integrity sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.14.5"
     to-fast-properties "^2.0.0"
 
 "@base2/pretty-print-object@1.0.0":
@@ -12914,12 +12715,7 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.3, lodash@^4.17.5, lodash@^4.2.1, lodash@~4.17.10:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
-
-lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
+lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.7.0, lodash@~4.17.10:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -15379,19 +15175,10 @@ postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
 
-postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.31, postcss@^7.0.32, postcss@^7.0.35, postcss@^7.0.5, postcss@^7.0.6:
+postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.13, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.31, postcss@^7.0.32, postcss@^7.0.35, postcss@^7.0.5, postcss@^7.0.6, postcss@^7.0.7:
   version "7.0.35"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.35.tgz#d2be00b998f7f211d8a276974079f2e92b970e24"
   integrity sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==
-  dependencies:
-    chalk "^2.4.2"
-    source-map "^0.6.1"
-    supports-color "^6.1.0"
-
-postcss@^7.0.13, postcss@^7.0.7:
-  version "7.0.36"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.36.tgz#056f8cffa939662a8f5905950c07d5285644dfcb"
-  integrity sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
@@ -17837,10 +17624,21 @@ stylelint-order@>=1.0.0, stylelint-order@^4.0.0:
     postcss "^7.0.31"
     postcss-sorting "^5.0.1"
 
-stylelint-scss@^3.19.0, stylelint-scss@^3.4.0:
+stylelint-scss@^3.19.0:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-3.19.0.tgz#528006d5a4c5a0f1f4d709b02fd3f626ed66d742"
   integrity sha512-Ic5bsmpS4wVucOw44doC1Yi9f5qbeVL4wPFiEOaUElgsOuLEN6Ofn/krKI8BeNL2gAn53Zu+IcVV4E345r6rBw==
+  dependencies:
+    lodash "^4.17.15"
+    postcss-media-query-parser "^0.2.3"
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-selector-parser "^6.0.2"
+    postcss-value-parser "^4.1.0"
+
+stylelint-scss@^3.4.0:
+  version "3.18.0"
+  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-3.18.0.tgz#8f06371c223909bf3f62e839548af1badeed31e9"
+  integrity sha512-LD7+hv/6/ApNGt7+nR/50ft7cezKP2HM5rI8avIdGaUWre3xlHfV4jKO/DRZhscfuN+Ewy9FMhcTq0CcS0C/SA==
   dependencies:
     lodash "^4.17.15"
     postcss-media-query-parser "^0.2.3"
@@ -18796,13 +18594,6 @@ unist-util-stringify-position@^2.0.0:
   dependencies:
     "@types/unist" "^2.0.2"
 
-unist-util-stringify-position@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-3.0.0.tgz#d517d2883d74d0daa0b565adc3d10a02b4a8cde9"
-  integrity sha512-SdfAl8fsDclywZpfMDTVDxA2V7LjtRDTOFd44wUJamgl6OlVngsqWjxvermMYf60elWHbxhuRCZml7AnuXCaSA==
-  dependencies:
-    "@types/unist" "^2.0.0"
-
 unist-util-visit-parents@^2.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
@@ -19121,13 +18912,13 @@ vfile-location@^3.0.0, vfile-location@^3.2.0:
   resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-3.2.0.tgz#d8e41fbcbd406063669ebf6c33d56ae8721d0f3c"
   integrity sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA==
 
-vfile-message@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-3.0.1.tgz#b9bcf87cb5525e61777e0c6df07e816a577588a3"
-  integrity sha512-gYmSHcZZUEtYpTmaWaFJwsuUD70/rTY4v09COp8TGtOkix6gGxb/a8iTQByIY9ciTk9GwAwIXd/J9OPfM4Bvaw==
+vfile-message@*, vfile-message@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-2.0.4.tgz#5b43b88171d409eae58477d13f23dd41d52c371a"
+  integrity sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==
   dependencies:
     "@types/unist" "^2.0.0"
-    unist-util-stringify-position "^3.0.0"
+    unist-util-stringify-position "^2.0.0"
 
 vfile-message@^1.0.0:
   version "1.1.1"
@@ -19135,14 +18926,6 @@ vfile-message@^1.0.0:
   integrity sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==
   dependencies:
     unist-util-stringify-position "^1.1.1"
-
-vfile-message@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-2.0.4.tgz#5b43b88171d409eae58477d13f23dd41d52c371a"
-  integrity sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    unist-util-stringify-position "^2.0.0"
 
 vfile@^3.0.0:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17656,6 +17656,11 @@ stylelint-scss@^3.2.0, stylelint-scss@^3.4.0:
     postcss-selector-parser "^6.0.2"
     postcss-value-parser "^4.1.0"
 
+stylelint-use-logical@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/stylelint-use-logical/-/stylelint-use-logical-1.1.0.tgz#f419386f48dae19fc59b024255c04f36738d879f"
+  integrity sha512-WwYAEoUNXxu4A9tZ+mPnvFSf3wKG9mY9+ZqnNjVHikfOQA4MTO6XeSC8BGCsY7LOG0GnDfmxMrRUJXFZRtaCmg==
+
 stylelint@^9.3.0:
   version "9.10.1"
   resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-9.10.1.tgz#5f0ee3701461dff1d68284e1386efe8f0677a75d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,7 +71,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@>=7.9.0":
+"@babel/core@>=7.2.2":
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.14.6.tgz#e0814ec1a950032ff16c13a2721de39a8416fcab"
   integrity sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==
@@ -4373,21 +4373,6 @@
     resolve-from "^5.0.0"
     store2 "^2.12.0"
 
-"@stylelint/postcss-css-in-js@^0.37.2":
-  version "0.37.2"
-  resolved "https://registry.yarnpkg.com/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.2.tgz#7e5a84ad181f4234a2480803422a47b8749af3d2"
-  integrity sha512-nEhsFoJurt8oUmieT8qy4nk81WRHmJynmVwn/Vts08PL9fhgIsMhk1GId5yAN643OzqEEb5S/6At2TZW7pqPDA==
-  dependencies:
-    "@babel/core" ">=7.9.0"
-
-"@stylelint/postcss-markdown@^0.36.2":
-  version "0.36.2"
-  resolved "https://registry.yarnpkg.com/@stylelint/postcss-markdown/-/postcss-markdown-0.36.2.tgz#0a540c4692f8dcdfc13c8e352c17e7bfee2bb391"
-  integrity sha512-2kGbqUVJUGE8dM+bMzXG/PYUWKkjLIkRLWNh39OaADkiabDRdw8ATFCgbMz5xdIcvwspPAluSL7uY+ZiTWdWmQ==
-  dependencies:
-    remark "^13.0.0"
-    unist-util-find-all-after "^3.0.2"
-
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
@@ -4750,6 +4735,22 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
+
+"@types/vfile-message@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/vfile-message/-/vfile-message-2.0.0.tgz#690e46af0fdfc1f9faae00cd049cc888957927d5"
+  integrity sha512-GpTIuDpb9u4zIO165fUy9+fXcULdD8HFRNli04GehoMVbeNq7D6OBnqSmg3lxZnC+UvgUhEWKxdKiwYUkGltIw==
+  dependencies:
+    vfile-message "*"
+
+"@types/vfile@^3.0.0":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/vfile/-/vfile-3.0.2.tgz#19c18cd232df11ce6fa6ad80259bc86c366b09b9"
+  integrity sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==
+  dependencies:
+    "@types/node" "*"
+    "@types/unist" "*"
+    "@types/vfile-message" "*"
 
 "@types/webpack-env@^1.16.0":
   version "1.16.0"
@@ -5845,6 +5846,11 @@ ast-types@^0.14.2:
   dependencies:
     tslib "^2.0.1"
 
+astral-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
+  integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
+
 astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
@@ -5899,7 +5905,7 @@ autocomplete.js@0.36.0:
   dependencies:
     immediate "^3.2.3"
 
-autoprefixer@^9.5.1, autoprefixer@^9.8.6:
+autoprefixer@^9.0.0, autoprefixer@^9.5.1, autoprefixer@^9.8.6:
   version "9.8.6"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.8.6.tgz#3b73594ca1bf9266320c5acf1588d74dea74210f"
   integrity sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==
@@ -6157,11 +6163,6 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
-
-balanced-match@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
-  integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
 
 base64-js@^1.0.2:
   version "1.3.1"
@@ -6804,7 +6805,7 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.5.tgz#ac82a944905a65ce204eb03023157edf29425c17"
   integrity sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.3.1, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.1, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -6840,7 +6841,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.1.0, chalk@^4.1.1:
+chalk@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
   integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
@@ -6852,6 +6853,11 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+character-entities-html4@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.4.tgz#0e64b0a3753ddbf1fdc044c5fd01d0199a02e125"
+  integrity sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==
 
 character-entities-legacy@^1.0.0:
   version "1.1.4"
@@ -7079,12 +7085,13 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
-clone-regexp@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/clone-regexp/-/clone-regexp-2.2.0.tgz#7d65e00885cd8796405c35a737e7a86b7429e36f"
-  integrity sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==
+clone-regexp@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/clone-regexp/-/clone-regexp-1.0.1.tgz#051805cd33173375d82118fc0918606da39fd60f"
+  integrity sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==
   dependencies:
-    is-regexp "^2.0.0"
+    is-regexp "^1.0.0"
+    is-supported-regexp-flag "^1.0.0"
 
 clone-response@^1.0.2:
   version "1.0.2"
@@ -9281,12 +9288,12 @@ execa@^4.0.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
-execall@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/execall/-/execall-2.0.0.tgz#16a06b5fe5099df7d00be5d9c06eecded1663b45"
-  integrity sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==
+execall@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execall/-/execall-1.0.0.tgz#73d0904e395b3cab0658b08d09ec25307f29bb73"
+  integrity sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=
   dependencies:
-    clone-regexp "^2.1.0"
+    clone-regexp "^1.0.0"
 
 exit@^0.1.2:
   version "0.1.2"
@@ -9447,7 +9454,7 @@ fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.1.1, fast-glob@^3.2.5:
+fast-glob@^3.1.1:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
   integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
@@ -9473,11 +9480,6 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
-
-fastest-levenshtein@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
-  integrity sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==
 
 fastq@^1.6.0:
   version "1.11.0"
@@ -9539,6 +9541,13 @@ figures@^3.0.0:
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   dependencies:
     escape-string-regexp "^1.0.5"
+
+file-entry-cache@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-4.0.0.tgz#633567d15364aefe0b299e1e217735e8f3a9f6e8"
+  integrity sha512-AVSwsnbV8vH/UVbvgEhf3saVQXORNv0ZzSkvkhQIaia5Tia+JhGTaa/ePUSVoPHQyGayQNmYfkzFi3WZV5zcpA==
+  dependencies:
+    flat-cache "^2.0.1"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -9688,6 +9697,15 @@ findup-sync@^3.0.0:
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
 
+flat-cache@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
+  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+  dependencies:
+    flatted "^2.0.0"
+    rimraf "2.6.3"
+    write "1.0.3"
+
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -9695,6 +9713,11 @@ flat-cache@^3.0.4:
   dependencies:
     flatted "^3.1.0"
     rimraf "^3.0.2"
+
+flatted@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
+  integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
 flatted@^3.1.0:
   version "3.1.1"
@@ -10041,7 +10064,7 @@ get-port@^4.2.0:
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-4.2.0.tgz#e37368b1e863b7629c43c5a323625f95cf24b119"
   integrity sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==
 
-get-stdin@8.0.0, get-stdin@^8.0.0:
+get-stdin@8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-8.0.0.tgz#cbad6a73feb75f6eeb22ba9e01f89aa28aa97a53"
   integrity sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==
@@ -10341,7 +10364,7 @@ globby@^7.1.1:
     pify "^3.0.0"
     slash "^1.0.0"
 
-globby@^9.2.0:
+globby@^9.0.0, globby@^9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
   integrity sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==
@@ -10369,7 +10392,7 @@ globule@^1.0.0:
     lodash "~4.17.10"
     minimatch "~3.0.2"
 
-gonzales-pe@^4.3.0:
+gonzales-pe@^4.2.3:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/gonzales-pe/-/gonzales-pe-4.3.0.tgz#fe9dec5f3c557eead09ff868c65826be54d067b3"
   integrity sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==
@@ -11037,7 +11060,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1, ignore@^5.1.4, ignore@^5.1.8:
+ignore@^5.0.4, ignore@^5.1.1, ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
@@ -11102,10 +11125,10 @@ import-lazy@^2.1.0:
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
   integrity sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=
 
-import-lazy@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
-  integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
+import-lazy@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-3.1.0.tgz#891279202c8a2280fdbd6674dbd8da1a1dfc67cc"
+  integrity sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==
 
 import-local@^1.0.0:
   version "1.0.0"
@@ -11316,6 +11339,11 @@ is-alphabetical@1.0.4, is-alphabetical@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz#9e7d6b94916be22153745d184c298cbf986a686d"
   integrity sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==
+
+is-alphanumeric@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz#4a9cef71daf4c001c1d81d63d140cf53fd6889f4"
+  integrity sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ=
 
 is-alphanumerical@^1.0.0:
   version "1.0.4"
@@ -11697,10 +11725,10 @@ is-regex@^1.1.2:
     call-bind "^1.0.2"
     has-symbols "^1.0.2"
 
-is-regexp@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-2.1.0.tgz#cd734a56864e23b956bf4e7c66c396a4c0b22c2d"
-  integrity sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+  integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
 
 is-resolvable@^1.0.0:
   version "1.1.0"
@@ -11739,6 +11767,11 @@ is-string@^1.0.5:
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
   integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
 
+is-supported-regexp-flag@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz#21ee16518d2c1dd3edd3e9a0d57e50207ac364ca"
+  integrity sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==
+
 is-svg@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-3.0.0.tgz#9321dbd29c212e5ca99c4fa9794c714bcafa2f75"
@@ -11771,11 +11804,6 @@ is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
-
-is-unicode-supported@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
-  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
 is-utf8@^0.2.0:
   version "0.2.1"
@@ -12583,10 +12611,10 @@ klona@^2.0.4:
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.4.tgz#7bb1e3affb0cb8624547ef7e8f6708ea2e39dfc0"
   integrity sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==
 
-known-css-properties@^0.21.0:
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.21.0.tgz#15fbd0bbb83447f3ce09d8af247ed47c68ede80d"
-  integrity sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw==
+known-css-properties@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.11.0.tgz#0da784f115ea77c76b81536d7052e90ee6c86a8a"
+  integrity sha512-bEZlJzXo5V/ApNNa5z375mJC6Nrz4vG43UgcSCrg2OHC+yuB6j0iDSrY7RQ/+PRofFB03wNIIt9iXIVLr4wc7w==
 
 language-subtag-registry@~0.3.2:
   version "0.3.21"
@@ -12655,6 +12683,11 @@ lerna@3.3.2:
     "@lerna/version" "^3.3.2"
     import-local "^1.0.0"
     npmlog "^4.1.2"
+
+leven@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
+  integrity sha1-wuep93IJTe6dNCAq6KzORoeHVYA=
 
 leven@^3.1.0:
   version "3.1.0"
@@ -12886,25 +12919,24 @@ lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.1
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
-lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-log-symbols@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
-  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
+log-symbols@^2.0.0, log-symbols@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
   dependencies:
-    chalk "^4.1.0"
-    is-unicode-supported "^0.1.0"
+    chalk "^2.0.1"
 
 loglevel@^1.6.8:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.0.tgz#728166855a740d59d38db01cf46f042caa041bb0"
   integrity sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ==
 
-longest-streak@^2.0.0:
+longest-streak@^2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
   integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
@@ -13107,6 +13139,11 @@ markdown-it@^8.4.1:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
+markdown-table@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
+  integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
+
 markdown-to-jsx@^6.11.4:
   version "6.11.4"
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz#b4528b1ab668aef7fe61c1535c27e837819392c5"
@@ -13120,7 +13157,7 @@ markdown-to-jsx@^7.1.0:
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.1.2.tgz#19d3da4cd8864045cdd13a0d179147fbd6a088d4"
   integrity sha512-O8DMCl32V34RrD+ZHxcAPc2+kYytuDIoQYjY36RVdsLK7uHjgNVvFec4yv0X6LgB4YEZgSvK5QtFi5YVqEpoMA==
 
-mathml-tag-names@^2.1.3:
+mathml-tag-names@^2.0.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz#4ddadd67308e780cf16a47685878ee27b736a0a3"
   integrity sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==
@@ -13141,23 +13178,19 @@ mdast-squeeze-paragraphs@^4.0.0:
   dependencies:
     unist-util-remove "^2.0.0"
 
+mdast-util-compact@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mdast-util-compact/-/mdast-util-compact-1.0.4.tgz#d531bb7667b5123abf20859be086c4d06c894593"
+  integrity sha512-3YDMQHI5vRiS2uygEFYaqckibpJtKq5Sj2c8JioeOQBU6INpKbdWzfyLqFFnDwEcEnRFIdMsguzs5pC1Jp4Isg==
+  dependencies:
+    unist-util-visit "^1.1.0"
+
 mdast-util-definitions@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-4.0.0.tgz#c5c1a84db799173b4dcf7643cda999e440c24db2"
   integrity sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==
   dependencies:
     unist-util-visit "^2.0.0"
-
-mdast-util-from-markdown@^0.8.0:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz#d1ef2ca42bc377ecb0463a987910dae89bd9a28c"
-  integrity sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==
-  dependencies:
-    "@types/mdast" "^3.0.0"
-    mdast-util-to-string "^2.0.0"
-    micromark "~2.11.0"
-    parse-entities "^2.0.0"
-    unist-util-stringify-position "^2.0.0"
 
 mdast-util-to-hast@10.0.1:
   version "10.0.1"
@@ -13173,27 +13206,10 @@ mdast-util-to-hast@10.0.1:
     unist-util-position "^3.0.0"
     unist-util-visit "^2.0.0"
 
-mdast-util-to-markdown@^0.6.0:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz#b33f67ca820d69e6cc527a93d4039249b504bebe"
-  integrity sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    longest-streak "^2.0.0"
-    mdast-util-to-string "^2.0.0"
-    parse-entities "^2.0.0"
-    repeat-string "^1.0.0"
-    zwitch "^1.0.0"
-
 mdast-util-to-string@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz#27055500103f51637bd07d01da01eb1967a43527"
   integrity sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==
-
-mdast-util-to-string@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz#b8cfe6a713e1091cb5b728fc48885a4767f8b97b"
-  integrity sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==
 
 mdn-data@2.0.4:
   version "2.0.4"
@@ -13276,6 +13292,21 @@ meow@^4.0.0:
     redent "^2.0.0"
     trim-newlines "^2.0.0"
 
+meow@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-5.0.0.tgz#dfc73d63a9afc714a5e371760eb5c88b91078aa4"
+  integrity sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==
+  dependencies:
+    camelcase-keys "^4.0.0"
+    decamelize-keys "^1.0.0"
+    loud-rejection "^1.0.0"
+    minimist-options "^3.0.1"
+    normalize-package-data "^2.3.4"
+    read-pkg-up "^3.0.0"
+    redent "^2.0.0"
+    trim-newlines "^2.0.0"
+    yargs-parser "^10.0.0"
+
 meow@^7.0.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/meow/-/meow-7.1.1.tgz#7c01595e3d337fcb0ec4e8eed1666ea95903d306"
@@ -13300,24 +13331,6 @@ meow@^8.0.0:
   dependencies:
     "@types/minimist" "^1.2.0"
     camelcase-keys "^6.2.2"
-    decamelize-keys "^1.1.0"
-    hard-rejection "^2.1.0"
-    minimist-options "4.1.0"
-    normalize-package-data "^3.0.0"
-    read-pkg-up "^7.0.1"
-    redent "^3.0.0"
-    trim-newlines "^3.0.0"
-    type-fest "^0.18.0"
-    yargs-parser "^20.2.3"
-
-meow@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-9.0.0.tgz#cd9510bc5cac9dee7d03c73ee1f9ad959f4ea364"
-  integrity sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==
-  dependencies:
-    "@types/minimist" "^1.2.0"
-    camelcase-keys "^6.2.2"
-    decamelize "^1.2.0"
     decamelize-keys "^1.1.0"
     hard-rejection "^2.1.0"
     minimist-options "4.1.0"
@@ -13360,14 +13373,6 @@ microevent.ts@~0.1.1:
   resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"
   integrity sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==
 
-micromark@~2.11.0:
-  version "2.11.4"
-  resolved "https://registry.yarnpkg.com/micromark/-/micromark-2.11.4.tgz#d13436138eea826383e822449c9a5c50ee44665a"
-  integrity sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==
-  dependencies:
-    debug "^4.0.0"
-    parse-entities "^2.0.0"
-
 micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -13387,7 +13392,7 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.2, micromatch@^4.0.4:
+micromatch@^4.0.2:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
   integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
@@ -14615,6 +14620,18 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.5:
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
 
+parse-entities@^1.0.2, parse-entities@^1.1.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.2.tgz#c31bf0f653b6661354f8973559cb86dd1d5edf50"
+  integrity sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 parse-entities@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-2.0.0.tgz#53c6eb5b9314a1f4ec99fa0fdf7ce01ecda0cbe8"
@@ -14829,7 +14846,7 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
-pify@^4.0.1:
+pify@^4.0.0, pify@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
@@ -14986,7 +15003,14 @@ postcss-html@^0.36.0:
   dependencies:
     htmlparser2 "^3.10.0"
 
-postcss-less@^3.1.4:
+postcss-jsx@^0.36.0:
+  version "0.36.4"
+  resolved "https://registry.yarnpkg.com/postcss-jsx/-/postcss-jsx-0.36.4.tgz#37a68f300a39e5748d547f19a747b3257240bd50"
+  integrity sha512-jwO/7qWUvYuWYnpOb0+4bIIgJt7003pgU3P6nETBLaOyBXuTD55ho21xnals5nBrlpTIFodyd3/jBi6UO3dHvA==
+  dependencies:
+    "@babel/core" ">=7.2.2"
+
+postcss-less@^3.1.0:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/postcss-less/-/postcss-less-3.1.4.tgz#369f58642b5928ef898ffbc1a6e93c958304c5ad"
   integrity sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==
@@ -15021,6 +15045,14 @@ postcss-loader@^4.2.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
     semver "^7.3.4"
+
+postcss-markdown@^0.36.0:
+  version "0.36.0"
+  resolved "https://registry.yarnpkg.com/postcss-markdown/-/postcss-markdown-0.36.0.tgz#7f22849ae0e3db18820b7b0d5e7833f13a447560"
+  integrity sha512-rl7fs1r/LNSB2bWRhyZ+lM/0bwKv9fhl38/06gF6mKMo/NPnp55+K1dSTosSVjFZc0e1ppBlu+WT91ba0PMBfQ==
+  dependencies:
+    remark "^10.0.1"
+    unist-util-find-all-after "^1.0.2"
 
 postcss-media-query-parser@^0.2.3:
   version "0.2.3"
@@ -15249,34 +15281,44 @@ postcss-reduce-transforms@^4.0.2:
     postcss "^7.0.0"
     postcss-value-parser "^3.0.0"
 
+postcss-reporter@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-reporter/-/postcss-reporter-6.0.1.tgz#7c055120060a97c8837b4e48215661aafb74245f"
+  integrity sha512-LpmQjfRWyabc+fRygxZjpRxfhRf9u/fdlKf4VHG4TSPbV2XNsuISzYW1KL+1aQzx53CAppa1bKG4APIB/DOXXw==
+  dependencies:
+    chalk "^2.4.1"
+    lodash "^4.17.11"
+    log-symbols "^2.2.0"
+    postcss "^7.0.7"
+
 postcss-resolve-nested-selector@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz#29ccbc7c37dedfac304e9fff0bf1596b3f6a0e4e"
   integrity sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=
 
-postcss-safe-parser@^4.0.1, postcss-safe-parser@^4.0.2:
+postcss-safe-parser@^4.0.0, postcss-safe-parser@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-4.0.2.tgz#a6d4e48f0f37d9f7c11b2a581bf00f8ba4870b96"
   integrity sha512-Uw6ekxSWNLCPesSv/cmqf2bY/77z11O7jZGPax3ycZMFU/oi2DMH9i89AdHc1tRwFg/arFoEwX0IS3LCUxJh1g==
   dependencies:
     postcss "^7.0.26"
 
-postcss-sass@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/postcss-sass/-/postcss-sass-0.4.4.tgz#91f0f3447b45ce373227a98b61f8d8f0785285a3"
-  integrity sha512-BYxnVYx4mQooOhr+zer0qWbSPYnarAy8ZT7hAQtbxtgVf8gy+LSLT/hHGe35h14/pZDTw1DsxdbrwxBN++H+fg==
+postcss-sass@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/postcss-sass/-/postcss-sass-0.3.5.tgz#6d3e39f101a53d2efa091f953493116d32beb68c"
+  integrity sha512-B5z2Kob4xBxFjcufFnhQ2HqJQ2y/Zs/ic5EZbCywCkxKd756Q40cIQ/veRDwSrw1BF6+4wUgmpm0sBASqVi65A==
   dependencies:
-    gonzales-pe "^4.3.0"
-    postcss "^7.0.21"
+    gonzales-pe "^4.2.3"
+    postcss "^7.0.1"
 
-postcss-scss@^2.1.1:
+postcss-scss@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-2.1.1.tgz#ec3a75fa29a55e016b90bf3269026c53c1d2b383"
   integrity sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==
   dependencies:
     postcss "^7.0.6"
 
-postcss-selector-parser@^3.0.0:
+postcss-selector-parser@^3.0.0, postcss-selector-parser@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz#b310f5c4c0fdaf76f94902bbaa30db6aa84f5270"
   integrity sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==
@@ -15293,14 +15335,6 @@ postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2:
     cssesc "^3.0.0"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
-    util-deprecate "^1.0.2"
-
-postcss-selector-parser@^6.0.5:
-  version "6.0.6"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz#2c5bba8174ac2f6981ab631a42ab0ee54af332ea"
-  integrity sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==
-  dependencies:
-    cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
 postcss-sorting@^5.0.1:
@@ -15354,7 +15388,7 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postcss@^7.0.21:
+postcss@^7.0.13, postcss@^7.0.7:
   version "7.0.36"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.36.tgz#056f8cffa939662a8f5905950c07d5285644dfcb"
   integrity sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==
@@ -16326,12 +16360,26 @@ remark-parse@8.0.3:
     vfile-location "^3.0.0"
     xtend "^4.0.1"
 
-remark-parse@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-9.0.0.tgz#4d20a299665880e4f4af5d90b7c7b8a935853640"
-  integrity sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==
+remark-parse@^6.0.0:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-6.0.3.tgz#c99131052809da482108413f87b0ee7f52180a3a"
+  integrity sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==
   dependencies:
-    mdast-util-from-markdown "^0.8.0"
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.1.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
 
 remark-slug@^6.0.0:
   version "6.0.0"
@@ -16349,21 +16397,34 @@ remark-squeeze-paragraphs@4.0.0:
   dependencies:
     mdast-squeeze-paragraphs "^4.0.0"
 
-remark-stringify@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-9.0.1.tgz#576d06e910548b0a7191a71f27b33f1218862894"
-  integrity sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==
+remark-stringify@^6.0.0:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-6.0.4.tgz#16ac229d4d1593249018663c7bddf28aafc4e088"
+  integrity sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==
   dependencies:
-    mdast-util-to-markdown "^0.6.0"
+    ccount "^1.0.0"
+    is-alphanumeric "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    longest-streak "^2.0.1"
+    markdown-escapes "^1.0.0"
+    markdown-table "^1.1.0"
+    mdast-util-compact "^1.0.0"
+    parse-entities "^1.0.2"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    stringify-entities "^1.0.1"
+    unherit "^1.0.4"
+    xtend "^4.0.1"
 
-remark@^13.0.0:
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/remark/-/remark-13.0.0.tgz#d15d9bf71a402f40287ebe36067b66d54868e425"
-  integrity sha512-HDz1+IKGtOyWN+QgBiAT0kn+2s6ovOxHyPAFGKVE81VSzJ+mq7RwHFledEvB5F1p4iJvOah/LOKdFuzvRnNLCA==
+remark@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/remark/-/remark-10.0.1.tgz#3058076dc41781bf505d8978c291485fe47667df"
+  integrity sha512-E6lMuoLIy2TyiokHprMjcWNJ5UxfGQjaMSMhV+f4idM625UjjK4j798+gPs5mfjzDE6vL0oFKVeZM6gZVSVrzQ==
   dependencies:
-    remark-parse "^9.0.0"
-    remark-stringify "^9.0.0"
-    unified "^9.1.0"
+    remark-parse "^6.0.0"
+    remark-stringify "^6.0.0"
+    unified "^7.0.0"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -16386,7 +16447,7 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
   integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
-repeat-string@^1.0.0, repeat-string@^1.5.4, repeat-string@^1.6.1:
+repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
@@ -16397,6 +16458,11 @@ repeating@^2.0.0:
   integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
   dependencies:
     is-finite "^1.0.0"
+
+replace-ext@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
+  integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
 
 request-promise-core@1.1.4:
   version "1.1.4"
@@ -16593,6 +16659,13 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   dependencies:
     glob "^7.1.3"
 
@@ -17053,6 +17126,15 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+slice-ansi@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
+  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
+  dependencies:
+    ansi-styles "^3.2.0"
+    astral-regex "^1.0.0"
+    is-fullwidth-code-point "^2.0.0"
+
 slice-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
@@ -17480,7 +17562,7 @@ string-width@^4.0.0, string-width@^4.1.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
-string-width@^4.2.0, string-width@^4.2.2:
+string-width@^4.2.0:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
   integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
@@ -17565,6 +17647,16 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
+
+stringify-entities@^1.0.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-1.3.2.tgz#a98417e5471fd227b3e45d3db1861c11caf668f7"
+  integrity sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==
+  dependencies:
+    character-entities-html4 "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-hexadecimal "^1.0.0"
 
 strip-ansi@6.0.0, strip-ansi@^6.0.0:
   version "6.0.0"
@@ -17716,27 +17808,27 @@ stylelint-config-property-sort-order-smacss@^7.1.0:
     css-property-sort-order-smacss "~2.1.3"
     stylelint-order "^4.0.0"
 
-stylelint-config-recommended@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-5.0.0.tgz#fb5653f495a60b4938f2ad3e77712d9e1039ae78"
-  integrity sha512-c8aubuARSu5A3vEHLBeOSJt1udOdS+1iue7BmJDTSXoCBmfEQmmWX+59vYIj3NQdJBY6a/QRv1ozVFpaB9jaqA==
+stylelint-config-recommended@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-2.2.0.tgz#46ab139db4a0e7151fd5f94af155512886c96d3f"
+  integrity sha512-bZ+d4RiNEfmoR74KZtCKmsABdBJr4iXRiCso+6LtMJPw5rd/KnxUWTxht7TbafrTJK1YRjNgnN0iVZaJfc3xJA==
 
-stylelint-config-sass-guidelines@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-sass-guidelines/-/stylelint-config-sass-guidelines-8.0.0.tgz#e92279aa052a04e822dd096d7c46c8e37d4b3406"
-  integrity sha512-v21iDWtzpfhuKJlYKpoE1vjp+GT8Cr6ZBWwMx/jf+eCEblZgAIDVVjgAELoDLhVj17DcEFwlIKJBMfrdAmXg0Q==
+stylelint-config-sass-guidelines@^5.0.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-sass-guidelines/-/stylelint-config-sass-guidelines-5.4.0.tgz#82f02ab6231f10564105d4fc192ca6cc75fede36"
+  integrity sha512-+etE2MuxbIy4GXdfqJS2y0/K6I04opnpiKFFmbICd8STxCiP/ZkNDBM3Os69ckr+dB2yIXnqMOwRtoMahS20Gg==
   dependencies:
-    stylelint-order "^4.0.0"
-    stylelint-scss "^3.18.0"
+    stylelint-order ">=1.0.0"
+    stylelint-scss "^3.4.0"
 
-stylelint-config-standard@^22.0.0:
-  version "22.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-22.0.0.tgz#c860be9a13ebbc1b084456fa10527bf13a44addf"
-  integrity sha512-uQVNi87SHjqTm8+4NIP5NMAyY/arXrBgimaaT7skvRfE9u3JKXRK9KBkbr4pVmeciuCcs64kAdjlxfq6Rur7Hw==
+stylelint-config-standard@^18.2.0:
+  version "18.3.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-18.3.0.tgz#a2a1b788d2cf876c013feaff8ae276117a1befa7"
+  integrity sha512-Tdc/TFeddjjy64LvjPau9SsfVRexmTFqUhnMBrzz07J4p2dVQtmpncRF/o8yZn8ugA3Ut43E6o1GtjX80TFytw==
   dependencies:
-    stylelint-config-recommended "^5.0.0"
+    stylelint-config-recommended "^2.2.0"
 
-stylelint-order@^4.0.0, stylelint-order@^4.1.0:
+stylelint-order@>=1.0.0, stylelint-order@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/stylelint-order/-/stylelint-order-4.1.0.tgz#692d05b7d0c235ac66fcf5ea1d9e5f08a76747f6"
   integrity sha512-sVTikaDvMqg2aJjh4r48jsdfmqLT+nqB1MOsaBnvM3OwLx4S+WXcsxsgk5w18h/OZoxZCxuyXMh61iBHcj9Qiw==
@@ -17745,7 +17837,7 @@ stylelint-order@^4.0.0, stylelint-order@^4.1.0:
     postcss "^7.0.31"
     postcss-sorting "^5.0.1"
 
-stylelint-scss@^3.18.0, stylelint-scss@^3.19.0:
+stylelint-scss@^3.19.0, stylelint-scss@^3.4.0:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-3.19.0.tgz#528006d5a4c5a0f1f4d709b02fd3f626ed66d742"
   integrity sha512-Ic5bsmpS4wVucOw44doC1Yi9f5qbeVL4wPFiEOaUElgsOuLEN6Ofn/krKI8BeNL2gAn53Zu+IcVV4E345r6rBw==
@@ -17761,59 +17853,58 @@ stylelint-use-logical-spec@^3.2.0:
   resolved "https://registry.yarnpkg.com/stylelint-use-logical-spec/-/stylelint-use-logical-spec-3.2.0.tgz#ec74f3ab2a61374ca20bb3b7e9eec71c4190ffa7"
   integrity sha512-3DRpU0HuLwHFGg4hZi1KHSH5sI/X0u4ZR2GA0lhavlcZvEDUkWRzqjA1Jh5I2nXi1KHqL7q/fM1lcKjWDbuqZA==
 
-stylelint@^13.13.1:
-  version "13.13.1"
-  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-13.13.1.tgz#fca9c9f5de7990ab26a00f167b8978f083a18f3c"
-  integrity sha512-Mv+BQr5XTUrKqAXmpqm6Ddli6Ief+AiPZkRsIrAoUKFuq/ElkUh9ZMYxXD0iQNZ5ADghZKLOWz1h7hTClB7zgQ==
+stylelint@^9.3.0:
+  version "9.10.1"
+  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-9.10.1.tgz#5f0ee3701461dff1d68284e1386efe8f0677a75d"
+  integrity sha512-9UiHxZhOAHEgeQ7oLGwrwoDR8vclBKlSX7r4fH0iuu0SfPwFaLkb1c7Q2j1cqg9P7IDXeAV2TvQML/fRQzGBBQ==
   dependencies:
-    "@stylelint/postcss-css-in-js" "^0.37.2"
-    "@stylelint/postcss-markdown" "^0.36.2"
-    autoprefixer "^9.8.6"
-    balanced-match "^2.0.0"
-    chalk "^4.1.1"
-    cosmiconfig "^7.0.0"
-    debug "^4.3.1"
-    execall "^2.0.0"
-    fast-glob "^3.2.5"
-    fastest-levenshtein "^1.0.12"
-    file-entry-cache "^6.0.1"
-    get-stdin "^8.0.0"
+    autoprefixer "^9.0.0"
+    balanced-match "^1.0.0"
+    chalk "^2.4.1"
+    cosmiconfig "^5.0.0"
+    debug "^4.0.0"
+    execall "^1.0.0"
+    file-entry-cache "^4.0.0"
+    get-stdin "^6.0.0"
     global-modules "^2.0.0"
-    globby "^11.0.3"
+    globby "^9.0.0"
     globjoin "^0.1.4"
-    html-tags "^3.1.0"
-    ignore "^5.1.8"
-    import-lazy "^4.0.0"
+    html-tags "^2.0.0"
+    ignore "^5.0.4"
+    import-lazy "^3.1.0"
     imurmurhash "^0.1.4"
-    known-css-properties "^0.21.0"
-    lodash "^4.17.21"
-    log-symbols "^4.1.0"
-    mathml-tag-names "^2.1.3"
-    meow "^9.0.0"
-    micromatch "^4.0.4"
+    known-css-properties "^0.11.0"
+    leven "^2.1.0"
+    lodash "^4.17.4"
+    log-symbols "^2.0.0"
+    mathml-tag-names "^2.0.1"
+    meow "^5.0.0"
+    micromatch "^3.1.10"
     normalize-selector "^0.2.0"
-    postcss "^7.0.35"
+    pify "^4.0.0"
+    postcss "^7.0.13"
     postcss-html "^0.36.0"
-    postcss-less "^3.1.4"
+    postcss-jsx "^0.36.0"
+    postcss-less "^3.1.0"
+    postcss-markdown "^0.36.0"
     postcss-media-query-parser "^0.2.3"
+    postcss-reporter "^6.0.0"
     postcss-resolve-nested-selector "^0.1.1"
-    postcss-safe-parser "^4.0.2"
-    postcss-sass "^0.4.4"
-    postcss-scss "^2.1.1"
-    postcss-selector-parser "^6.0.5"
+    postcss-safe-parser "^4.0.0"
+    postcss-sass "^0.3.5"
+    postcss-scss "^2.0.0"
+    postcss-selector-parser "^3.1.0"
     postcss-syntax "^0.36.2"
-    postcss-value-parser "^4.1.0"
-    resolve-from "^5.0.0"
-    slash "^3.0.0"
+    postcss-value-parser "^3.3.0"
+    resolve-from "^4.0.0"
+    signal-exit "^3.0.2"
+    slash "^2.0.0"
     specificity "^0.4.1"
-    string-width "^4.2.2"
-    strip-ansi "^6.0.0"
+    string-width "^3.0.0"
     style-search "^0.1.0"
     sugarss "^2.0.0"
     svg-tags "^1.0.0"
-    table "^6.6.0"
-    v8-compile-cache "^2.3.0"
-    write-file-atomic "^3.0.3"
+    table "^5.0.0"
 
 stylus-loader@^3.0.2:
   version "3.0.2"
@@ -17928,7 +18019,17 @@ tabbable@^5.1.4:
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.5.tgz#efec48ede268d511c261e3b81facbb4782a35147"
   integrity sha512-oVAPrWgLLqrbvQE8XqcU7CVBq6SQbaIbHkhOca3u7/jzuQvyZycrUKPCGr04qpEIUslmUlULbSeN+m3QrKEykA==
 
-table@^6.0.9, table@^6.6.0:
+table@^5.0.0:
+  version "5.4.6"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
+  integrity sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
+  dependencies:
+    ajv "^6.10.2"
+    lodash "^4.17.14"
+    slice-ansi "^2.1.0"
+    string-width "^3.0.0"
+
+table@^6.0.9:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/table/-/table-6.7.1.tgz#ee05592b7143831a8c94f3cee6aae4c1ccef33e2"
   integrity sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==
@@ -18575,17 +18676,19 @@ unified@9.2.0:
     trough "^1.0.0"
     vfile "^4.0.0"
 
-unified@^9.1.0:
-  version "9.2.1"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.1.tgz#ae18d5674c114021bfdbdf73865ca60f410215a3"
-  integrity sha512-juWjuI8Z4xFg8pJbnEZ41b5xjGUWGHqXALmBZ3FC3WX0PIx1CZBIIJ6mXbYMcf6Yw4Fi0rFUTA1cdz/BglbOhA==
+unified@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-7.1.0.tgz#5032f1c1ee3364bd09da12e27fdd4a7553c7be13"
+  integrity sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==
   dependencies:
+    "@types/unist" "^2.0.0"
+    "@types/vfile" "^3.0.0"
     bail "^1.0.0"
     extend "^3.0.0"
-    is-buffer "^2.0.0"
-    is-plain-obj "^2.0.0"
+    is-plain-obj "^1.1.0"
     trough "^1.0.0"
-    vfile "^4.0.0"
+    vfile "^3.0.0"
+    x-is-string "^0.1.0"
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -18633,17 +18736,22 @@ unist-builder@2.0.3, unist-builder@^2.0.0:
   resolved "https://registry.yarnpkg.com/unist-builder/-/unist-builder-2.0.3.tgz#77648711b5d86af0942f334397a33c5e91516436"
   integrity sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==
 
-unist-util-find-all-after@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/unist-util-find-all-after/-/unist-util-find-all-after-3.0.2.tgz#fdfecd14c5b7aea5e9ef38d5e0d5f774eeb561f6"
-  integrity sha512-xaTC/AGZ0rIM2gM28YVRAFPIZpzbpDtU3dRmp7EXlNVA8ziQc4hY3H7BHXM1J49nEmiqc3svnqMReW+PGqbZKQ==
+unist-util-find-all-after@^1.0.2:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/unist-util-find-all-after/-/unist-util-find-all-after-1.0.5.tgz#5751a8608834f41d117ad9c577770c5f2f1b2899"
+  integrity sha512-lWgIc3rrTMTlK1Y0hEuL+k+ApzFk78h+lsaa2gHf63Gp5Ww+mt11huDniuaoq1H+XMK2lIIjjPkncxXcDp3QDw==
   dependencies:
-    unist-util-is "^4.0.0"
+    unist-util-is "^3.0.0"
 
 unist-util-generated@^1.0.0:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-1.1.6.tgz#5ab51f689e2992a472beb1b35f2ce7ff2f324d4b"
   integrity sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg==
+
+unist-util-is@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
+  integrity sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
 
 unist-util-is@^4.0.0:
   version "4.1.0"
@@ -18654,6 +18762,13 @@ unist-util-position@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-3.1.0.tgz#1c42ee6301f8d52f47d14f62bbdb796571fa2d47"
   integrity sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==
+
+unist-util-remove-position@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz#ec037348b6102c897703eee6d0294ca4755a2020"
+  integrity sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==
+  dependencies:
+    unist-util-visit "^1.1.0"
 
 unist-util-remove-position@^2.0.0:
   version "2.0.1"
@@ -18669,12 +18784,31 @@ unist-util-remove@^2.0.0:
   dependencies:
     unist-util-is "^4.0.0"
 
+unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
+  integrity sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==
+
 unist-util-stringify-position@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz#cce3bfa1cdf85ba7375d1d5b17bdc4cada9bd9da"
   integrity sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==
   dependencies:
     "@types/unist" "^2.0.2"
+
+unist-util-stringify-position@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-3.0.0.tgz#d517d2883d74d0daa0b565adc3d10a02b4a8cde9"
+  integrity sha512-SdfAl8fsDclywZpfMDTVDxA2V7LjtRDTOFd44wUJamgl6OlVngsqWjxvermMYf60elWHbxhuRCZml7AnuXCaSA==
+  dependencies:
+    "@types/unist" "^2.0.0"
+
+unist-util-visit-parents@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
+  integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==
+  dependencies:
+    unist-util-is "^3.0.0"
 
 unist-util-visit-parents@^3.0.0:
   version "3.1.1"
@@ -18692,6 +18826,13 @@ unist-util-visit@2.0.3, unist-util-visit@^2.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
     unist-util-visit-parents "^3.0.0"
+
+unist-util-visit@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
+  integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
+  dependencies:
+    unist-util-visit-parents "^2.0.0"
 
 universal-user-agent@^4.0.0:
   version "4.0.1"
@@ -18918,11 +19059,6 @@ v8-compile-cache@^2.1.1:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"
   integrity sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==
 
-v8-compile-cache@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
-  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
-
 v8-to-istanbul@^7.0.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-7.1.1.tgz#04bfd1026ba4577de5472df4f5e89af49de5edda"
@@ -18975,10 +19111,30 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+vfile-location@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.6.tgz#8a274f39411b8719ea5728802e10d9e0dff1519e"
+  integrity sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==
+
 vfile-location@^3.0.0, vfile-location@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-3.2.0.tgz#d8e41fbcbd406063669ebf6c33d56ae8721d0f3c"
   integrity sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA==
+
+vfile-message@*:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-3.0.1.tgz#b9bcf87cb5525e61777e0c6df07e816a577588a3"
+  integrity sha512-gYmSHcZZUEtYpTmaWaFJwsuUD70/rTY4v09COp8TGtOkix6gGxb/a8iTQByIY9ciTk9GwAwIXd/J9OPfM4Bvaw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-stringify-position "^3.0.0"
+
+vfile-message@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.1.1.tgz#5833ae078a1dfa2d96e9647886cd32993ab313e1"
+  integrity sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==
+  dependencies:
+    unist-util-stringify-position "^1.1.1"
 
 vfile-message@^2.0.0:
   version "2.0.4"
@@ -18987,6 +19143,16 @@ vfile-message@^2.0.0:
   dependencies:
     "@types/unist" "^2.0.0"
     unist-util-stringify-position "^2.0.0"
+
+vfile@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-3.0.1.tgz#47331d2abe3282424f4a4bb6acd20a44c4121803"
+  integrity sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==
+  dependencies:
+    is-buffer "^2.0.0"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^1.0.0"
+    vfile-message "^1.0.0"
 
 vfile@^4.0.0:
   version "4.2.1"
@@ -19602,7 +19768,7 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, write-file-atomic@^2.4.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
-write-file-atomic@^3.0.0, write-file-atomic@^3.0.3:
+write-file-atomic@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
   integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
@@ -19644,6 +19810,13 @@ write-pkg@^3.1.0:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
 
+write@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
+  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
+  dependencies:
+    mkdirp "^0.5.1"
+
 ws@^6.2.1:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.2.tgz#dd5cdbd57a9979916097652d78f1cc5faea0c32e"
@@ -19655,6 +19828,11 @@ ws@^7.2.3, ws@^7.4.4:
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.5.tgz#a484dd851e9beb6fdb420027e3885e8ce48986c1"
   integrity sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==
+
+x-is-string@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
+  integrity sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=
 
 xdg-basedir@^4.0.0:
   version "4.0.0"
@@ -19718,6 +19896,13 @@ yargs-parser@5.0.0-security.0:
   dependencies:
     camelcase "^3.0.0"
     object.assign "^4.1.0"
+
+yargs-parser@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
+  dependencies:
+    camelcase "^4.1.0"
 
 yargs-parser@^13.1.2:
   version "13.1.2"


### PR DESCRIPTION
This PR is intended to vet the use of CSS logical properties and values as a way to support RTL styling.

This includes:
- [x] Converting existing styles to utilize CSS logicals (e.g. `margin-right` to `margin-inline-end`)
- [x] Adding linting to enforce the use of logicals across our packages
  - The existing [stylelint-use-logical-spec](https://github.com/Jordan-Hall/stylelint-use-logical-spec) package covers the required properties for baseline RTL support, but has some undesirable behavior around 4-value shorthands.
  - `property-blacklist` has been updated to account for this lapse. 
  - [x] Inventory linting and auto-fix support
- [x] Adding a control to Storybook to allow for viewing components in RTL mode
  - [This pxblue addon](https://github.com/pxblue/storybook-addons/tree/dev/rtl) is simple and gives us a persistent, global RTL toggle.

![storybook-addon-rtl](https://user-images.githubusercontent.com/36284167/121740548-14fc4a80-cab2-11eb-89ef-b765659e45b8.gif)

- [x] Confirm necessary browser support for RTL + possible solutions