### PR TITLE
feat(odyssey-react): add storybook a11y

### DIFF
--- a/packages/odyssey-react/.storybook/main.js
+++ b/packages/odyssey-react/.storybook/main.js
@@ -14,6 +14,7 @@ module.exports = {
   "addons": [
     "@storybook/addon-links",
     "@storybook/addon-essentials",
-    "@storybook/preset-scss"
+    "@storybook/preset-scss",
+    "@storybook/addon-a11y",
   ]
 }

--- a/packages/odyssey-react/.storybook/preview.js
+++ b/packages/odyssey-react/.storybook/preview.js
@@ -1,7 +1,10 @@
 import "./preview.scss";
 
 export const parameters = {
-  controls: { expanded: true },
+  controls: {
+    expanded: true,
+    sort: 'requiredFirst'
+  },
   grid: {
     cellSize: 10
   },

--- a/packages/odyssey-react/package.json
+++ b/packages/odyssey-react/package.json
@@ -17,6 +17,7 @@
     "@babel/preset-env": "^7.14.2",
     "@babel/preset-react": "^7.13.13",
     "@babel/preset-typescript": "^7.13.0",
+    "@storybook/addon-a11y": "^6.2.9",
     "@storybook/addon-actions": "^6.2.9",
     "@storybook/addon-essentials": "^6.2.9",
     "@storybook/addon-links": "^6.2.9",

--- a/packages/odyssey-react/src/components/Button/Button.stories.tsx
+++ b/packages/odyssey-react/src/components/Button/Button.stories.tsx
@@ -32,11 +32,6 @@ export default {
       control: { type: "boolean" }
     },
   },
-  parameters: {
-    controls: {
-      sort: 'requiredFirst'
-    }
-  }
 };
 
 const Template: Story<Props> = ({ variant, disabled, onClick, wide }) => (

--- a/packages/odyssey-react/src/components/FieldLabel/FieldLabel.stories.tsx
+++ b/packages/odyssey-react/src/components/FieldLabel/FieldLabel.stories.tsx
@@ -22,11 +22,6 @@ export default {
     children: { control: 'text' },
     id: { control: 'text' },
   },
-  parameters: {
-    controls: {
-      sort: 'requiredFirst'
-    }
-  }
 };
 
 const Template: Story<Props> = (props) => (

--- a/packages/odyssey-react/src/components/Status/Status.stories.tsx
+++ b/packages/odyssey-react/src/components/Status/Status.stories.tsx
@@ -23,11 +23,6 @@ export default {
       control: { type: "boolean" }
     }
   },
-  parameters: {
-    controls: {
-      sort: 'requiredFirst'
-    }
-  }
 };
 
 const Template: Story<Props> = ({

--- a/packages/odyssey-react/src/components/Tag/Tag.stories.tsx
+++ b/packages/odyssey-react/src/components/Tag/Tag.stories.tsx
@@ -18,11 +18,6 @@ import type { Props } from ".";
 export default {
   title: `Components/Tag`,
   component: Tag,
-  parameters: {
-    controls: {
-      sort: 'requiredFirst'
-    }
-  }
 };
 
 const Template: Story<Props> = ({ tags }) => (

--- a/packages/odyssey-react/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/odyssey-react/src/components/TextArea/TextArea.stories.tsx
@@ -38,11 +38,6 @@ export default {
     onBlur: { control: false },
     onFocus: { control: false }
   },
-  parameters: {
-    controls: {
-      sort: 'requiredFirst'
-    }
-  }
 };
 
 const Template: Story<Props> = (props) => (

--- a/packages/odyssey-react/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.stories.tsx
@@ -37,11 +37,6 @@ export default {
     onBlur: { control: false },
     onFocus: { control: false }
   },
-  parameters: {
-    controls: {
-      sort: 'requiredFirst'
-    }
-  }
 };
 
 const Template: Story<Props> = (props) => (

--- a/packages/odyssey-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/odyssey-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -22,9 +22,6 @@ export default {
   component: Tooltip,
   parameters: {
     layout: 'centered',
-    controls: {
-      sort: 'requiredFirst'
-    },
   }
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3477,6 +3477,28 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@storybook/addon-a11y@^6.2.9":
+  version "6.2.9"
+  resolved "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-6.2.9.tgz#8386d73343db03c15d07f6bf927a4030d441d1ff"
+  integrity sha512-wo7nFpEqEeiHDsRKnhqe2gIHZ9Z7/Aefw570kBgReU5tKlmrb5rFAfTVBWGBZlLHWeJMsFsRsWrWrmkf1B52OQ==
+  dependencies:
+    "@storybook/addons" "6.2.9"
+    "@storybook/api" "6.2.9"
+    "@storybook/channels" "6.2.9"
+    "@storybook/client-api" "6.2.9"
+    "@storybook/client-logger" "6.2.9"
+    "@storybook/components" "6.2.9"
+    "@storybook/core-events" "6.2.9"
+    "@storybook/theming" "6.2.9"
+    axe-core "^4.1.1"
+    core-js "^3.8.2"
+    global "^4.4.0"
+    lodash "^4.17.20"
+    react-sizeme "^3.0.1"
+    regenerator-runtime "^0.13.7"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/addon-actions@6.2.9", "@storybook/addon-actions@^6.2.9":
   version "6.2.9"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-6.2.9.tgz#688413ac77410690755a5da3c277bfa0ff1a10b0"
@@ -5712,7 +5734,7 @@ axe-core@^3.5.5:
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz#84315073b53fa3c0c51676c588d59da09a192227"
   integrity sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==
 
-axe-core@^4.0.2:
+axe-core@^4.0.2, axe-core@^4.1.1:
   version "4.2.2"
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.2.2.tgz#0c987d82c8b82b4b9b7a945f1b5ef0d8fed586ed"
   integrity sha512-OKRkKM4ojMEZRJ5UNJHmq9tht7cEnRnqKG6KyB/trYws00Xtkv12mHtlJ0SK7cmuNbrU8dPUova3ELTuilfBbw==


### PR DESCRIPTION
This PR adds a new [storybook addon for a11y](https://storybook.js.org/addons/@storybook/addon-a11y). This addon allows us to *manually* check for accessibility concerns while building out components within the storybook playground.

![a11y-addon](https://user-images.githubusercontent.com/63716167/122829886-8f4c7c00-d2b5-11eb-99ae-1117b8a3c739.gif)

This PR also contains a small refactor commit to de-duplicate configuration parameters for the [controls addon](https://storybook.js.org/addons/@storybook/addon-controls) to be located in the global `preview.js` file.
