### PR TITLE
Refactor: RTL Naming

### DIFF
--- a/packages/docs/components/button.md
+++ b/packages/docs/components/button.md
@@ -221,7 +221,7 @@ You should pair Disabled Buttons with a Tooltip if the user would benefit from a
       <button class="ods-button" aria-describedby="launch-description" disabled>
         <span class="ods-button--label">Launch</span>
       </button>
-      <aside id="launch-description" class="ods-tooltip is-ods-tooltip-left" role="tooltip">
+      <aside id="launch-description" class="ods-tooltip is-ods-tooltip-start" role="tooltip">
         Unable to launch before countdown completes.
       </aside>
     </span>

--- a/packages/docs/components/modal.md
+++ b/packages/docs/components/modal.md
@@ -50,7 +50,7 @@ How modals arrive on the screen is as important as the content they contain. Ani
 
 <Description>
 
-Users may close modals by clicking on the button in the upper right-hand corner of the container. They may also click anywhere outside of the container, within the "curtain".
+Users may close modals by clicking on the button in the upper, ending corner of the container. They may also click anywhere outside of the container, within the "curtain".
 
 </Description>
 

--- a/packages/docs/components/tab.md
+++ b/packages/docs/components/tab.md
@@ -29,7 +29,7 @@ links:
 
 <Description>
 
