### PR TITLE
refactor(odyssey-react): omit

### DIFF
--- a/packages/odyssey-react/src/utils/omit.test.ts
+++ b/packages/odyssey-react/src/utils/omit.test.ts
@@ -12,14 +12,22 @@
 
 import { omit } from "./omit";
 
-describe("omit", () => {
-  it(`returns an object with default keys omitted`, () => {
-    const obj = Object.freeze({
-      className: 'foo bar baz',
-      children: 'Hello World',
-      style: { color: 'plum' }
+describe(`omit`, () => {
+  describe(`enforcing design consistency`, () => {
+    it(`returns an object with default style override keys omitted`, () => {
+      const obj = Object.freeze({
+        className: 'foo bar baz',
+        style: { color: 'plum' }
+      });
+      expect(omit(obj)).toEqual({});
     });
-    expect(omit(obj)).toEqual({});
+  });
+
+  describe(`preventing unexpected behavior`, () => {
+    it(`returns an object with default children key omitted`, () => {
+      const obj = Object.freeze({ children: 'Hello World' });
+      expect(omit(obj)).toEqual({});
+    });
   });
 
   it(`returns an object with specified keys omitted`, () => {

--- a/packages/odyssey-react/src/utils/omit.test.ts
+++ b/packages/odyssey-react/src/utils/omit.test.ts
@@ -14,7 +14,11 @@ import { omit } from "./omit";
 
 describe("omit", () => {
   it(`returns an object with default keys omitted`, () => {
-    const obj = Object.freeze({ className: 'foo bar baz', children: 'Hello World' });
+    const obj = Object.freeze({
+      className: 'foo bar baz',
+      children: 'Hello World',
+      style: { color: 'plum' }
+    });
     expect(omit(obj)).toEqual({});
   });
 

--- a/packages/odyssey-react/src/utils/omit.ts
+++ b/packages/odyssey-react/src/utils/omit.ts
@@ -10,16 +10,15 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { useMemo } from 'react';
-
 // eslint-disable-next-line @typescript-eslint/ban-types
-type omit = <T extends {}, U extends (keyof T)[]>(obj: T, ...rest: U) => Omit<T, U[number]>;
+const notOwnProperty = (obj: object, prop: string) => !{}.hasOwnProperty.call(obj, prop);
+const omitList = `children className style`.split(` `);
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-const notOwnProperty = (obj: {}, prop: string) => !{}.hasOwnProperty.call(obj, prop);
-const omitList = `children className`.split(` `);
-
-export const omit: omit = (obj, ...rest) => {
+function omit<
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  T extends object,
+  U extends (keyof T)[]
+>(obj: T, ...rest: U): Omit<T, U[number]> {
   const omitted = Object.create(null);
 
   for (const key in obj) {
@@ -31,8 +30,6 @@ export const omit: omit = (obj, ...rest) => {
   }
 
   return omitted;
-};
+}
 
-export const useOmit: omit = (obj, ...rest) => {
-  return useMemo(() => omit(obj, ...rest), [omit, obj, rest]);
-};
+export { omit, omit as useOmit };


### PR DESCRIPTION
This PR refactors `omit` to include `style` as a default omitted prop (to enforce design consistency and easy to maintain styling APIs). It also cleans up the type declarations and removes memoization that actually hurts performance due to the way JS allocates a new referential identity for every rest parameter.