### PR TITLE
feat(odyssey-react): add FieldLabel component

### DIFF
--- a/packages/odyssey-react/src/components/FieldLabel/FieldLabel.stories.tsx
+++ b/packages/odyssey-react/src/components/FieldLabel/FieldLabel.stories.tsx
@@ -1,0 +1,62 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import type { Story } from "@storybook/react";
+import React from "react";
+import FieldLabel from ".";
+import type { Props } from ".";
+
+export default {
+  title: `Components/FieldLabel`,
+  component: FieldLabel,
+  argTypes: {
+    children: { control: 'text' },
+    id: { control: 'text' },
+  },
+  parameters: {
+    controls: {
+      sort: 'requiredFirst'
+    }
+  }
+};
+
+const Template: Story<Props> = (props) => (
+  <FieldLabel {...props} />
+);
+
+export const Label = Template.bind({});
+Label.args = {
+  variant: "label",
+  children: "Destination"
+};
+
+export const Hint = Template.bind({});
+Hint.args = {
+  variant: "hint",
+  children: "None of these are achievable... yet."
+};
+
+export const _Error = Template.bind({});
+_Error.args = {
+  variant: "error",
+  children: "You must acknowledge the dangers before proceeding."
+};
+
+export const Optional: Story<Props> = (props) =>  (
+  <span data-optional>
+    <FieldLabel {...props} />
+  </span>
+)
+Optional.args = {
+  variant: "optional",
+  children: "Optional"
+};

--- a/packages/odyssey-react/src/components/FieldLabel/FieldLabel.test.tsx
+++ b/packages/odyssey-react/src/components/FieldLabel/FieldLabel.test.tsx
@@ -1,0 +1,51 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import React from "react";
+import { render } from "@testing-library/react";
+import FieldLabel from ".";
+import type { FieldLabelVariant } from ".";
+
+const labelText = "Field Label";
+
+describe("FieldLabel", () => {
+  it("renders visibly into the document", () => {
+    const { getByText } = render(
+      <FieldLabel children={labelText} />
+    );
+
+    expect(getByText(labelText)).toBeVisible();
+  });
+
+  it("renders a provided id", () => {
+    const { getByText } = render(
+      <FieldLabel children={labelText} id="foo" />
+    );
+
+    expect(getByText(labelText)).toHaveAttribute("id", "foo");
+  });
+
+  it.each<[FieldLabelVariant, keyof HTMLElementTagNameMap]>([
+    ["label", "label"],
+    ["hint", "aside"],
+    ["error", "aside"],
+    ["optional", "aside"]
+  ])("renders %s variant with %s node type", (variant, tagName) => {
+    const { getByText } = render(
+      <FieldLabel variant={variant} children="foo" />
+    );
+
+    expect(getByText("foo").tagName.toLowerCase()).toBe(tagName);
+  });
+
+  a11yCheck(() => render(<FieldLabel children="foo" />));
+});

--- a/packages/odyssey-react/src/components/FieldLabel/index.tsx
+++ b/packages/odyssey-react/src/components/FieldLabel/index.tsx
@@ -1,0 +1,69 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import React from 'react';
+import type {
+  FunctionComponent,
+  ReactText
+} from 'react';
+import { useCx } from '../../utils';
+
+export type FieldLabelVariant = 'label' | 'hint' | 'error' | 'optional';
+export type Props = {
+  /**
+   * The text content to be displayed to the user.
+   */
+  children: ReactText,
+
+  /**
+   * The underlying element id attribute.
+   */
+  id?: string,
+
+  /**
+   * The visual variant to be displayed to the user.
+   * @default label
+   */
+  variant?: FieldLabelVariant,
+};
+
+/**
+ * FieldLabels make forms accessible by providing context to the user.
+ * They can be used with all Odyssey inputs.
+ */
+const FieldLabel: FunctionComponent<Props> = (props) => {
+  const {
+    children,
+    id,
+    variant = 'label'
+  } = props;
+
+  const Component = variant === 'label' ? 'label' : 'aside';
+
+  const className = useCx(
+    variant === 'error' && 'ods-field--error',
+    variant === 'hint' && 'ods-field--hint',
+    variant === 'label' && 'ods-label',
+    variant === 'optional' && 'ods-label--optional'
+  );
+
+  return (
+    <Component
+      className={className}
+      id={id}
+    >
+      {children}
+    </Component>
+  );
+};
+
+export default FieldLabel;

--- a/packages/odyssey-react/src/utils/cx.test.ts
+++ b/packages/odyssey-react/src/utils/cx.test.ts
@@ -19,8 +19,8 @@ describe('cx', () => {
 
   it('returns a string with falsy and non string variadic arguments excluded', () => {
     expect(
-      cx('foo', false && 'bar', true, false, undefined)
-    ).toEqual('foo');
+      cx(false && 'foo', true && 'bar', '', false, undefined)
+    ).toEqual('bar');
   });
 
   it('returns a string with object variadic arguments evaluated correctly', () => {

--- a/packages/odyssey-react/src/utils/cx.ts
+++ b/packages/odyssey-react/src/utils/cx.ts
@@ -21,13 +21,13 @@ export const cx: cx = (...args) => {
   let lead = ''
 
   for (const arg of args) {
-    if (typeof arg === 'string') { classNames += `${lead}${arg}` }
+    if (typeof arg === 'string') { arg && (classNames += `${lead}${arg}`) }
     if (typeof arg === 'object') {
       Object.entries(arg).forEach(
         ([k, v]) => v && (classNames +=`${lead}${k}`)
       )
     }
-    if (!lead) { lead = ' ' }
+    if (!lead && classNames) { lead = ' ' }
   }
 
   return classNames;


### PR DESCRIPTION
This PR adds a new `<FieldLabel />` component. I'm holding off on refactoring other form inputs to use this until we have our discussion next sprint regarding form design. This PR additionally fixes a small issue for `cx` where preceding falsy expressions would append a leading space into the class attribute in the DOM.