-Users interact with Tab as they would a button, the main difference is the outcome. By default, the first tab from the left is active and the associated content displayed in the tab panel. Upon selecting a different tab, the tab indicator appears on the selected tab. The tab panel will then update to show the new content.
+Users interact with Tab as they would a button, the main difference is the outcome. By default, the first tab is active and the associated content displayed in the tab panel. Upon selecting a different tab, the tab indicator appears on the selected tab. The tab panel will then update to show the new content.
 
 Additionally, the tab element is keyboard-navigable (See [Accessibility: Keyboard Support](#keyboard-support))
 

--- a/packages/docs/components/table.md
+++ b/packages/docs/components/table.md
@@ -135,9 +135,9 @@ Note that tables should not have a fixed width, nor should their columns. Browse
 
 <Description>
 
-If your data set has keys on two axes, we also support setting the left-most column as a row heading. This is helpful when you expect the user tuseze a known value for data lookup (e.g. "Which missions went to Mars?").
+If your data set has keys on two axes, we also support setting the starting column as a row heading. This is helpful when you expect the user tuseze a known value for data lookup (e.g. "Which missions went to Mars?").
 
-Be sure to identify your row heading column as well. That is, don't leave a blank cell in the upper left. Our secondary headings need context too!
+Be sure to identify your row heading column as well. That is, don't leave a blank cell in the starting header column. Our secondary headings need context too!
 
 </Description>
 
@@ -244,7 +244,7 @@ Note: spanning multiple rows or columns may cause issues for assistive technolog
 
 Titles & captions should describe the table the user is viewing. They are not abstractions.
 
-Reserve the left-hand column for your most important data. Cascade lower priority data to the right.
+Reserve the starting column for your most important data. Cascade lower priority data toward the end.
 
 Don't use long column headings. Try to keep them as short as or shorter than your column content.
 
@@ -386,7 +386,7 @@ If mixed, the heading checkbox should be set to Indeterminate.
 
 <h4 class="desc-counter--title">Numerical data</h4>
 
-We use tabular numbers and right-align figures for quick scanning.
+We use tabular numbers and end-align figures for quick scanning.
 
 Leave off any units. Instead, specify them in the column's header.
 

--- a/packages/docs/components/toast.md
+++ b/packages/docs/components/toast.md
@@ -64,7 +64,7 @@ Each Toast is made up of up to four parts: Icon & Color, Title, Body, and a Dism
 
 Toasts may be triggered by different types of events, but they are always transient. With this in mind, Toasts should not include any interactive or long-form content.
 
-The Toast pen will take care of positioning and layout automatically. Toasts will appear in the bottom-right corner above all other content.
+The Toast pen will take care of positioning and layout automatically. Toasts will appear in the bottom, ending corner above all other content.
 
 If multiple Toasts are triggered in a short time, they will stack in order of appearance. For visual consistency, Toasts will resize to match the largest Toast visible.
 
@@ -374,7 +374,7 @@ Do not use Danger Toasts for in-page errors such as invalid form fields. Instead
 
 <Description>
 
-`.ods-toast-pen` provides a container which is positioned fixed to the bottom right hand corner of a page. When a toast element is appended to it, motion is automatically handled for you using CSS animation.
+`.ods-toast-pen` provides a container which is positioned fixed to the bottom, ending corner of a page. When a toast element is appended to it, motion is automatically handled for you using CSS animation.
 
 </Description>
 

--- a/packages/docs/components/tooltip.md
+++ b/packages/docs/components/tooltip.md
@@ -100,7 +100,7 @@ This may be the case for disabled controls or inline content like abbreviations.
       <button class="ods-button" aria-describedby="launch-description" disabled>
         Launch
       </button>
-      <aside id="launch-description" class="ods-tooltip is-ods-tooltip-left" role="tooltip">
+      <aside id="launch-description" class="ods-tooltip is-ods-tooltip-start" role="tooltip">
         Unable to launch before countdown completes.
       </aside>
     </span>
@@ -122,7 +122,7 @@ Tooltips are transient by design, which makes them a bad candidate for interacti
     <button class="ods-button" aria-describedby="download-description-link" disabled>
       Launch
     </button>
-    <aside id="download-description-link" class="ods-tooltip is-ods-tooltip-right" role="tooltip">
+    <aside id="download-description-link" class="ods-tooltip is-ods-tooltip-end" role="tooltip">
       Enable launch by <a href="#">initiating the countdown</a>.
     </aside>
   </span>
@@ -170,7 +170,7 @@ When positioning a Tooltip, ensure:
     </span>
     <span class="has-ods-tooltip sample--tip">
       <abbr tabindex="0" aria-describedby="tip-right">Right</abbr>
-      <aside id="tip-right" class="ods-tooltip is-ods-tooltip-right" role="tooltip">
+      <aside id="tip-right" class="ods-tooltip is-ods-tooltip-end" role="tooltip">
         A right-hand tip.
       </aside>
     </span>
@@ -182,7 +182,7 @@ When positioning a Tooltip, ensure:
     </span>
     <span class="has-ods-tooltip sample--tip">
       <abbr tabindex="0" aria-describedby="tip-left">Left</abbr>
-      <aside id="tip-left" class="ods-tooltip is-ods-tooltip-left" role="tooltip">
+      <aside id="tip-left" class="ods-tooltip is-ods-tooltip-start" role="tooltip">
         A left-hand tip.
       </aside>
     </span>
@@ -296,7 +296,7 @@ When possible, provide inline text that becomes visible on touchscreen devices. 
       <button class="ods-button" aria-describedby="edit-label">
         <OdsIcon icon="edit"></OdsIcon>
       </button>
-      <aside id="edit-label" class="ods-tooltip is-ods-tooltip-right" role="tooltip">
+      <aside id="edit-label" class="ods-tooltip is-ods-tooltip-end" role="tooltip">
         Tooltip label
       </aside>
     </span>
@@ -307,7 +307,7 @@ When possible, provide inline text that becomes visible on touchscreen devices. 
       <button class="ods-button" aria-describedby="edit-label">
         <svg role="presentation" focusable="false" class="ods-icon">...</svg>
       </button>
-      <aside id="edit-label" class="ods-tooltip is-ods-tooltip-right" role="tooltip">
+      <aside id="edit-label" class="ods-tooltip is-ods-tooltip-end" role="tooltip">
         Tooltip label
       </aside>
     </span>
@@ -348,7 +348,7 @@ When possible, provide inline text that becomes visible on touchscreen devices. 
       <button class="ods-button" aria-describedby="edit-label">
         <OdsIcon icon="edit"></OdsIcon>
       </button>
-      <aside id="edit-label" class="ods-tooltip is-ods-tooltip-left" role="tooltip">
+      <aside id="edit-label" class="ods-tooltip is-ods-tooltip-start" role="tooltip">
         Tooltip label
       </aside>
     </span>
@@ -359,7 +359,7 @@ When possible, provide inline text that becomes visible on touchscreen devices. 
       <button class="ods-button" aria-describedby="edit-label">
         <svg role="presentation" focusable="false" class="ods-icon">...</svg>
       </button>
-      <aside id="edit-label" class="ods-tooltip is-ods-tooltip-left" role="tooltip">
+      <aside id="edit-label" class="ods-tooltip is-ods-tooltip-start" role="tooltip">
         Tooltip label
       </aside>
     </span>

--- a/packages/docs/components/tooltip.md
+++ b/packages/docs/components/tooltip.md
@@ -169,9 +169,9 @@ When positioning a Tooltip, ensure:
       </aside>
     </span>
     <span class="has-ods-tooltip sample--tip">
-      <abbr tabindex="0" aria-describedby="tip-right">Right</abbr>
-      <aside id="tip-right" class="ods-tooltip is-ods-tooltip-end" role="tooltip">
-        A right-hand tip.
+      <abbr tabindex="0" aria-describedby="tip-end">End</abbr>
+      <aside id="tip-end" class="ods-tooltip is-ods-tooltip-end" role="tooltip">
+        An ending tip.
       </aside>
     </span>
     <span class="has-ods-tooltip sample--tip">
@@ -181,9 +181,9 @@ When positioning a Tooltip, ensure:
       </aside>
     </span>
     <span class="has-ods-tooltip sample--tip">
-      <abbr tabindex="0" aria-describedby="tip-left">Left</abbr>
-      <aside id="tip-left" class="ods-tooltip is-ods-tooltip-start" role="tooltip">
-        A left-hand tip.
+      <abbr tabindex="0" aria-describedby="tip-start">Start</abbr>
+      <aside id="tip-start" class="ods-tooltip is-ods-tooltip-start" role="tooltip">
+        A start-hand tip.
       </aside>
     </span>
   </div>
@@ -262,7 +262,7 @@ When possible, provide inline text that becomes visible on touchscreen devices. 
 ::: slot html-scss
 
 
-## Position top
+## Position: Top
 
 <figure class="docs-example" data-optional>
   <div class="docs-example--rendered">
@@ -288,7 +288,7 @@ When possible, provide inline text that becomes visible on touchscreen devices. 
   ```
 </figure>
 
-## Position right
+## Position: End
 
 <figure class="docs-example" data-optional>
   <div class="docs-example--rendered">
@@ -314,7 +314,7 @@ When possible, provide inline text that becomes visible on touchscreen devices. 
   ```
 </figure>
 
-## Position bottom
+## Position: Bottom
 
 <figure class="docs-example" data-optional>
   <div class="docs-example--rendered">
@@ -340,7 +340,7 @@ When possible, provide inline text that becomes visible on touchscreen devices. 
   ```
 </figure>
 
-## Position left
+## Position: Start
 
 <figure class="docs-example" data-optional>
   <div class="docs-example--rendered">

--- a/packages/docs/icons.md
+++ b/packages/docs/icons.md
@@ -162,7 +162,7 @@ UI indicators are visual indicators that are baked into UIs like the radio circl
 </Description>
 
 <Visual>
-  <img alt="An illustration of a select input. On right side, arrow points at a down-arrow glyph which is an example of a UI indicator." src="/images/icons-indicator-example.svg">
+  <img alt="An illustration of a select input. On the ending side, an arrow points at a down-arrow glyph which is an example of a UI indicator." src="/images/icons-indicator-example.svg">
 </Visual>
 
 ### When to use an icon
@@ -216,7 +216,7 @@ As best practice, use a verb to suggest an action. For more clarity use a verb +
   </button>
 </Visual>
 
-### Choosing the right icon
+### Choosing an icon
 
 <Description>
 

--- a/packages/odyssey-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/odyssey-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -30,14 +30,14 @@ const Template: Story<Props> = () => (
     <Tooltip label="Top tooltip label" position="top">
       <Button variant="primary" onClick={action('Top button clicked')}>Top</Button>
     </Tooltip>
-    <Tooltip label="Right tooltip label" position="right">
-      <Button onClick={action('Right button clicked')} variant="clear">Right</Button>
+    <Tooltip label="Ending tooltip label" position="end">
+      <Button onClick={action('Ending button clicked')} variant="clear">End</Button>
     </Tooltip>
     <Tooltip label="Bottom tooltip label" position="bottom">
       <Button onClick={action('Bottom button clicked')} variant="clear">Bottom</Button>
     </Tooltip>
-    <Tooltip label="Left tooltip label" position="left">
-      <Button onClick={action('Left button clicked')} variant="clear">Left</Button>
+    <Tooltip label="Starting tooltip label" position="start">
+      <Button onClick={action('Starting button clicked')} variant="clear">Start</Button>
     </Tooltip>
   </>
 );

--- a/packages/odyssey-react/src/components/Tooltip/index.tsx
+++ b/packages/odyssey-react/src/components/Tooltip/index.tsx
@@ -30,7 +30,7 @@ export type Props = {
    * The position the tooltip will be displayed
    * @default top
    */
-  position?: 'top' | 'right' | 'bottom' | 'left',
+  position?: 'top' | 'end' | 'bottom' | 'start',
 
   /**
    * The position the tooltip will be displayed

--- a/packages/odyssey/src/scss/components/_tooltip.scss
+++ b/packages/odyssey/src/scss/components/_tooltip.scss
@@ -88,7 +88,7 @@
   }
 }
 
-.is-ods-tooltip-right {
+.is-ods-tooltip-end {
   inset-block-start: 50%;
   inset-inline-start: calc(100% + #{$spacing-s});
   transform: translateY(-50%);
@@ -139,7 +139,7 @@
   }
 }
 
-.is-ods-tooltip-left {
+.is-ods-tooltip-start {
   inset-block-start: 50%;
   inset-inline-end: calc(100% + #{$spacing-s});
   transform: translateY(-50%);
@@ -200,9 +200,9 @@
   }
 
   .is-ods-tooltip-top,
-  .is-ods-tooltip-right,
+  .is-ods-tooltip-end,
   .is-ods-tooltip-bottom,
-  .is-ods-tooltip-left {
+  .is-ods-tooltip-start {
     inset-block-start: 0;
     inset-inline-end: unset;
     inset-block-end: unset;


### PR DESCRIPTION
Now that our codebase has moved beyond physical properties, we should upgrade our language to match. At the simplest, this is moving from a Right/Left paradigm to a Start/End paradigm in documentation, props, and class names.

Jira: https://oktainc.atlassian.net/browse/OKTA-405624