### PR TITLE
chore: add workflow_dispatch to preview deployment & fix cache

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -37,28 +37,14 @@ jobs:
           git log --format=%B -n 1 ${{ github.event.after }} >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 
-      - name: set $NODE_VERSION
-        run: echo "NODE_VERSION=$(node --version)" >> $GITHUB_ENV
-
-      - name: Check cache
-        uses: actions/cache@v2
-        id: cache
+      - name: setup node
+        uses: actions/setup-node@v2
         with:
-          path: |
-            node_modules
-            **/node_modules
-          key: |
-            ${{ runner.os }}-node-${{ env.NODE_VERSION }}-cache-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ env.NODE_VERSION }}
+          node-version: v12.20.0
+          cache: yarn
 
-      - name: Install & prepare dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Install dependencies
         run: yarn install --frozen-lockfile
-
-      - name: Prepare dependencies
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: yarn prepare
 
       - name: Run lint
         run: yarn lint

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,5 +1,6 @@
 name: Preview Deployment
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - master

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -37,14 +37,28 @@ jobs:
           git log --format=%B -n 1 ${{ github.event.after }} >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - name: set $NODE_VERSION
+        run: echo "NODE_VERSION=$(node --version)" >> $GITHUB_ENV
 
-      - name: Install dependencies
+      - name: Check cache
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            node_modules
+            **/node_modules
+          key: |
+            ${{ runner.os }}-node-${{ env.NODE_VERSION }}-cache-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ env.NODE_VERSION }}
+
+      - name: Install & prepare dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
+
+      - name: Prepare dependencies
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: yarn prepare
 
       - name: Run lint
         run: yarn lint


### PR DESCRIPTION
See if this fixes caching across branches 🤞  - build time is ~50% faster not having to download and build just under 500mB of dependencies.

[this github writeup describes the cache + branch relationship](https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#example-of-search-priority).