### PR TITLE
Update available Button sizes

### DIFF
--- a/packages/docs/components/button.md
+++ b/packages/docs/components/button.md
@@ -216,7 +216,7 @@ Large Buttons incease their padding, but not their font size. They're intended f
 
 <Visual>
   <template>
-    <button class="ods-button is-ods-button-l">
+    <button class="ods-button is-ods-button-size-l">
       <span class="ods-button--label">Log in to your console</span>
     </button>
   </template>
@@ -645,25 +645,25 @@ Color is not a clear affordance for all users, please use clear, concise copy to
 
 <figure class="docs-example">
   <div class="docs-example--rendered">
-    <button class="ods-button is-ods-button-s">
+    <button class="ods-button is-ods-button-size-s">
       <span class="ods-button--label">Primary</span>
     </button>
-    <button class="ods-button is-ods-button-hover is-ods-button-s">
+    <button class="ods-button is-ods-button-hover is-ods-button-size-s">
       <span class="ods-button--label">Hover</span>
     </button>
-    <button class="ods-button is-ods-button-focus is-ods-button-s">
+    <button class="ods-button is-ods-button-focus is-ods-button-size-s">
       <span class="ods-button--label">Focus</span>
     </button>
-    <button class="ods-button is-ods-button-s" disabled>
+    <button class="ods-button is-ods-button-size-s" disabled>
       <span class="ods-button--label">Disabled</span>
     </button>
   </div>
 
   ```html
-  <button class="ods-button is-ods-button-s">
+  <button class="ods-button is-ods-button-size-s">
     <span class="ods-button--label">Primary</span>
   </button>
-  <button class="ods-button is-ods-button-s" disabled>
+  <button class="ods-button is-ods-button-size-s" disabled>
     <span class="ods-button--label">Primary</span>
   </button>
   ```
@@ -701,25 +701,25 @@ Color is not a clear affordance for all users, please use clear, concise copy to
 
 <figure class="docs-example">
   <div class="docs-example--rendered">
-    <button class="ods-button is-ods-button-l">
+    <button class="ods-button is-ods-button-size-l">
       <span class="ods-button--label">Primary</span>
     </button>
-    <button class="ods-button is-ods-button-l is-ods-button-hover">
+    <button class="ods-button is-ods-button-size-l is-ods-button-hover">
       <span class="ods-button--label">Hover</span>
     </button>
-    <button class="ods-button is-ods-button-l is-ods-button-focus">
+    <button class="ods-button is-ods-button-size-l is-ods-button-focus">
       <span class="ods-button--label">Focus</span>
     </button>
-    <button class="ods-button is-ods-button-l" disabled>
+    <button class="ods-button is-ods-button-size-l" disabled>
       <span class="ods-button--label">Disabled</span>
     </button>
   </div>
 
   ```html
-  <button class="ods-button is-ods-button-l">
+  <button class="ods-button is-ods-button-size-l">
     <span class="ods-button--label">Primary</span>
   </button>
-  <button class="ods-button is-ods-button-l" disabled>
+  <button class="ods-button is-ods-button-size-l" disabled>
     <span class="ods-button--label">Primary</span>
   </button>
   ```

--- a/packages/docs/components/button.md
+++ b/packages/docs/components/button.md
@@ -216,7 +216,7 @@ Large Buttons incease their padding, but not their font size. They're intended f
 
 <Visual>
   <template>
-    <button class="ods-button is-ods-button-large">
+    <button class="ods-button is-ods-button-l">
       <span class="ods-button--label">Log in to your console</span>
     </button>
   </template>
@@ -637,6 +637,90 @@ Color is not a clear affordance for all users, please use clear, concise copy to
   </button>
   <button class="ods-button is-ods-button-clear" disabled>
     <span class="ods-button--label">Clear</span>
