### PR TITLE
chore: add sb deploy to workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -49,7 +49,10 @@ jobs:
         run: yarn test
 
       - name: Build docs
-        run: yarn workspace @okta/design-docs build
+        run: |
+          yarn workspace @okta/design-docs build
+          yarn workspace @okta/odyssey-react build-storybook
+          cp -r packages/odyssey-react/storybook-static packages/docs/dist/sb
 
       - name: Create GitHub deployment
         uses: bobheadxi/deployments@v0.4.2

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 npm-debug.log
 package-lock.json
 yarn-error.log
+storybook-static


### PR DESCRIPTION
This PR adds a static build of our storybook playground into the publicly hosted dir for the vuepress docs site. Accessible via a URL path for now: `/sb/index.html`