### PR TITLE
chore(odyssey-storybook): remove typography-header global styles

### DIFF
--- a/packages/odyssey-react/src/components/Banner/index.tsx
+++ b/packages/odyssey-react/src/components/Banner/index.tsx
@@ -101,7 +101,7 @@ export type Props = ComponentProps & DismissableComponentProps;
         {/* @todo Insert <Icon> component */}
         &#8253;
       </span>
-      { title && <span className="ods-banner--title"><Title visualLevel="6" children={ title } /></span> }
+      { title && <div className="ods-banner--title"><Title visualLevel="6" children={ title } /></div> }
       { content && <p className="ods-banner--content">{ content }</p> }
       { children && <section className="ods-banner--actions">{ children }</section> }
       { onDismiss &&

--- a/packages/odyssey-react/src/components/Banner/index.tsx
+++ b/packages/odyssey-react/src/components/Banner/index.tsx
@@ -11,6 +11,7 @@
  */
 
 import type { FunctionComponent, ReactNode } from 'react';
+import Title from '../Title';
 import { useCx, useOmit } from '../../utils';
 import Button from '../Button';
 
@@ -100,10 +101,10 @@ export type Props = ComponentProps & DismissableComponentProps;
         {/* @todo Insert <Icon> component */}
         &#8253;
       </span>
-      {title && <h1 className="ods-banner--title">{title}</h1>}
-      {content && <p className="ods-banner--content">{content}</p>}
-      {children && <section className="ods-banner--actions">{children}</section>}
-      {onDismiss &&
+      { title && <span className="ods-banner--title"><Title visualLevel="6" children={ title } /></span> }
+      { content && <p className="ods-banner--content">{ content }</p> }
+      { children && <section className="ods-banner--actions">{ children }</section> }
+      { onDismiss &&
         <span className="ods-banner--dismiss">
           <Button variant="dismiss" onClick={onDismiss} aria-label={dismissButtonLabel}>
             {/* @todo Insert <Icon> component, dismiss variant */}

--- a/packages/odyssey-react/src/components/Banner/index.tsx
+++ b/packages/odyssey-react/src/components/Banner/index.tsx
@@ -101,7 +101,7 @@ export type Props = ComponentProps & DismissableComponentProps;
         {/* @todo Insert <Icon> component */}
         &#8253;
       </span>
-      { title && <div className="ods-banner--title"><Title visualLevel="6" children={ title } /></div> }
+      { title && <div className="ods-banner--title"><Title visualLevel="6" lineHeight="title" noEndMargin children={ title } /></div> }
       { content && <p className="ods-banner--content">{ content }</p> }
       { children && <section className="ods-banner--actions">{ children }</section> }
       { onDismiss &&

--- a/packages/odyssey-react/src/components/Infobox/Infobox.module.scss
+++ b/packages/odyssey-react/src/components/Infobox/Infobox.module.scss
@@ -40,7 +40,6 @@
 
 .infoboxTitle {
   grid-area: title;
-  font-size: $size-title-6;
 }
 
 .infoboxContent {

--- a/packages/odyssey-react/src/components/Infobox/Infobox.module.scss
+++ b/packages/odyssey-react/src/components/Infobox/Infobox.module.scss
@@ -34,7 +34,7 @@
   grid-area: icon;
   align-self: start;
   font-size: $size-title-5;
-  line-height: 1;
+  line-height: $title-line-height;
   justify-self: start;
 }
 

--- a/packages/odyssey-react/src/components/Infobox/index.tsx
+++ b/packages/odyssey-react/src/components/Infobox/index.tsx
@@ -12,6 +12,7 @@
 
 import type { FunctionComponent, ReactElement, ReactNode } from 'react';
 import { useOmit } from '../../utils';
+import Title from '../Title';
 import styles from './Infobox.module.scss';
 
 export type InfoboxVariants = 'info' | 'danger' | 'caution' | 'success';
@@ -91,8 +92,9 @@ export type StaticComponents = {
         {/* @todo Insert <Icon> component */}
         ‽
       </span>
-      {title && <h1 className={styles.infoboxTitle}>{title}</h1>}
-      {children}
+
+      { title && <span className={ styles.infoboxTitle }><Title visualLevel="6" children={ title } /></span> }
+      { children }
     </aside>
   );
 };

--- a/packages/odyssey-react/src/components/Infobox/index.tsx
+++ b/packages/odyssey-react/src/components/Infobox/index.tsx
@@ -93,7 +93,7 @@ export type StaticComponents = {
         ‽
       </span>
 
-      { title && <span className={ styles.infoboxTitle }><Title visualLevel="6" children={ title } /></span> }
+      { title && <div className={ styles.infoboxTitle }><Title visualLevel="6" children={ title } /></div> }
       { children }
     </aside>
   );

--- a/packages/odyssey-react/src/components/Modal/Modal.module.scss
+++ b/packages/odyssey-react/src/components/Modal/Modal.module.scss
@@ -70,15 +70,6 @@
   margin-block-end: $spacing-xs;
 }
 
-.title {
-  margin-block-start: 0;
-  margin-block-end: 0;
-  color: $text-heading;
-  font-size: $size-title-4;
-  font-weight: 600;
-  line-height: $title-line-height;
-}
-
 .content {
   padding-block-start: $spacing-xs;
   padding-block-end: $spacing-l;

--- a/packages/odyssey-react/src/components/Modal/index.tsx
+++ b/packages/odyssey-react/src/components/Modal/index.tsx
@@ -15,6 +15,7 @@ import type { FunctionComponent, ReactElement, ReactNode, ReactText } from "reac
 import { createPortal } from "react-dom";
 import Button from "../Button";
 import type { ButtonVariants } from "../Button";
+import Title from '../Title';
 import { useOid, useCx } from "../../utils";
 import styles from './Modal.module.scss';
 
@@ -132,15 +133,13 @@ Modal.Header = ({ children }) => (
         &#8253;
       </Modal.Button>
     </span>
-    <h1 className={styles.title} id="ods-modal-standard-title">
-      {children}
-    </h1>
+    <Title visualLevel="4" children={ children } />
   </header>
 );
 
 Modal.Body = ({ children }) => (
-  <main className={styles.content} id="ods-modal-standard-content">
-    {children}
+  <main className={ styles.content }>
+    { children }
   </main>
 );
 

--- a/packages/odyssey-react/src/components/Modal/index.tsx
+++ b/packages/odyssey-react/src/components/Modal/index.tsx
@@ -133,7 +133,7 @@ Modal.Header = ({ children }) => (
         &#8253;
       </Modal.Button>
     </span>
-    <Title visualLevel="4" children={ children } />
+    <Title visualLevel="4" noEndMargin lineHeight="title" children={children} />
   </header>
 );
 

--- a/packages/odyssey-react/src/components/Modal/index.tsx
+++ b/packages/odyssey-react/src/components/Modal/index.tsx
@@ -72,7 +72,11 @@ export type StaticComponents = {
   Button: FunctionComponent<PropsModalButton>
 }
 
-export const ModalContext = createContext<{ onClose: () => void}>({ onClose: () => void 0 });
+export interface ModalContext {
+  onClose?: () => void,
+  modalTitleId?: string;
+}
+export const ModalContext = createContext<ModalContext>({});
 
 /**
  * UI that appears on top of the main content and moves the system into a mode 
@@ -98,8 +102,9 @@ export const ModalContext = createContext<{ onClose: () => void}>({ onClose: () 
  * </Modal>
  */
 const Modal: FunctionComponent<PropsModal> & StaticComponents = (props) => {
-  const { children, id, open = false, onClose, onOpen } = props
-  const context = useMemo(() => ({ onClose, onOpen }), [onClose, onOpen]);
+  const { children, id, open = false, onClose, onOpen } = props;
+  const modalTitleId = useOid();
+  const context = useMemo(() => ({ onClose, modalTitleId }), [onClose, modalTitleId]);
   const oid = useOid(id);
   const modalDialog = useRef<HTMLDivElement>(null);
   const componentClass = useCx(
@@ -115,7 +120,7 @@ const Modal: FunctionComponent<PropsModal> & StaticComponents = (props) => {
     <ModalContext.Provider value={context}>
       <div className={componentClass} id={oid} aria-hidden={!open} data-testid="ods-modal">
         <div className={styles.overlay} tabIndex={-1}>
-          <div className={styles.dialog} role="dialog" aria-modal="true" aria-labelledby="ods-modal-standard-title" ref={modalDialog}> 
+          <div className={styles.dialog} role="dialog" aria-modal="true" aria-labelledby={modalTitleId} ref={modalDialog}>
             {children}
           </div>
         </div>
@@ -125,17 +130,26 @@ const Modal: FunctionComponent<PropsModal> & StaticComponents = (props) => {
   )
 };
 
-Modal.Header = ({ children }) => (
-  <header className={styles.header}>
-    <span className={styles.dismiss}>
-      <Modal.Button close variant="dismiss">
-        {/* @todo Insert <Icon> component */}
-        &#8253;
-      </Modal.Button>
-    </span>
-    <Title visualLevel="4" noEndMargin lineHeight="title" children={children} />
-  </header>
-);
+Modal.Header = ({ children }) => {
+  const { modalTitleId } = useContext(ModalContext);
+  return (
+    <header className={styles.header}>
+      <span className={styles.dismiss}>
+        <Modal.Button close variant="dismiss">
+          {/* @todo Insert <Icon> component */}
+          &#8253;
+        </Modal.Button>
+      </span>
+      <Title
+        id={modalTitleId}
+        visualLevel="4"
+        noEndMargin
+        lineHeight="title"
+        children={children}
+      />
+    </header>
+  );
+};
 
 Modal.Body = ({ children }) => (
   <main className={ styles.content }>
@@ -151,7 +165,7 @@ Modal.Footer = ({ children }) => (
 
 Modal.Button = ({ children, variant, close, onClick }) => {
   const { onClose } = useContext(ModalContext);
-  return <Button variant={variant} onClick={close ? () => onClose() : onClick}>{children}</Button>
+  return <Button variant={variant} onClick={close ? onClose : onClick}>{children}</Button>;
 };
 
 export default Modal

--- a/packages/odyssey-react/src/components/Title/Title.module.scss
+++ b/packages/odyssey-react/src/components/Title/Title.module.scss
@@ -53,3 +53,15 @@
 .level6 {
   line-height: $base-line-height;
 }
+
+.noEndMargin {
+  margin-block-end: 0;
+}
+
+.baseLineHeight {
+  line-height: $base-line-height;
+}
+
+.titleLineHeight {
+  line-height: $title-line-height;
+}

--- a/packages/odyssey-react/src/components/Title/Title.stories.tsx
+++ b/packages/odyssey-react/src/components/Title/Title.stories.tsx
@@ -24,10 +24,12 @@ export default {
   },
 };
 
-const Template: Story<Props> = ({ level, visualLevel, children }) => <Title level={level} visualLevel={visualLevel} children={children} />;
+const Template: Story<Props> = ({ level, visualLevel, children }) => (
+  <Title level={ level } visualLevel={ visualLevel } children={ children } />
+);
 
 export const Primary = Template.bind({});
 Primary.args = {
-  level: 1,
+  level: "1",
   children: "Section title"
 };

--- a/packages/odyssey-react/src/components/Title/Title.test.tsx
+++ b/packages/odyssey-react/src/components/Title/Title.test.tsx
@@ -13,25 +13,27 @@
 import { render, screen } from "@testing-library/react";
 import Title from ".";
 
-const title = "heading";
+const heading = "heading";
 const titleText = "This is a title.";
 
 describe("Title", () => {
   it("render the title", () => {
-    const { getByText } = render(<Title level={1} children={titleText} />);
+    render(<Title children={ titleText } />);
 
-    expect(getByText(titleText)).toBeInTheDocument();
+    const headingElement = screen.getByRole(heading);
+    expect(headingElement).toBeVisible();
+    expect(headingElement.tagName).toBe('H1');
   });
 
   it('changes the semantic tag based on the level prop', () => {
-    const { getByRole } = render(<Title level={3} children={titleText} />);
+    render(<Title level="3" children={ titleText } />);
 
-    expect(getByRole(title).tagName).toBe('H3');
+    expect(screen.getByRole(heading).tagName).toBe('H3');
   });
 
   it('changes the visual appearance based on the visualLevel prop', () => {
-    const { getByRole } = render(<Title level={3} visualLevel={6} children={titleText} />);
-    const component = getByRole(title);
+    render(<Title level="3" visualLevel="6" children={ titleText } />);
+    const component = screen.getByRole(heading);
 
     expect(component.tagName).toBe('H3');
     expect(component.classList).toContain('level6');
@@ -40,11 +42,11 @@ describe("Title", () => {
   it('enforces types for polymorphic rest props', () => {
     render(
       // @ts-expect-error heading element does not have href attribute
-      <Title href="/foo/bar.baz" children={titleText} />
+      <Title href="/foo/bar.baz" children={ titleText } />
     );
-    const component = screen.getByRole(title);
+    const component = screen.getByRole(heading);
     expect(component).toHaveAttribute('href');
   });
 
-  a11yCheck(() => render(<Title level={1} children={titleText} />));
+  a11yCheck(() => render(<Title level="1" children={ titleText } />));
 });

--- a/packages/odyssey-react/src/components/Title/index.tsx
+++ b/packages/odyssey-react/src/components/Title/index.tsx
@@ -14,14 +14,14 @@ import type { FunctionComponent, ReactText } from 'react';
 import { useCx, useOmit } from '../../utils';
 import styles from './Title.module.scss';
 
-type Levels = 1 | 2 | 3 | 4 | 5 | 6;
+type Levels = '1' | '2' | '3' | '4' | '5' | '6';
 
 export type Props = {
   /**
    * The semantic level for the underlying heading tag
    * @default 1
    */
-  level: Levels,
+  level?: Levels,
 
   /**
    * The visual level level for the underlying heading tag
@@ -43,7 +43,7 @@ export type Props = {
  * @example <Title level={1}>Section title</Title>
  */
 const Title: FunctionComponent<Props> = (
-  { level = 1, visualLevel, children, ...rest }
+  { level = '1', visualLevel, children, ...rest }
 ) => {
   const Tag = `h${level}` as const;
 

--- a/packages/odyssey-react/src/components/Title/index.tsx
+++ b/packages/odyssey-react/src/components/Title/index.tsx
@@ -10,13 +10,20 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import type { FunctionComponent, ReactText } from 'react';
+import type {
+  ComponentPropsWithoutRef,
+  FunctionComponent,
+  ReactText
+} from 'react';
 import { useCx, useOmit } from '../../utils';
 import styles from './Title.module.scss';
 
 type Levels = '1' | '2' | '3' | '4' | '5' | '6';
 
-export type Props = {
+export interface Props extends Omit<
+  ComponentPropsWithoutRef<'h1'>,
+  'style' | 'className'
+> {
   /**
    * The semantic level for the underlying heading tag
    * @default 1
@@ -43,7 +50,7 @@ export type Props = {
    * Specify explicit line height spacing
    */
   lineHeight?: 'base' | 'title';
-};
+}
 
 /**
  * Titles are used to describe the main idea of a page, a section, 

--- a/packages/odyssey-react/src/components/Title/index.tsx
+++ b/packages/odyssey-react/src/components/Title/index.tsx
@@ -31,8 +31,19 @@ export type Props = {
   /**
    * The human readable section title to be visually displayed
    */
-  children: ReactText
-}
+  children: ReactText,
+
+  /**
+   * Remove default block end margin
+   * @default false
+   */
+  noEndMargin?: boolean;
+
+  /*
+   * Specify explicit line height spacing
+   */
+  lineHeight?: 'base' | 'title';
+};
 
 /**
  * Titles are used to describe the main idea of a page, a section, 
@@ -40,23 +51,31 @@ export type Props = {
  * use the corresponding title size.
  * 
  * @component
- * @example <Title level={1}>Section title</Title>
  */
-const Title: FunctionComponent<Props> = (
-  { level = '1', visualLevel, children, ...rest }
-) => {
+const Title: FunctionComponent<Props> = (props) => {
+  const {
+    level = '1',
+    visualLevel,
+    children,
+    noEndMargin = false,
+    lineHeight,
+    ...rest
+  } = props;
+
   const Tag = `h${level}` as const;
 
   const componentClass = useCx(
     styles.heading,
-    visualLevel && styles[`level${visualLevel}`]
+    visualLevel && styles[`level${visualLevel}`],
+    noEndMargin && styles.noEndMargin,
+    lineHeight && styles[`${lineHeight}LineHeight`]
   );
 
   const omitProps = useOmit(rest);
 
   return (
     <Tag {...omitProps} className={componentClass}>{children}</Tag>
-  )
-}
+  );
+};
 
 export default Title;

--- a/packages/odyssey-storybook/src/index.ts
+++ b/packages/odyssey-storybook/src/index.ts
@@ -63,7 +63,6 @@ module.exports = {
                 @import '@okta/odyssey/src/scss/base/typography-global';
                 @import '@okta/odyssey/src/scss/base/typography-text';
                 @import '@okta/odyssey/src/scss/base/typography-list';
-                @import '@okta/odyssey/src/scss/base/typography-header';
 
                 // Components
                 @import '@okta/odyssey/src/scss/components/banner';


### PR DESCRIPTION
[OKTA-419574](https://oktainc.atlassian.net/browse/OKTA-419574)

- Refactors `<Title />` types
  - string based rather than numeric for easier JSX use
  - Allows `level` prop to default to `"1"` as intended.
  - Allows for omitted rest props against instrinsic h1 type
- Adds new style focused props as a temporary API until we have `<View />` or `<Box />`
- Fixes static ids for `<Modal />` component a11y associations