### PR TITLE
feat(odyssey-react): add cx util

### DIFF
--- a/packages/odyssey-react/src/components/Button/index.tsx
+++ b/packages/odyssey-react/src/components/Button/index.tsx
@@ -12,8 +12,7 @@
 
 import React from 'react';
 import type { FunctionComponent, MouseEventHandler, ReactNode } from 'react';
-import { useOmit } from '../../utils';
-import classNames from "classnames";
+import { useCx, useOmit } from '../../utils';
 
 export type ButtonVariants = 'primary' | 'secondary' | 'danger' | 'dismiss' | 'clear';
 export type Props = {
@@ -61,10 +60,11 @@ const Button: FunctionComponent<Props> = (props) => {
     ...rest
   } = props;
 
-  const componentClass = classNames("ods-button", {
-    [`is-ods-button-${variant}`]: variant,
-    "is-ods-button-full-width": wide
-  });
+  const componentClass = useCx(
+    "ods-button",
+    `is-ods-button-${variant}`,
+    { "is-ods-button-full-width": wide }
+  );
 
   const omitProps = useOmit(rest);
 

--- a/packages/odyssey-react/src/utils/cx.test.ts
+++ b/packages/odyssey-react/src/utils/cx.test.ts
@@ -10,6 +10,22 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-export { oid, useOid } from './oid';
-export { omit, useOmit } from './omit';
-export { cx, useCx } from './cx';
+import { cx } from './cx';
+
+describe('cx', () => {
+  it('returns a string with variadic arguments joined', () => {
+    expect(cx('foo', 'bar', 'baz')).toEqual('foo bar baz');
+  });
+
+  it('returns a string with falsy and non string variadic arguments excluded', () => {
+    expect(
+      cx('foo', false && 'bar', true, false, undefined)
+    ).toEqual('foo');
+  });
+
+  it('returns a string with object variadic arguments evaluated correctly', () => {
+    expect(
+      cx('foo', { bar: true, baz: false }, { qux: true, quux: undefined })
+    ).toEqual('foo bar qux');
+  });
+});

--- a/packages/odyssey-react/src/utils/cx.ts
+++ b/packages/odyssey-react/src/utils/cx.ts
@@ -10,6 +10,29 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-export { oid, useOid } from './oid';
-export { omit, useOmit } from './omit';
-export { cx, useCx } from './cx';
+import { useMemo } from 'react';
+
+type arg = string | boolean | undefined | { [key: string]: boolean | undefined }
+
+type cx = (...args: arg[]) => string;
+
+export const cx: cx = (...args) => {
+  let classNames = ''
+  let lead = ''
+
+  for (const arg of args) {
+    if (typeof arg === 'string') { classNames += `${lead}${arg}` }
+    if (typeof arg === 'object') {
+      Object.entries(arg).forEach(
+        ([k, v]) => v && (classNames +=`${lead}${k}`)
+      )
+    }
+    if (!lead) { lead = ' ' }
+  }
+
+  return classNames;
+}
+
+export const useCx: cx = (...args) => {
+  return useMemo(() => cx(...args), [cx, args]);
+};


### PR DESCRIPTION
This PR adds a new util `cx` that replaces the `classnames` dependency we previously installed. The idea here is that we can avoid the cost of network requests for each install (CI builds etc) into the future by rolling our own simple util.