### PR TITLE
fix(odyssey): numerical data should not flip in RTL

### DIFF
--- a/packages/odyssey/src/scss/components/_table.scss
+++ b/packages/odyssey/src/scss/components/_table.scss
@@ -152,7 +152,9 @@
   }
 
   .is-ods-table-num {
-    text-align: end;
+    /* Numerical data display should not swap for RTL languages. */
+    /* stylelint-disable-next-line liberty/use-logical-spec */
+    text-align: right;
     font-feature-settings: 'lnum', 'tnum';
   }
 


### PR DESCRIPTION
Because it's always parsed LTR, numerical data in Tables should remain right-aligned for both LTR and RTL languages.

<img width="432" alt="Screen Shot 2021-07-26 at 10 58 55 AM" src="https://user-images.githubusercontent.com/36284167/127036495-a0b1284e-3ef9-4d96-9bd1-45336aa589b9.png">

<img width="522" alt="Screen Shot 2021-07-26 at 10 58 33 AM" src="https://user-images.githubusercontent.com/36284167/127036497-3e366b53-b8d3-4400-9d9d-f90e7169ded6.png">

The ongoing [RTL document](https://docs.google.com/document/d/1yt4tyiFEjcdJVOXyPnTOIOmVkVIzG0cNYLjKkeA6J9s/edit#) has been updated to reflect this guidance.