### PR TITLE
feat(odyssey-typescript): upgrade to 4.4.2

### DIFF
--- a/packages/odyssey-typescript/package.json
+++ b/packages/odyssey-typescript/package.json
@@ -5,6 +5,6 @@
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.2"
   }
 }

--- a/packages/odyssey-typescript/tsconfig.strict.json
+++ b/packages/odyssey-typescript/tsconfig.strict.json
@@ -7,6 +7,8 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "resolveJsonModule": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -19515,10 +19515,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.3.5:
-  version "4.3.5"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
+  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
This PR upgrades our TS depedency to [the latest minor release version](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/). I'd love to see us adopt [`exactOptionalPropertyTypes` ](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes) but we'll need to work through a separate batch of about 60 component prop violations where we explicitly pass undefined through.