+  </button>
+  ```
+</figure>
+
+## Size: Small
+
+<figure class="docs-example">
+  <div class="docs-example--rendered">
+    <button class="ods-button is-ods-button-s">
+      <span class="ods-button--label">Primary</span>
+    </button>
+    <button class="ods-button is-ods-button-hover is-ods-button-s">
+      <span class="ods-button--label">Hover</span>
+    </button>
+    <button class="ods-button is-ods-button-focus is-ods-button-s">
+      <span class="ods-button--label">Focus</span>
+    </button>
+    <button class="ods-button is-ods-button-s" disabled>
+      <span class="ods-button--label">Disabled</span>
+    </button>
+  </div>
+
+  ```html
+  <button class="ods-button is-ods-button-s">
+    <span class="ods-button--label">Primary</span>
+  </button>
+  <button class="ods-button is-ods-button-s" disabled>
+    <span class="ods-button--label">Primary</span>
+  </button>
+  ```
+</figure>
+
+## Size: Medium
+
+<figure class="docs-example">
+  <div class="docs-example--rendered">
+    <button class="ods-button">
+      <span class="ods-button--label">Primary</span>
+    </button>
+    <button class="ods-button is-ods-button-hover">
+      <span class="ods-button--label">Hover</span>
+    </button>
+    <button class="ods-button is-ods-button-focus">
+      <span class="ods-button--label">Focus</span>
+    </button>
+    <button class="ods-button" disabled>
+      <span class="ods-button--label">Disabled</span>
+    </button>
+  </div>
+
+  ```html
+  <button class="ods-button">
+    <span class="ods-button--label">Primary</span>
+  </button>
+  <button class="ods-button" disabled>
+    <span class="ods-button--label">Primary</span>
+  </button>
+  ```
+</figure>
+
+## Size: Large
+
+<figure class="docs-example">
+  <div class="docs-example--rendered">
+    <button class="ods-button is-ods-button-l">
+      <span class="ods-button--label">Primary</span>
+    </button>
+    <button class="ods-button is-ods-button-l is-ods-button-hover">
+      <span class="ods-button--label">Hover</span>
+    </button>
+    <button class="ods-button is-ods-button-l is-ods-button-focus">
+      <span class="ods-button--label">Focus</span>
+    </button>
+    <button class="ods-button is-ods-button-l" disabled>
+      <span class="ods-button--label">Disabled</span>
+    </button>
+  </div>
+
+  ```html
+  <button class="ods-button is-ods-button-l">
+    <span class="ods-button--label">Primary</span>
+  </button>
+  <button class="ods-button is-ods-button-l" disabled>
+    <span class="ods-button--label">Primary</span>
   </button>
   ```
 </figure>

--- a/packages/docs/components/button.md
+++ b/packages/docs/components/button.md
@@ -46,7 +46,7 @@ In Odyssey there are five Button variants: Primary, Secondary, Danger, Clear, an
 
 <Description>
 
-Use our default button for primary actions in a view. For example, “Save”.
+Use our default Button for primary actions in a view. For example, “Save”.
 
 It's ideal to have one Primary Button per view. However, it's okay to have more than one Primary Button as long that they are equal in priority.
 
@@ -64,7 +64,7 @@ It's ideal to have one Primary Button per view. However, it's okay to have more 
 
 <Description>
 
-This is ideal for a secondary actions to compliment the Primary Button. Like the Primary Button, use this button sparingly to provide focus to the user.
+This is ideal for a secondary actions to compliment the Primary Button. Like the Primary Button, use this Button sparingly to provide focus to the user.
 
 </Description>
 
@@ -98,7 +98,7 @@ Use Danger Buttons for scenarios where a user may be deleting information or mak
 
 Use Clear Buttons for interactions that change visible UI but don't submit data. For example, showing a password field or dismissing a modal.
 
-They pair well with Primary and Secondary buttons.
+They pair well with Primary and Secondary Buttons.
 
 </Description>
 
@@ -131,11 +131,102 @@ The Dismiss Button has unique padding and will inherit the text color of it's pa
   </template>
 </Visual>
 
+## Sizes
+
+<Description>
+
+We offer three sizes of Buttons for use: Small, Medium, and Large. Full-width buttons are also available.
+
+In order to provide a sufficient click area, all Button labels have a minimum width equal to twice the line-height.
+
+</Description>
+
+### Small
+
+<Description>
+
+Small Buttons are best used for actions within Table rows. Their font-size is descreased while keeping padding proportional to our medium size.
+
+</Description>
+
+<Visual>
+  <figure class="ods-table--figure">
+    <figcaption class="ods-table--figcaption">
+      Near and far planets
+    </figcaption>
+    <table class="ods-table">
+      <caption>Information about the nearest and farthest planets.</caption>
+      <thead>
+        <tr>
+          <th scope="column">
+            Planet
+          </th>
+          <th scope="column" class="is-ods-table-num">
+            Distance (AU)
+          </th>
+          <th scope="column">
+            Travel
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Mars</td>
+          <td class="is-ods-table-num">0.52</td>
+          <td><button class="ods-button is-ods-button-secondary">Travel</button></td>
+        </tr>
+        <tr>
+          <td>Saturn</td>
+          <td class="is-ods-table-num">8.52</td>
+          <td><button class="ods-button is-ods-button-secondary">Travel</button></td>
+        </tr>
+        <tr>
+          <td>Neptune</td>
+          <td class="is-ods-table-num">29.09</td>
+          <td><button class="ods-button is-ods-button-secondary">Travel</button></td>
+        </tr>
+      </tbody>
+    </table>
+  </figure>
+</Visual>
+
+### Medium
+
+<Description>
+
+Our default size, medium Buttons are built for use in most contexts.
+
+</Description>
+
+<Visual>
+  <template>
+    <button class="ods-button">
+      <span class="ods-button--label">Activate thrusters</span>
+    </button>
+  </template>
+</Visual>
+
+### Large
+
+<Description>
+
+Large Buttons incease their padding, but not their font size. They're intended for single-interaction UIs like logging in.
+
+</Description>
+
+<Visual>
+  <template>
+    <button class="ods-button is-ods-button-large">
+      <span class="ods-button--label">Log in to your console</span>
+    </button>
+  </template>
+</Visual>
+
 ### Full-width
 
 <Description>
 
-Full-width buttons are intended for single-interaction UIs. These are often widgets like "Sign In" or "Sign Up".
+Full-width Buttons are intended for single-interaction UIs. These are often widgets like "Sign In" or "Sign Up".
 
 Use this variant when you desire the Button to be full-width regardless of screen size.
 
@@ -232,7 +323,7 @@ You should pair Disabled Buttons with a Tooltip if the user would benefit from a
 
 <Description>
 
-Use buttons to indicate the in-page actions a user can take.
+Use Buttons to indicate the in-page actions a user can take.
 
 </Description>
 
@@ -244,7 +335,7 @@ Use buttons to indicate the in-page actions a user can take.
 
 <Description>
 
-Don't use buttons to navigate users around the site or product; use links instead.
+Don't use Buttons to navigate users around the site or product; use links instead.
 
 </Description>
 
@@ -258,7 +349,7 @@ Don't use buttons to navigate users around the site or product; use links instea
 
 <Description>
 
-Consider the following when writing content for buttons. By doing so, it will ensure users can easily navigate the page and complete the task at hand efficiently.
+Consider the following when writing content for Buttons. By doing so, it will ensure users can easily navigate the page and complete the task at hand efficiently.
 
 </Description>
 
@@ -266,7 +357,7 @@ Consider the following when writing content for buttons. By doing so, it will en
 
 <Description>
 
-Provide enough context to ensure the user is aware what the interaction will achieve. Avoid patterns that require the user to discover what a button does.
+Provide enough context to ensure the user is aware what the interaction will achieve. Avoid patterns that require the user to discover what a Button does.
 
 </Description>
 
@@ -280,7 +371,7 @@ Provide enough context to ensure the user is aware what the interaction will ach
 
 <Description>
 
-Be strategic in your button placement so a user has the best context. For example, consider using Buttons at the end of a form or preceding them with supporting copy.
+Be strategic in your Button placement so a user has the best context. For example, consider using Buttons at the end of a form or preceding them with supporting copy.
 
 </Description>
 
@@ -296,7 +387,7 @@ Be strategic in your button placement so a user has the best context. For exampl
 
 <Description>
 
-Don't use more than three words inside of a button. If a user needs more context, consider other design solutions.
+Don't use more than three words inside of a Button. If a user needs more context, consider other design solutions.
 
 </Description>
 
@@ -344,7 +435,7 @@ When using multiple words, use sentence case. Capitalize only the first letter a
 
 <Description>
 
-Icons can be added to any of our button variants to increase clarity or add flair. Icons will be laid out automatically based on language direction.
+Icons can be added to any of our Button variants to increase clarity or add flair. Icons will be laid out automatically based on language direction.
 
 </Description>
 
@@ -361,7 +452,7 @@ Icons can be added to any of our button variants to increase clarity or add flai
 
 <Description>
 
-We recommend pairing icon-only buttons with our Tooltip. While this is not required, it will increase clarity for sighted users.
+We recommend pairing icon-only Buttons with our Tooltip. While this is not required, it will increase clarity for sighted users.
 
 </Description>
 
@@ -382,7 +473,7 @@ We recommend pairing icon-only buttons with our Tooltip. While this is not requi
 
 <Description>
 
-Color is not a clear affordance for all users, please use clear, concise copy to label buttons. Good rules of thumb: use three or less words to describe your action and start your label with a verb (e.g. "Access report" vs "Report PDF").
+Color is not a clear affordance for all users, please use clear, concise copy to label Buttons. Good rules of thumb: use three or less words to describe your action and start your label with a verb (e.g. "Access report" vs "Report PDF").
 
 </Description>
 

--- a/packages/odyssey-react/src/components/Button/Button.stories.tsx
+++ b/packages/odyssey-react/src/components/Button/Button.stories.tsx
@@ -28,19 +28,16 @@ export default {
     onClick: {
       control: { type: null }
     },
-    large: {
-      control: { type: "boolean" }
-    },
     wide: {
       control: { type: "boolean" }
     },
   },
 };
 
-const Template: Story<Props> = ({ variant, disabled, onClick, large, wide }) => (
+const Template: Story<Props> = ({ variant, disabled, onClick, size, wide }) => (
   <>
-    <Button variant={variant} onClick={onClick} disabled={disabled} large={large} wide={wide}>Default</Button>
-    <Button variant={variant} onClick={onClick} disabled={true} large={large} wide={wide}>Disabled</Button>
+    <Button variant={variant} onClick={onClick} disabled={disabled} size={size} wide={wide}>Default</Button>
+    <Button variant={variant} onClick={onClick} disabled={true} size={size} wide={wide}>Disabled</Button>
   </>
 );
 
@@ -84,9 +81,25 @@ Dismiss.argTypes = {
   onClick: { action: 'clicked button/dismiss' },
 };
 
+export const Small = Template.bind({});
+Small.args = {
+  size: "small"
+};
+Small.argTypes = {
+  onClick: { action: 'clicked button/small' },
+};
+
+export const Medium = Template.bind({});
+Medium.args = {
+  size: "medium"
+};
+Medium.argTypes = {
+  onClick: { action: 'clicked button/medium' },
+};
+
 export const Large = Template.bind({});
 Large.args = {
-  large: true
+  size: "large"
 };
 Large.argTypes = {
   onClick: { action: 'clicked button/large' },

--- a/packages/odyssey-react/src/components/Button/Button.stories.tsx
+++ b/packages/odyssey-react/src/components/Button/Button.stories.tsx
@@ -83,7 +83,7 @@ Dismiss.argTypes = {
 
 export const Small = Template.bind({});
 Small.args = {
-  size: "small"
+  size: "s"
 };
 Small.argTypes = {
   onClick: { action: 'clicked button/small' },
@@ -91,7 +91,7 @@ Small.argTypes = {
 
 export const Medium = Template.bind({});
 Medium.args = {
-  size: "medium"
+  size: "m"
 };
 Medium.argTypes = {
   onClick: { action: 'clicked button/medium' },
@@ -99,7 +99,7 @@ Medium.argTypes = {
 
 export const Large = Template.bind({});
 Large.args = {
-  size: "large"
+  size: "l"
 };
 Large.argTypes = {
   onClick: { action: 'clicked button/large' },

--- a/packages/odyssey-react/src/components/Button/Button.stories.tsx
+++ b/packages/odyssey-react/src/components/Button/Button.stories.tsx
@@ -28,16 +28,19 @@ export default {
     onClick: {
       control: { type: null }
     },
+    large: {
+      control: { type: "boolean" }
+    },
     wide: {
       control: { type: "boolean" }
     },
   },
 };
 
-const Template: Story<Props> = ({ variant, disabled, onClick, wide }) => (
+const Template: Story<Props> = ({ variant, disabled, onClick, large, wide }) => (
   <>
-    <Button variant={variant} onClick={onClick} disabled={disabled} wide={wide}>Default</Button>
-    <Button variant={variant} onClick={onClick} disabled={true} wide={wide}>Disabled</Button>
+    <Button variant={variant} onClick={onClick} disabled={disabled} large={large} wide={wide}>Default</Button>
+    <Button variant={variant} onClick={onClick} disabled={true} large={large} wide={wide}>Disabled</Button>
   </>
 );
 
@@ -79,6 +82,14 @@ Dismiss.args = {
 };
 Dismiss.argTypes = {
   onClick: { action: 'clicked button/dismiss' },
+};
+
+export const Large = Template.bind({});
+Large.args = {
+  large: true
+};
+Large.argTypes = {
+  onClick: { action: 'clicked button/large' },
 };
 
 export const Wide = Template.bind({});

--- a/packages/odyssey-react/src/components/Button/index.tsx
+++ b/packages/odyssey-react/src/components/Button/index.tsx
@@ -32,6 +32,11 @@ export type Props = {
   onClick?: MouseEventHandler<HTMLButtonElement>,
 
   /**
+   * Increases the block padding and height of the button.
+   */
+  large?: boolean;
+
+  /**
    * The visual variant to be displayed to the user.
    * @default primary
    */
@@ -55,6 +60,7 @@ const Button: FunctionComponent<Props> = (props) => {
     children,
     disabled,
     onClick,
+    large,
     variant = "primary",
     wide,
     ...rest
@@ -63,6 +69,7 @@ const Button: FunctionComponent<Props> = (props) => {
   const componentClass = useCx(
     "ods-button",
     `is-ods-button-${variant}`,
+    { "is-ods-button-large": large},
     { "is-ods-button-full-width": wide }
   );
 

--- a/packages/odyssey-react/src/components/Button/index.tsx
+++ b/packages/odyssey-react/src/components/Button/index.tsx
@@ -15,6 +15,7 @@ import type { FunctionComponent, MouseEventHandler, ReactText } from 'react';
 import { useCx, useOmit } from '../../utils';
 
 export type ButtonVariants = 'primary' | 'secondary' | 'danger' | 'dismiss' | 'clear';
+export type ButtonSizes = 'small' | 'medium' | 'large';
 export type Props = {
   /**
    * Text content to be rendered within the button, usualy label text.
@@ -32,9 +33,10 @@ export type Props = {
   onClick?: MouseEventHandler<HTMLButtonElement>,
 
   /**
-   * Increases the block padding and height of the button.
+   * The size to be displayed to the user.
+   * @default medium
    */
-  large?: boolean;
+  size?: ButtonSizes;
 
   /**
    * The visual variant to be displayed to the user.
@@ -60,7 +62,7 @@ const Button: FunctionComponent<Props> = (props) => {
     children,
     disabled,
     onClick,
-    large,
+    size = "medium",
     variant = "primary",
     wide,
     ...rest
@@ -69,7 +71,7 @@ const Button: FunctionComponent<Props> = (props) => {
   const componentClass = useCx(
     "ods-button",
     `is-ods-button-${variant}`,
-    { "is-ods-button-large": large},
+    `is-ods-button-${size}`,
     { "is-ods-button-full-width": wide }
   );
 

--- a/packages/odyssey-react/src/components/Button/index.tsx
+++ b/packages/odyssey-react/src/components/Button/index.tsx
@@ -15,7 +15,7 @@ import type { FunctionComponent, MouseEventHandler, ReactText } from 'react';
 import { useCx, useOmit } from '../../utils';
 
 export type ButtonVariants = 'primary' | 'secondary' | 'danger' | 'dismiss' | 'clear';
-export type ButtonSizes = 'small' | 'medium' | 'large';
+export type ButtonSizes = 's' | 'm' | 'l';
 export type Props = {
   /**
    * Text content to be rendered within the button, usualy label text.
@@ -62,7 +62,7 @@ const Button: FunctionComponent<Props> = (props) => {
     children,
     disabled,
     onClick,
-    size = "medium",
+    size = "m",
     variant = "primary",
     wide,
     ...rest

--- a/packages/odyssey-react/src/components/Button/index.tsx
+++ b/packages/odyssey-react/src/components/Button/index.tsx
@@ -71,7 +71,7 @@ const Button: FunctionComponent<Props> = (props) => {
   const componentClass = useCx(
     "ods-button",
     `is-ods-button-${variant}`,
-    `is-ods-button-${size}`,
+    `is-ods-button-size-${size}`,
     { "is-ods-button-full-width": wide }
   );
 

--- a/packages/odyssey/src/scss/components/_button.scss
+++ b/packages/odyssey/src/scss/components/_button.scss
@@ -53,6 +53,9 @@
 }
 
 .ods-button--label {
+  display: inline-block;
+  min-width: $spacing-l-em;
+
   &:not(:only-child) {
     margin-inline-start: $spacing-xs;
   }
@@ -186,4 +189,9 @@
 .is-ods-button-full-width {
   display: block;
   width: 100%;
+}
+
+.is-ods-button-large {
+  padding-block: $spacing-s-em;
+  padding-inline: $spacing-m-em;
 }

--- a/packages/odyssey/src/scss/components/_button.scss
+++ b/packages/odyssey/src/scss/components/_button.scss
@@ -182,7 +182,7 @@
   line-height: $title-line-height;
 }
 
-.is-ods-button-small {
+.is-ods-button-s {
   @extend %button-small;
 }
 
@@ -191,7 +191,7 @@
   width: 100%;
 }
 
-.is-ods-button-large {
+.is-ods-button-l {
   padding-block: $spacing-s-em;
   padding-inline: $spacing-m-em;
 }

--- a/packages/odyssey/src/scss/components/_button.scss
+++ b/packages/odyssey/src/scss/components/_button.scss
@@ -182,7 +182,7 @@
   line-height: $title-line-height;
 }
 
-.is-ods-button-s {
+.is-ods-button-size-s {
   @extend %button-small;
 }
 
@@ -191,7 +191,7 @@
   width: 100%;
 }
 
-.is-ods-button-l {
+.is-ods-button-size-l {
   padding-block: $spacing-s-em;
   padding-inline: $spacing-m-em;
 }


### PR DESCRIPTION
This PR adds the "Large" button variant to our styles and component + updates the Button docs to account for available sizes.

This also adds a `min-width` for `.ods-button-label`. This is applied to the label and not the Button to keep the requirement sequestered to Buttons with written labels.