### PR TITLE
feat(odyssey-react): adds text component

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,1 @@
+*.stories.tsx

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,1 +1,0 @@
-*.stories.tsx

--- a/packages/odyssey-react/src/components/Heading/Heading.tsx
+++ b/packages/odyssey-react/src/components/Heading/Heading.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import type { ComponentPropsWithRef, ReactText } from "react";
+import type { ComponentPropsWithRef, ReactText, ReactNode } from "react";
 import { forwardRef } from "react";
 import { useCx, useOmit, withStyles } from "../../utils";
 import styles from "./Heading.module.scss";
@@ -31,7 +31,7 @@ export interface HeadingProps
   /**
    * The human readable section title to be visually displayed
    */
-  children: ReactText;
+  children: ReactText | ReactNode;
 
   /**
    * Remove default block end margin

--- a/packages/odyssey-react/src/components/Text/Text.module.scss
+++ b/packages/odyssey-react/src/components/Text/Text.module.scss
@@ -28,17 +28,6 @@
     text-decoration: none;
   }
 
-  // address {
-  //   max-width: $max-line-length;
-  //   margin-block-start: 0;
-  //   margin-block-end: $type-margin;
-  //   margin-inline: 0;
-
-  //   &:last-child {
-  //     margin-block-end: 0;
-  //   }
-  // }
-
   em,
   &.em {
     font-style: italic;
@@ -134,19 +123,6 @@
   &.dfn {
     font-style: italic;
   }
-
-  // figure:not([class]) {
-  //   display: grid;
-  //   grid-gap: $spacing-s;
-  //   grid-template-columns: minmax(min-content, max-content);
-  //   justify-content: center;
-  //   justify-items: center;
-
-  //   figcaption:not([class]) {
-  //     color: $text-sub;
-  //     font-size: ms(0);
-  //   }
-  // }
 
   ins,
   &.ins {
@@ -245,14 +221,6 @@
       @include outline;
     }
   }
-
-  // hr {
-  //   margin-block: $spacing-s;
-  //   margin-inline: 0;
-  //   border-width: 1px;
-  //   border-style: solid;
-  //   border-color: cv('gray', '200');
-  // }
 
   code,
   .code {

--- a/packages/odyssey-react/src/components/Text/Text.module.scss
+++ b/packages/odyssey-react/src/components/Text/Text.module.scss
@@ -21,7 +21,7 @@
   font-feature-settings: "lnum", "pnum";
   text-decoration-skip-ink: all;
 
-  // Semantic Elements
+  /* stylelint-disable selector-max-type, selector-max-class, selector-class-pattern */
   abbr,
   &.abbr {
     border-block-end: 1px dashed $color-primary-dark;
@@ -264,6 +264,7 @@
     font-style: italic;
     font-weight: 600;
   }
+  /* stylelint-enable */
 }
 
 // Color

--- a/packages/odyssey-react/src/components/Text/Text.module.scss
+++ b/packages/odyssey-react/src/components/Text/Text.module.scss
@@ -21,7 +21,7 @@
   font-feature-settings: "lnum", "pnum";
   text-decoration-skip-ink: all;
 
-  /* stylelint-disable selector-max-type, selector-max-class, selector-class-pattern */
+  /* stylelint-disable selector-max-type */
   abbr,
   &.abbr {
     border-block-end: 1px dashed $color-primary-dark;
@@ -31,8 +31,9 @@
   em,
   &.em {
     font-style: italic;
-
-    > em {
+    /* stylelint-disable-next-line selector-max-class */
+    > em,
+    > .em {
       text-decoration: underline;
     }
   }
@@ -40,7 +41,7 @@
   strong,
   &.strong {
     font-weight: 600;
-
+    /* stylelint-disable-next-line selector-max-class */
     > strong,
     > .strong {
       text-decoration: underline;
@@ -77,13 +78,15 @@
     }
   }
 
+  /* stylelint-disable selector-class-pattern */
   p,
   &.p {
+    /* stylelint-enable selector-class-pattern */
     max-width: $max-line-length;
     margin-block-start: 0;
     margin-block-end: $type-margin;
     margin-inline: 0;
-
+    /* stylelint-disable-next-line selector-max-class */
     details &,
     .details & {
       font-size: ms(0);
@@ -137,16 +140,6 @@
     @include is-visually-hidden;
   }
 
-  ins::before,
-  &.ins::before {
-    content: attr(data-a11y-start);
-  }
-
-  ins::after,
-  &.ins::after {
-    content: attr(data-a11y-end);
-  }
-
   kbd,
   &.kbd {
     @include border-radius($base-border-radius);
@@ -165,6 +158,7 @@
   &.mark {
     background: cv("yellow", "000");
   }
+  /* stylelint-disable selector-class-pattern */
 
   q,
   &.q {
@@ -192,7 +186,7 @@
     box-shadow: 0 1px 0 cv("gray", "200");
     font-family: $mono-font-family;
     font-size: ms(0);
-
+    /* stylelint-disable-next-line selector-max-class */
     kbd,
     .kbd {
       background: $white;

--- a/packages/odyssey-react/src/components/Text/Text.module.scss
+++ b/packages/odyssey-react/src/components/Text/Text.module.scss
@@ -1,0 +1,374 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+.root {
+  color: $text-body;
+  font-family: $body-font-family;
+  font-size: ($base-font-size / 16px) * 100%;
+  font-style: normal;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: $base-line-height;
+  font-feature-settings: "lnum", "pnum";
+  text-decoration-skip-ink: all;
+
+  // Semantic Elements
+  abbr,
+  &.abbr {
+    border-block-end: 1px dashed $color-primary-dark;
+    text-decoration: none;
+  }
+
+  // address {
+  //   max-width: $max-line-length;
+  //   margin-block-start: 0;
+  //   margin-block-end: $type-margin;
+  //   margin-inline: 0;
+
+  //   &:last-child {
+  //     margin-block-end: 0;
+  //   }
+  // }
+
+  em,
+  &.em {
+    font-style: italic;
+
+    > em {
+      text-decoration: underline;
+    }
+  }
+
+  strong,
+  &.strong {
+    font-weight: 600;
+
+    > strong,
+    > .strong {
+      text-decoration: underline;
+    }
+  }
+
+  sub,
+  &.sup {
+    font-size: ms(-2);
+    line-height: 1;
+    vertical-align: super;
+  }
+
+  sub,
+  &.sub {
+    font-size: ms(-2);
+    line-height: 1;
+    vertical-align: sub;
+  }
+
+  blockquote,
+  &.blockquote {
+    max-width: $max-line-length;
+    margin-block-start: 0;
+    margin-block-end: $type-margin;
+    margin-inline: 0;
+    padding-block: 0;
+    padding-inline-end: 0;
+    padding-inline-start: $spacing-s;
+    border-inline-start: 3px solid $border-color-display;
+
+    &:last-child {
+      margin-block-end: 0;
+    }
+  }
+
+  p,
+  &.p {
+    max-width: $max-line-length;
+    margin-block-start: 0;
+    margin-block-end: $type-margin;
+    margin-inline: 0;
+
+    details &,
+    .details & {
+      font-size: ms(0);
+    }
+
+    &:last-child {
+      margin-block-end: 0;
+    }
+  }
+
+  pre,
+  &.pre {
+    margin-block-start: 0;
+    margin-block-end: $type-margin;
+    margin-inline: 0;
+    font-family: $mono-font-family;
+    white-space: pre-wrap;
+    tab-size: 2;
+
+    &:last-child {
+      margin-block-end: 0;
+    }
+  }
+
+  cite,
+  &.cite {
+    font-style: italic;
+  }
+
+  del,
+  &.del {
+    display: inline-block;
+    background: $color-danger-light;
+  }
+
+  dfn,
+  &.dfn {
+    font-style: italic;
+  }
+
+  // figure:not([class]) {
+  //   display: grid;
+  //   grid-gap: $spacing-s;
+  //   grid-template-columns: minmax(min-content, max-content);
+  //   justify-content: center;
+  //   justify-items: center;
+
+  //   figcaption:not([class]) {
+  //     color: $text-sub;
+  //     font-size: ms(0);
+  //   }
+  // }
+
+  ins,
+  &.ins {
+    display: inline-block;
+    background: cv("green", "000");
+  }
+
+  ins::before,
+  ins::after,
+  &.ins::before,
+  &.ins::after {
+    @include is-visually-hidden;
+  }
+
+  ins::before,
+  &.ins::before {
+    content: attr(data-a11y-start);
+  }
+
+  ins::after,
+  &.ins::after {
+    content: attr(data-a11y-end);
+  }
+
+  kbd,
+  &.kbd {
+    @include border-radius($base-border-radius);
+
+    display: inline-block;
+    padding-block: 0;
+    padding-inline: $spacing-xs;
+    border: 1px solid cv("gray", "200");
+    background: cv("gray", "000");
+    box-shadow: 0 2px 0 cv("gray", "000"), 0 3px 0 cv("gray", "200");
+    font-weight: 400;
+    line-height: $title-line-height;
+  }
+
+  mark,
+  &.mark {
+    background: cv("yellow", "000");
+  }
+
+  q,
+  &.q {
+    quotes: '"' '"' "'" "'";
+
+    &::before {
+      content: open-quote;
+    }
+
+    &::after {
+      content: close-quote;
+    }
+  }
+
+  s,
+  &.s {
+    text-decoration: line-through;
+  }
+
+  samp,
+  &.samp {
+    padding-block: 0;
+    padding-inline: 0.5ch;
+    background-color: cv("gray", "000");
+    box-shadow: 0 1px 0 cv("gray", "200");
+    font-family: $mono-font-family;
+    font-size: ms(0);
+
+    kbd,
+    .kbd {
+      background: $white;
+    }
+  }
+
+  small,
+  &.small {
+    font-size: $size-body-caption;
+  }
+
+  details,
+  &.details {
+    font-size: ms(0);
+  }
+
+  summary,
+  &.summary {
+    @include border-radius($base-border-radius);
+
+    font-size: ms(1);
+    font-weight: 600;
+    cursor: default;
+
+    &:focus {
+      @include outline;
+    }
+  }
+
+  // hr {
+  //   margin-block: $spacing-s;
+  //   margin-inline: 0;
+  //   border-width: 1px;
+  //   border-style: solid;
+  //   border-color: cv('gray', '200');
+  // }
+
+  code,
+  .code {
+    font-family: $mono-font-family;
+  }
+
+  var,
+  .var {
+    font-style: italic;
+    font-weight: 600;
+  }
+}
+
+// Color
+.bodyColor {
+  color: $text-body;
+}
+
+.bodyInverseColor {
+  color: $text-body-inverse;
+}
+
+.subColor {
+  color: $text-sub;
+}
+
+.codeColor {
+  color: $text-code;
+}
+
+.dangerColor {
+  color: $text-danger;
+}
+
+.dangerDisabledColor {
+  color: $text-danger-disabled;
+}
+
+// Weight
+.boldWeight {
+  font-weight: 600;
+}
+
+.regularWeight {
+  font-weight: 400;
+}
+
+// Style
+.normalStyle {
+  font-style: normal;
+}
+
+.italicStyle {
+  font-style: italic;
+}
+
+// Transform
+.noneTransform {
+  text-transform: none;
+}
+
+.capitalizeTransform {
+  text-transform: capitalize;
+}
+
+.uppercaseTransform {
+  text-transform: uppercase;
+}
+
+.lowercaseTransform {
+  text-transform: lowercase;
+}
+
+.fullWidthTransform {
+  text-transform: full-width;
+}
+
+.fullSizeKanaTransform {
+  text-transform: full-size-kana;
+}
+
+// Size
+.ledeSize {
+  font-size: $size-body-lede;
+}
+
+.baseSize {
+  font-size: $size-body-base;
+}
+
+.captionSize {
+  font-size: $size-body-caption;
+}
+
+// Wrap
+.normalWrap {
+  overflow-wrap: normal;
+}
+
+.breakWordWrap {
+  overflow-wrap: break-word;
+}
+
+.anywhereWrap {
+  overflow-wrap: anywhere;
+}
+
+// Line height
+.normalLineHeight {
+  line-height: $base-line-height;
+}
+
+.titleLineHeight {
+  line-height: $title-line-height;
+}
+
+.fontLineHeight {
+  line-height: 1;
+}

--- a/packages/odyssey-react/src/components/Text/Text.test.tsx
+++ b/packages/odyssey-react/src/components/Text/Text.test.tsx
@@ -22,5 +22,12 @@ describe("Text", () => {
     expect(getByText(children)).toBeInTheDocument();
   });
 
+  it("it allows the user to change the tagName using the as prop", () => {
+    const tagName = "abbr";
+    const { container } = render(<Text as={tagName} children={children} />);
+
+    expect(container.querySelector(tagName)).toBeInTheDocument();
+  });
+
   a11yCheck(() => render(<Text children={children} />));
 });

--- a/packages/odyssey-react/src/components/Text/Text.test.tsx
+++ b/packages/odyssey-react/src/components/Text/Text.test.tsx
@@ -1,0 +1,26 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { render } from "@testing-library/react";
+import Text from ".";
+
+const children = "Text child content.";
+
+describe("Text", () => {
+  it("renders into the document", () => {
+    const { getByText } = render(<Text children={children} />);
+
+    expect(getByText(children)).toBeInTheDocument();
+  });
+
+  a11yCheck(() => render(<Text children={children} />));
+});

--- a/packages/odyssey-react/src/components/Text/TextElements.stories.tsx
+++ b/packages/odyssey-react/src/components/Text/TextElements.stories.tsx
@@ -1,0 +1,242 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { Story } from "@storybook/react";
+import Text from ".";
+import type { Props } from ".";
+
+export default {
+  title: `Utilities/Text/Elements`,
+  component: Text,
+  argTypes: {
+    children: {
+      control: { type: "string" },
+    },
+  },
+};
+
+const Template: Story<Props> = ({ children, as, ...rest }) => (
+  <Text as={as} {...rest}>
+    {children}
+  </Text>
+);
+
+export const span = Template.bind({});
+span.storyName = "span (default)";
+span.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)",
+    },
+  },
+};
+span.args = {
+  children: "Text based content",
+};
+
+export const p = Template.bind({});
+p.storyName = "p";
+p.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The `<p>` HTML element represents a paragraph. Paragraphs are usually represented in visual media as blocks of text separated from adjacent blocks by blank lines and/or first-line indentation, but HTML paragraphs can be any structural grouping of related content, such as images or form fields. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p)",
+    },
+  },
+};
+p.args = {
+  children:
+    "Odyssey is Okta’s official design system built for use across all Okta products and sites. We aim to enable designers and developers to build efficiently and consistently while optimizing for user experience and accessibility.",
+  as: "p",
+};
+
+export const abbr = Template.bind({});
+abbr.storyName = "abbr";
+abbr.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The HTML `<abbr>` element represents an abbreviation or acronym; the optional title attribute can provide an expansion or description for the abbreviation. If present, title must contain this full description and nothing else. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr)",
+    },
+  },
+};
+abbr.args = {
+  children: "abbr",
+  as: "abbr",
+  title: "Represents an abbreviation or acronym",
+};
+
+export const em = Template.bind({});
+em.storyName = "em";
+em.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The `<em>` HTML element marks text that has stress emphasis. The `<em>` element can be nested, with each level of nesting indicating a greater degree of emphasis. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em)",
+    },
+  },
+};
+em.args = {
+  children: "This text is emphasized",
+  as: "em",
+};
+
+export const strong = Template.bind({});
+strong.storyName = "strong";
+strong.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The `<strong>` HTML element indicates that its contents have strong importance, seriousness, or urgency. Browsers typically render the contents in bold type. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong)",
+    },
+  },
+};
+strong.args = {
+  children: "This text represents strong importance",
+  as: "strong",
+};
+
+export const sup = Template.bind({});
+sup.storyName = "sup";
+sup.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The `<sup>` HTML element specifies inline text which is to be displayed as superscript for solely typographical reasons. Superscripts are usually rendered with a raised baseline using smaller text. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup)",
+    },
+  },
+};
+sup.args = {
+  children: (
+    <Text>
+      a<Text as="sup">2</Text> + b<Text as="sup">2</Text> = c
+      <Text as="sup">2</Text>
+    </Text>
+  ),
+};
+
+export const sub = Template.bind({});
+sub.storyName = "sub";
+sub.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The `<sub>` HTML element specifies inline text which should be displayed as subscript for solely typographical reasons. Subscripts are typically rendered with a lowered baseline using smaller text. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub)",
+    },
+  },
+};
+sub.args = {
+  children: (
+    <Text>
+      Penicillin (R-C<Text as="sub">9</Text>H<Text as="sub">11</Text>N
+      <Text as="sub">2</Text>O<Text as="sub">4</Text>S) was discovered by
+      Alexander Fleming in 1928.
+    </Text>
+  ),
+};
+
+export const blockquote = Template.bind({});
+blockquote.storyName = "blockquote";
+blockquote.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The `<blockquote>` HTML element indicates that the enclosed text is an extended quotation. Usually, this is rendered visually by indentation (see Notes for how to change it). A URL for the source of the quotation may be given using the cite attribute, while a text representation of the source can be given using the `<cite>` element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote)",
+    },
+  },
+};
+blockquote.args = {
+  children: (
+    <Text>
+      <Text as="p">
+        The important thing is not to stop questioning. Curiosity has its own
+        reason for existence.
+      </Text>
+      <footer>
+        Albert Einstein,{" "}
+        <Text as="cite">
+          Old Man's Advice to Youth: "Never Lose a Holy Curiosity," LIFE
+          magazine (2 May 1955) statement to William Miller, p. 64.
+        </Text>
+      </footer>
+    </Text>
+  ),
+  as: "blockquote",
+};
+
+export const pre = Template.bind({});
+pre.storyName = "pre";
+pre.parameters = {
+  docs: {
+    description: {
+      story:
+        '> The `<pre>` HTML element represents preformatted text which is to be presented exactly as written in the HTML file. The text is typically rendered using a non-proportional, or "monospaced, font. Whitespace inside this element is displayed as written. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre)',
+    },
+  },
+};
+pre.args = {
+  children: "This text represents pre importance",
+  as: "pre",
+};
+
+export const cite = Template.bind({});
+cite.storyName = "cite";
+cite.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The HTML Citation element (`<cite>`) is used to describe a reference to a cited creative work, and must include the title of that work. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite)",
+    },
+  },
+};
+cite.args = {
+  children: "This text represents cite importance",
+  as: "cite",
+};
+
+export const del = Template.bind({});
+del.storyName = "del";
+del.parameters = {
+  docs: {
+    description: {
+      story: `> The &lt;del&gt; HTML element represents a range of text that has been deleted from a document. This can be used when rendering "track changes" 
+        or source code diff information, for example. The &lt;ins&gt; element can be used for the opposite purpose: to indicate text that has been added 
+        to the document. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del)
+
+### Accessibility
+
+Many screen readers do not let users know of the presence of &lt;del&gt;. To fix this, you should consider using **a11yStart** and **a11yEnd** props to 
+prepend and append assistive text to the contents of the tag. In the above example, there are additional spaces before and after the text,
+this is intentional. Not adding these spaces will cause the content within the tag to run into the text within the tag.`,
+    },
+  },
+};
+del.args = {
+  children: (
+    <Text>
+      There is{" "}
+      <Text as="del" a11yStart=" [deletion start] " a11yEnd=" [deletion end] ">
+        nothing
+      </Text>{" "}
+      <Text
+        as="ins"
+        a11yStart=" [insertion start] "
+        a11yEnd=" [insertion end] "
+      >
+        no code
+      </Text>{" "}
+      either good or bad, but running it makes it so.
+    </Text>
+  ),
+  as: "blockquote",
+};

--- a/packages/odyssey-react/src/components/Text/TextElements.stories.tsx
+++ b/packages/odyssey-react/src/components/Text/TextElements.stories.tsx
@@ -58,9 +58,20 @@ abbr.parameters = {
   },
 };
 abbr.args = {
-  children: "abbr",
+  children: (
+    <Text as="p">
+      If you are a
+      <Text as="abbr" title="Back-end">
+        BE
+      </Text>
+      or
+      <Text as="abbr" title="Front-end">
+        FE
+      </Text>
+      developer, you should checkout our dev docs.
+    </Text>
+  ),
   as: "abbr",
-  title: "Represents an abbreviation or acronym",
 };
 
 export const address = Template.bind({});

--- a/packages/odyssey-react/src/components/Text/TextElements.stories.tsx
+++ b/packages/odyssey-react/src/components/Text/TextElements.stories.tsx
@@ -12,6 +12,8 @@
 
 import { Story } from "@storybook/react";
 import Text from ".";
+import Title from "../Title";
+import Link from "../Link";
 import type { Props } from ".";
 
 export default {
@@ -44,22 +46,6 @@ span.args = {
   children: "Text based content",
 };
 
-export const p = Template.bind({});
-p.storyName = "p";
-p.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The `<p>` HTML element represents a paragraph. Paragraphs are usually represented in visual media as blocks of text separated from adjacent blocks by blank lines and/or first-line indentation, but HTML paragraphs can be any structural grouping of related content, such as images or form fields. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p)",
-    },
-  },
-};
-p.args = {
-  children:
-    "Odyssey is Okta’s official design system built for use across all Okta products and sites. We aim to enable designers and developers to build efficiently and consistently while optimizing for user experience and accessibility.",
-  as: "p",
-};
-
 export const abbr = Template.bind({});
 abbr.storyName = "abbr";
 abbr.parameters = {
@@ -76,73 +62,19 @@ abbr.args = {
   title: "Represents an abbreviation or acronym",
 };
 
-export const em = Template.bind({});
-em.storyName = "em";
-em.parameters = {
+export const address = Template.bind({});
+address.storyName = "address";
+address.parameters = {
   docs: {
     description: {
       story:
-        "> The `<em>` HTML element marks text that has stress emphasis. The `<em>` element can be nested, with each level of nesting indicating a greater degree of emphasis. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em)",
+        "> The HTML `<address>` element indicates that the enclosed HTML provides contact information for a person or people, or for an organization. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address)",
     },
   },
 };
-em.args = {
-  children: "This text is emphasized",
-  as: "em",
-};
-
-export const strong = Template.bind({});
-strong.storyName = "strong";
-strong.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The `<strong>` HTML element indicates that its contents have strong importance, seriousness, or urgency. Browsers typically render the contents in bold type. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong)",
-    },
-  },
-};
-strong.args = {
-  children: "This text represents strong importance",
-  as: "strong",
-};
-
-export const sup = Template.bind({});
-sup.storyName = "sup";
-sup.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The `<sup>` HTML element specifies inline text which is to be displayed as superscript for solely typographical reasons. Superscripts are usually rendered with a raised baseline using smaller text. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup)",
-    },
-  },
-};
-sup.args = {
-  children: (
-    <Text>
-      a<Text as="sup">2</Text> + b<Text as="sup">2</Text> = c
-      <Text as="sup">2</Text>
-    </Text>
-  ),
-};
-
-export const sub = Template.bind({});
-sub.storyName = "sub";
-sub.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The `<sub>` HTML element specifies inline text which should be displayed as subscript for solely typographical reasons. Subscripts are typically rendered with a lowered baseline using smaller text. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub)",
-    },
-  },
-};
-sub.args = {
-  children: (
-    <Text>
-      Penicillin (R-C<Text as="sub">9</Text>H<Text as="sub">11</Text>N
-      <Text as="sub">2</Text>O<Text as="sub">4</Text>S) was discovered by
-      Alexander Fleming in 1928.
-    </Text>
-  ),
+address.args = {
+  children: "address",
+  as: "address",
 };
 
 export const blockquote = Template.bind({});
@@ -174,21 +106,6 @@ blockquote.args = {
   as: "blockquote",
 };
 
-export const pre = Template.bind({});
-pre.storyName = "pre";
-pre.parameters = {
-  docs: {
-    description: {
-      story:
-        '> The `<pre>` HTML element represents preformatted text which is to be presented exactly as written in the HTML file. The text is typically rendered using a non-proportional, or "monospaced, font. Whitespace inside this element is displayed as written. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre)',
-    },
-  },
-};
-pre.args = {
-  children: "This text represents pre importance",
-  as: "pre",
-};
-
 export const cite = Template.bind({});
 cite.storyName = "cite";
 cite.parameters = {
@@ -200,8 +117,43 @@ cite.parameters = {
   },
 };
 cite.args = {
-  children: "This text represents cite importance",
-  as: "cite",
+  children: (
+    <Text as="blockquote">
+      <Text as="p">
+        Tell me, O Muse, of that ingenious hero who travelled far and wide after
+        he had sacked the famous town of Troy.
+      </Text>
+      <footer>
+        First sentence in{" "}
+        <Text as="cite">
+          <Link href="https://www.gutenberg.org/files/1727/1727-h/1727-h.htm#chap01">
+            The Odyssey
+          </Link>
+        </Text>{" "}
+        by Homer (Book I).
+      </footer>
+    </Text>
+  ),
+};
+
+export const code = Template.bind({});
+code.storyName = "code";
+code.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The `<code>` HTML element displays its contents styled in a fashion intended to indicate that the text is a short fragment of computer code. By default, the content text is displayed using the user agent's default monospace font. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code)",
+    },
+  },
+};
+code.args = {
+  children: (
+    <Text as="p">
+      The <Text as="code">pop()</Text> array method removes the last element of
+      an array and returns that element.
+    </Text>
+  ),
+  as: "code",
 };
 
 export const del = Template.bind({});
@@ -229,7 +181,7 @@ del.args = {
         nothing
       </Text>{" "}
       <Text
-        as="ins"
+        as="del"
         a11yStart=" [insertion start] "
         a11yEnd=" [insertion end] "
       >
@@ -239,4 +191,326 @@ del.args = {
     </Text>
   ),
   as: "blockquote",
+};
+
+/** @todo revisit this example, its a complex one */
+export const dfn = Template.bind({});
+dfn.storyName = "dfn";
+dfn.parameters = {
+  docs: {
+    description: {
+      story: `> The &lt;dfn&gt; is used to indicate the term being defined within the context of a definition phrase or sentence. The &lt;p&gt; element, the &lt;dt&gt;/&lt;dd&gt; pairing, or the &lt;section&gt; element which is the nearest ancestor of the &lt;dfn&gt; is considered to be the definition of the term. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Eldfnent/dfn)
+        There are multiple, valid ways to use &lt;dfn&gt;. 
+        
+For the sake of usability, Odyssey recommends you follow one of two formats.
+For most terms, the content of &lt;dfn&gt; should be term you are defining:`,
+    },
+  },
+};
+dfn.args = {
+  children: (
+    <Text as="p">
+      A{" "}
+      <Text as="dfn" id="def-cruller">
+        cruller
+      </Text>{" "}
+      is a small, braided torpedo of fried dough.
+    </Text>
+  ),
+};
+
+export const em = Template.bind({});
+em.storyName = "em";
+em.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The `<em>` HTML element marks text that has stress emphasis. The `<em>` element can be nested, with each level of nesting indicating a greater degree of emphasis. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em)",
+    },
+  },
+};
+em.args = {
+  children: "This text is emphasized",
+  as: "em",
+};
+
+export const ins = Template.bind({});
+ins.storyName = "ins";
+ins.parameters = {
+  docs: {
+    description: {
+      story: `> The HTML &lt;ins&gt; element represents a range of text that has been added to a document. You can use the <del> element to similarly represent a range of text that has been deleted from the document. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins)
+
+### Accessibility
+
+Many screen readers do not let users know of the presence of ins. To fix this, you should consider using **data-a11y-start** and **data-a11y-end**, prepend and append assistive text to the contents of the tag. In the above example, there are additional spaces before and after the text, this is intentional. Not adding these spaces will cause the content within the tag to run into the text within the tag.`,
+    },
+  },
+};
+ins.args = {
+  children: (
+    <>
+      <Text as="p">“You're late!”</Text>
+      <Text as="del">
+        <p>“I apologize for the delay.”</p>
+      </Text>
+      <Text as="ins" cite="../howtobeawizard.html">
+        <p>“A wizard is never late &hellip;”</p>
+      </Text>
+    </>
+  ),
+};
+
+export const kbd = Template.bind({});
+kbd.storyName = "kbd";
+kbd.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The `<kbd>` HTML element represents a span of inline text denoting textual user input from a keyboard, voice input, or any other text entry device. By convention, the user agent defaults to rendering the contents of a <kbd> element using its default monospace font, although this is not mandated by the HTML standard. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd)",
+    },
+  },
+};
+kbd.args = {
+  children: (
+    <Text as="p">
+      Pressing <Text as="kbd">tab</Text> will take you to the next focusable
+      element on the page.
+    </Text>
+  ),
+};
+
+export const mark = Template.bind({});
+mark.storyName = "mark";
+mark.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The `<mark>` HTML element represents a span of inline text denoting textual user input from a keyboard, voice input, or any other text entry device. By convention, the user agent defaults to rendering the contents of a <mark> element using its default monospace font, although this is not mandated by the HTML standard. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark)",
+    },
+  },
+};
+mark.args = {
+  children: (
+    <Text>
+      <Text as="p">Search results for "Button":</Text>
+      <hr />
+      <ul>
+        <li>
+          <Text as="mark">Button</Text> labels should clearly indicate what
+          action the user is taking, e.g. "Add User" instead of "Submit".
+        </li>
+        <li>
+          Please follow normal <mark>Button</mark> variant guidelines within
+          tables.
+        </li>
+      </ul>
+    </Text>
+  ),
+};
+
+export const p = Template.bind({});
+p.storyName = "p";
+p.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The `<p>` HTML element represents a paragraph. Paragraphs are usually represented in visual media as blocks of text separated from adjacent blocks by blank lines and/or first-line indentation, but HTML paragraphs can be any structural grouping of related content, such as images or form fields. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p)",
+    },
+  },
+};
+p.args = {
+  children:
+    "Odyssey is Okta’s official design system built for use across all Okta products and sites. We aim to enable designers and developers to build efficiently and consistently while optimizing for user experience and accessibility.",
+  as: "p",
+};
+
+export const pre = Template.bind({});
+pre.storyName = "pre";
+pre.parameters = {
+  docs: {
+    description: {
+      story:
+        '> The `<pre>` HTML element represents preformatted text which is to be presented exactly as written in the HTML file. The text is typically rendered using a non-proportional, or "monospaced, font. Whitespace inside this element is displayed as written. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre)',
+    },
+  },
+};
+pre.args = {
+  children: (
+    <Text as="pre">
+      <code>
+        {`const fruitColors = {
+  apple: 'red',
+  banana: 'yellow'
+}`}
+      </code>
+    </Text>
+  ),
+  as: "pre",
+};
+
+export const q = Template.bind({});
+q.storyName = "q";
+q.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The HTML `<q>` element indicates that the enclosed text is a short inline quotation. Most modern browsers implement this by surrounding the text in quotation marks. This element is intended for short quotations that don't require paragraph breaks; for long quotations use the <blockquote> element - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q)",
+    },
+  },
+};
+q.args = {
+  children: (
+    <Text as="p">
+      While Marge was fighting the monorail, Homer wondered,{" "}
+      <Text as="q" cite="https://www.imdb.com/title/tt0701173/quotes/qt0245595">
+        Donuts - is there anything they can't do?
+      </Text>
+    </Text>
+  ),
+};
+
+export const s = Template.bind({});
+s.storyName = "s";
+s.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The HTML `<s>` element renders text with a strikethrough, or a line through it. Use the <s> element to represent things that are no longer relevant or no longer accurate. However, <s> is not appropriate when indicating document edits; for that, use the <del> and <ins> elements, as appropriate. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s)",
+    },
+  },
+};
+s.args = {
+  children: (
+    <>
+      <Text as="p">
+        <Text as="s">
+          Ramen with white "Paitan" Broth (Limited: 15 servings per day).
+        </Text>
+      </Text>
+      <Text as="p">
+        <Text as="strong">
+          This dish is now <strong>sold out!</strong>
+        </Text>
+      </Text>
+    </>
+  ),
+};
+
+export const samp = Template.bind({});
+samp.storyName = "samp";
+samp.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The HTML Sample Element (`<samp>`) is used to enclose inline text which represents sample (or quoted) output from a computer program. Its contents are typically rendered using the browser's default monospaced font (such as Courier or Lucida Console). - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp)",
+    },
+  },
+};
+samp.args = {
+  children: (
+    <Text as="p">
+      When iDonut crashed, it told me
+      <Text as="samp">
+        Press <Text as="kbd">F5</Text> to refresh bakery.
+      </Text>
+    </Text>
+  ),
+};
+
+export const small = Template.bind({});
+small.storyName = "small";
+small.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The `<small>` HTML element indicates that its contents have small importance, seriousness, or urgency. Browsers typically render the contents in bold type. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small)",
+    },
+  },
+};
+small.args = {
+  children: <>&copy; 2020 Atko, Inc. All Rights Reserved.</>,
+  as: "small",
+};
+
+export const strong = Template.bind({});
+strong.storyName = "strong";
+strong.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The `<strong>` HTML element indicates that its contents have strong importance, seriousness, or urgency. Browsers typically render the contents in bold type. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong)",
+    },
+  },
+};
+strong.args = {
+  children: (
+    <Text as="p">
+      For your safety and the safety of others,{" "}
+      <Text as="strong">please don't run.</Text>
+    </Text>
+  ),
+  as: "strong",
+};
+
+export const sub = Template.bind({});
+sub.storyName = "sub";
+sub.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The `<sub>` HTML element specifies inline text which should be displayed as subscript for solely typographical reasons. Subscripts are typically rendered with a lowered baseline using smaller text. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub)",
+    },
+  },
+};
+sub.args = {
+  children: (
+    <Text>
+      Penicillin (R-C<Text as="sub">9</Text>H<Text as="sub">11</Text>N
+      <Text as="sub">2</Text>O<Text as="sub">4</Text>S) was discovered by
+      Alexander Fleming in 1928.
+    </Text>
+  ),
+};
+
+export const sup = Template.bind({});
+sup.storyName = "sup";
+sup.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The `<sup>` HTML element specifies inline text which is to be displayed as superscript for solely typographical reasons. Superscripts are usually rendered with a raised baseline using smaller text. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup)",
+    },
+  },
+};
+sup.args = {
+  children: (
+    <Text>
+      a<Text as="sup">2</Text> + b<Text as="sup">2</Text> = c
+      <Text as="sup">2</Text>
+    </Text>
+  ),
+};
+
+export const varElement = Template.bind({});
+varElement.storyName = "var";
+varElement.parameters = {
+  docs: {
+    description: {
+      story:
+        "> The `<var>` HTML element represents the name of a variable in a mathematical expression or a programming context. It's typically presented using an italicized version of the current typeface, although that behavior is browser-dependent. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var)",
+    },
+  },
+};
+varElement.args = {
+  children: (
+    <>
+      <Title level="3">
+        Solve for <Text as="var">x</Text>
+      </Title>
+      <Text as="p">
+        2<sup>2</sup>(<var>x</var>+3)+9-5=32
+      </Text>
+    </>
+  ),
 };

--- a/packages/odyssey-react/src/components/Text/TextElements.stories.tsx
+++ b/packages/odyssey-react/src/components/Text/TextElements.stories.tsx
@@ -15,6 +15,7 @@ import Text from ".";
 import Title from "../Title";
 import Link from "../Link";
 import type { Props } from ".";
+import ScreenReaderText from "../ScreenReaderText";
 
 export default {
   title: `Utilities/Text/Elements`,
@@ -167,7 +168,7 @@ del.parameters = {
 
 ### Accessibility
 
-Many screen readers do not let users know of the presence of &lt;del&gt;. To fix this, you should consider using **a11yStart** and **a11yEnd** props to 
+Many screen readers do not let users know of the presence of &lt;del&gt;. To fix this, you should consider using the ScreenReaderText component to 
 prepend and append assistive text to the contents of the tag. In the above example, there are additional spaces before and after the text,
 this is intentional. Not adding these spaces will cause the content within the tag to run into the text within the tag.`,
     },
@@ -177,15 +178,14 @@ del.args = {
   children: (
     <Text>
       There is{" "}
-      <Text as="del" a11yStart=" [deletion start] " a11yEnd=" [deletion end] ">
+      <Text as="del">
+        <ScreenReaderText>[deletion start]</ScreenReaderText>
         nothing
+        <ScreenReaderText>[deletion end]</ScreenReaderText>
       </Text>{" "}
-      <Text
-        as="del"
-        a11yStart=" [insertion start] "
-        a11yEnd=" [insertion end] "
-      >
-        no code
+      <Text as="del">
+        <ScreenReaderText>[insertion start]</ScreenReaderText>
+        no code <ScreenReaderText>[insertion start]</ScreenReaderText>
       </Text>{" "}
       either good or bad, but running it makes it so.
     </Text>
@@ -243,7 +243,7 @@ ins.parameters = {
 
 ### Accessibility
 
-Many screen readers do not let users know of the presence of ins. To fix this, you should consider using **data-a11y-start** and **data-a11y-end**, prepend and append assistive text to the contents of the tag. In the above example, there are additional spaces before and after the text, this is intentional. Not adding these spaces will cause the content within the tag to run into the text within the tag.`,
+Many screen readers do not let users know of the presence of ins. To fix this, you should consider using the ScreenReaderText component, prepend and append assistive text to the contents of the tag. In the above example, there are additional spaces before and after the text, this is intentional. Not adding these spaces will cause the content within the tag to run into the text within the tag.`,
     },
   },
 };

--- a/packages/odyssey-react/src/components/Text/TextStyles.stories.tsx
+++ b/packages/odyssey-react/src/components/Text/TextStyles.stories.tsx
@@ -27,20 +27,24 @@ export default {
 const Template: Story<Props> = ({ children, ...rest }) => (
   <Text {...rest}>{children}</Text>
 );
-const TemplateWithContainer: Story<Props> = ({ children, ...rest }) => (
-  <div
-    style={{
-      background: "#faf5dc",
-      width: "min-content",
-      maxWidth: "8em",
-      height: "200px",
-      paddingBlock: "1rem",
-      paddingInline: "1rem",
-    }}
-  >
-    <Text {...rest}>{children}</Text>
-  </div>
-);
+
+const TemplateWithContainer: Story<Props> = ({ children, ...rest }) => {
+  /* prettier-ignore */
+  const style = {  /* stylelint-disable-line */
+    background: "#faf5dc",
+    width: "min-content",
+    maxWidth: "8em",
+    height: "200px",
+    paddingBlock: "1rem",
+    paddingInline: "1rem",
+  };
+
+  return (
+    <div style={style}>
+      <Text {...rest}>{children}</Text>
+    </div>
+  );
+};
 
 export const ColorBody = Template.bind({});
 ColorBody.storyName = "Color: Body (default)";

--- a/packages/odyssey-react/src/components/Text/TextStyles.stories.tsx
+++ b/packages/odyssey-react/src/components/Text/TextStyles.stories.tsx
@@ -27,7 +27,6 @@ export default {
 const Template: Story<Props> = ({ children, ...rest }) => (
   <Text {...rest}>{children}</Text>
 );
-
 const TemplateWithContainer: Story<Props> = ({ children, ...rest }) => (
   <div
     style={{
@@ -35,7 +34,8 @@ const TemplateWithContainer: Story<Props> = ({ children, ...rest }) => (
       width: "min-content",
       maxWidth: "8em",
       height: "200px",
-      padding: "1rem",
+      paddingBlock: "1rem",
+      paddingInline: "1rem",
     }}
   >
     <Text {...rest}>{children}</Text>
@@ -103,17 +103,17 @@ WeightBold.args = {
 
 // Style
 export const StyleNormal = Template.bind({});
-StyleNormal.storyName = "Style: Normal (default)";
+StyleNormal.storyName = "Font style: Normal (default)";
 StyleNormal.args = {
   children: "Normal text Style",
-  style: "normal",
+  fontStyle: "normal",
 };
 
 export const StyleItalic = Template.bind({});
-StyleItalic.storyName = "Style: Italic";
+StyleItalic.storyName = "Font style: Italic";
 StyleItalic.args = {
   children: "Italic text Style",
-  style: "italic",
+  fontStyle: "italic",
 };
 
 // Transform
@@ -195,7 +195,7 @@ WrapNormal.args = {
 };
 
 export const WrapBreakWord = TemplateWithContainer.bind({});
-WrapBreakWord.storyName = "Wrap: BreakWord (default)";
+WrapBreakWord.storyName = "Wrap: Break word (default)";
 WrapBreakWord.args = {
   children: (
     <>

--- a/packages/odyssey-react/src/components/Text/TextStyles.stories.tsx
+++ b/packages/odyssey-react/src/components/Text/TextStyles.stories.tsx
@@ -1,0 +1,241 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { Story } from "@storybook/react";
+import Text from ".";
+import type { Props } from ".";
+
+export default {
+  title: `Utilities/Text/Styles`,
+  component: Text,
+  argTypes: {
+    children: {
+      control: { type: "string" },
+    },
+  },
+};
+
+const Template: Story<Props> = ({ children, ...rest }) => (
+  <Text {...rest}>{children}</Text>
+);
+
+const TemplateWithContainer: Story<Props> = ({ children, ...rest }) => (
+  <div
+    style={{
+      background: "#faf5dc",
+      width: "min-content",
+      maxWidth: "8em",
+      height: "200px",
+      padding: "1rem",
+    }}
+  >
+    <Text {...rest}>{children}</Text>
+  </div>
+);
+
+export const ColorBody = Template.bind({});
+ColorBody.storyName = "Color: Body (default)";
+ColorBody.args = {
+  children: "Default body text color",
+};
+
+export const BodyInverse = Template.bind({});
+BodyInverse.storyName = "Color: Body, inverse";
+BodyInverse.parameters = {
+  backgrounds: { default: "inverse (gray-900)" },
+};
+BodyInverse.args = {
+  children: "Danger (disabled) text color",
+  color: "bodyInverse",
+};
+
+export const Code = Template.bind({});
+Code.storyName = "Color: Code";
+Code.args = {
+  children: "Code text color",
+  color: "code",
+};
+
+export const ColorDanger = Template.bind({});
+ColorDanger.storyName = "Color: Danger";
+ColorDanger.args = {
+  children: "Danger text color",
+  color: "danger",
+};
+
+export const ColorDangerDisabled = Template.bind({});
+ColorDangerDisabled.storyName = "Color: Danger, disabled";
+ColorDangerDisabled.args = {
+  children: "Danger (disabled) text color",
+  color: "dangerDisabled",
+};
+
+export const ColorSub = Template.bind({});
+ColorSub.storyName = "Color: Sub";
+ColorSub.args = {
+  children: "Sub text color",
+  color: "sub",
+};
+
+// Weight
+export const WeightRegular = Template.bind({});
+WeightRegular.storyName = "Weight: Regular";
+WeightRegular.args = {
+  children: "Regular text weight",
+  weight: "regular",
+};
+
+export const WeightBold = Template.bind({});
+WeightBold.storyName = "Weight: Bold";
+WeightBold.args = {
+  children: "Bold text weight",
+  weight: "bold",
+};
+
+// Style
+export const StyleNormal = Template.bind({});
+StyleNormal.storyName = "Style: Normal (default)";
+StyleNormal.args = {
+  children: "Normal text Style",
+  style: "normal",
+};
+
+export const StyleItalic = Template.bind({});
+StyleItalic.storyName = "Style: Italic";
+StyleItalic.args = {
+  children: "Italic text Style",
+  style: "italic",
+};
+
+// Transform
+export const TransformNormal = Template.bind({});
+TransformNormal.storyName = "Transform: none (default)";
+TransformNormal.args = {
+  children: "Normal text transform style",
+  transform: "none",
+};
+
+export const TransformCapitalize = Template.bind({});
+TransformCapitalize.storyName = "Transform: Capitalize";
+TransformCapitalize.args = {
+  children: "Capitalize text transform style",
+  transform: "capitalize",
+};
+
+export const TransformLowerCase = Template.bind({});
+TransformLowerCase.storyName = "Transform: Lower case";
+TransformLowerCase.args = {
+  children: "Lower case text transform style",
+  transform: "lowercase",
+};
+
+export const TransformUpperCase = Template.bind({});
+TransformUpperCase.storyName = "Transform: Upper case";
+TransformUpperCase.args = {
+  children: "Uppercase text transform style",
+  transform: "uppercase",
+};
+
+export const TransformFullWidth = Template.bind({});
+TransformFullWidth.storyName = "Transform: Full width";
+TransformFullWidth.args = {
+  children: "Full width text transform style",
+  transform: "fullWidth",
+};
+
+export const TransformFullSizeKana = Template.bind({});
+TransformFullSizeKana.storyName = "Transform: Full size kana";
+TransformFullSizeKana.args = {
+  children: "Full size kana text transform style",
+  transform: "fullSizeKana",
+};
+
+// Transform
+export const SizeLede = Template.bind({});
+SizeLede.storyName = "Size: Lede";
+SizeLede.args = {
+  children: "Lede text size style",
+  size: "lede",
+};
+
+export const SizeBase = Template.bind({});
+SizeBase.storyName = "Size: Base (default)";
+SizeBase.args = {
+  children: "Base text size style",
+  size: "base",
+};
+
+export const SizeCaption = Template.bind({});
+SizeCaption.storyName = "Size: Caption";
+SizeCaption.args = {
+  children: "Caption text size style",
+  size: "caption",
+};
+
+// Wrap
+export const WrapNormal = TemplateWithContainer.bind({});
+WrapNormal.storyName = "Wrap: Normal";
+WrapNormal.args = {
+  children: (
+    <>
+      Normal text wrap style. The wrap prop can be{" "}
+      <strong>incomprehensibile</strong> if viewed in the wrong context
+    </>
+  ),
+  wrap: "normal",
+};
+
+export const WrapBreakWord = TemplateWithContainer.bind({});
+WrapBreakWord.storyName = "Wrap: BreakWord (default)";
+WrapBreakWord.args = {
+  children: (
+    <>
+      Normal text wrap style. The wrap prop can be{" "}
+      <strong>incomprehensibile</strong> if viewed in the wrong context
+    </>
+  ),
+  wrap: "breakWord",
+};
+
+export const WrapAnywhere = TemplateWithContainer.bind({});
+WrapAnywhere.storyName = "Wrap: Anywhere";
+WrapAnywhere.args = {
+  children: (
+    <>
+      Normal text wrap style. The wrap prop can be{" "}
+      <strong>incomprehensibile</strong> if viewed in the wrong context
+    </>
+  ),
+  wrap: "anywhere",
+};
+
+// Line Height
+export const LineHeightNormal = TemplateWithContainer.bind({});
+LineHeightNormal.storyName = "Line height: Normal (default)";
+LineHeightNormal.args = {
+  children: "Normal text LineHeight style",
+  lineHeight: "normal",
+};
+
+export const LineHeightTitle = TemplateWithContainer.bind({});
+LineHeightTitle.storyName = "Line height: Title";
+LineHeightTitle.args = {
+  children: "Title text LineHeight style",
+  lineHeight: "title",
+};
+
+export const LineHeightFont = TemplateWithContainer.bind({});
+LineHeightFont.storyName = "Line height: Font (1)";
+LineHeightFont.args = {
+  children: "Font text LineHeight style",
+  lineHeight: "font",
+};

--- a/packages/odyssey-react/src/components/Text/index.tsx
+++ b/packages/odyssey-react/src/components/Text/index.tsx
@@ -1,0 +1,148 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import type { FunctionComponent, ReactText, ReactNode } from "react";
+import { useCx, useOmit } from "../../utils";
+import styles from "./Text.module.scss";
+import ScreenReaderText from "../ScreenReaderText";
+
+export type Props = {
+  /**
+   * Text content to be rendered
+   */
+  children: ReactText | ReactNode;
+
+  /**
+   * Prepends visually hidden assistive text to the child contents
+   */
+  a11yStart?: ReactText;
+
+  /**
+   * Appends visually hidden assistive text to the child contents
+   */
+  a11yEnd?: ReactText;
+
+  /**
+   * The semantic element to be rendered in to the DOM
+   * @default span
+   */
+  as?:
+    | "span"
+    | "p"
+    | "abbr"
+    | "em"
+    | "strong"
+    | "sup"
+    | "sub"
+    | "blockquote"
+    | "cite"
+    | "del"
+    | "pre";
+
+  /**
+   * @todo
+   * @default body
+   */
+  color?: "body" | "bodyInverse" | "code" | "danger" | "dangerDisabled" | "sub";
+
+  /**
+   * @todo
+   * @default regular
+   */
+  weight?: "regular" | "bold";
+
+  /**
+   * @todo
+   * @default normal
+   */
+  style?: "normal" | "italic";
+
+  /**
+   * @todo
+   * @default none
+   */
+  transform?:
+    | "none"
+    | "capitalize"
+    | "uppercase"
+    | "lowercase"
+    | "fullWidth"
+    | "fullSizeKana";
+
+  /**
+   * @todo
+   * @default normal
+   */
+  size?: "lede" | "base" | "caption";
+
+  /**
+   * @todo
+   * @default normal
+   */
+  lineHeight?: "normal" | "title" | "font";
+
+  /**
+   * @todo
+   * @default normal
+   */
+  wrap?: "normal" | "breakWord" | "anywhere";
+};
+
+/**
+ * A component which provides style for visible text elements.
+ *
+ * @component
+ * @example
+ * <Text>Text label</Text>
+ */
+const Text: FunctionComponent<Props> = (props) => {
+  const {
+    children,
+    as = "p",
+    color = "body",
+    weight = "regular",
+    style = "normal",
+    transform = "none",
+    size = "base",
+    wrap = "normal",
+    lineHeight = "normal",
+    a11yStart,
+    a11yEnd,
+    ...rest
+  } = props;
+
+  const Tag = as;
+
+  const componentClass = useCx(
+    styles.root,
+    styles[as],
+    styles[color + "Color"],
+    styles[weight + "Weight"],
+    styles[style + "Style"],
+    styles[transform + "Transform"],
+    styles[size + "Size"],
+    styles[wrap + "Wrap"],
+    styles[lineHeight + "LineHeight"]
+  );
+
+  const omitProps = useOmit(rest);
+
+  return (
+    <Tag {...omitProps} className={componentClass}>
+      {a11yStart && <ScreenReaderText>{a11yStart}</ScreenReaderText>}
+      {children}
+      {a11yEnd && <ScreenReaderText>{a11yEnd}</ScreenReaderText>}
+    </Tag>
+  );
+};
+
+export default Text;

--- a/packages/odyssey-react/src/components/Text/index.tsx
+++ b/packages/odyssey-react/src/components/Text/index.tsx
@@ -10,12 +10,17 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import type { FunctionComponent, ReactText, ReactNode } from "react";
+import type {
+  FunctionComponent,
+  ReactText,
+  ReactNode,
+  HTMLAttributes,
+} from "react";
 import { useCx, useOmit } from "../../utils";
 import styles from "./Text.module.scss";
 import ScreenReaderText from "../ScreenReaderText";
 
-export type Props = {
+export interface Props extends HTMLAttributes<HTMLElement> {
   /**
    * Text content to be rendered
    */
@@ -36,7 +41,9 @@ export type Props = {
    * @default span
    */
   as?:
+    | "address"
     | "span"
+    | "dfn"
     | "p"
     | "abbr"
     | "em"
@@ -46,28 +53,37 @@ export type Props = {
     | "blockquote"
     | "cite"
     | "del"
-    | "pre";
+    | "pre"
+    | "var"
+    | "q"
+    | "s"
+    | "samp"
+    | "small"
+    | "kbd"
+    | "ins"
+    | "mark"
+    | "code";
 
   /**
-   * @todo
+   * The text color style for the text content.
    * @default body
    */
   color?: "body" | "bodyInverse" | "code" | "danger" | "dangerDisabled" | "sub";
 
   /**
-   * @todo
+   * The font weight for the text content.
    * @default regular
    */
   weight?: "regular" | "bold";
 
   /**
-   * @todo
+   * The font style (normal or italic) for the text content.
    * @default normal
    */
-  style?: "normal" | "italic";
+  fontStyle?: "normal" | "italic";
 
   /**
-   * @todo
+   * The text-transform for the text content.
    * @default none
    */
   transform?:
@@ -79,23 +95,26 @@ export type Props = {
     | "fullSizeKana";
 
   /**
-   * @todo
+   * The font-size for the text content.
    * @default normal
    */
   size?: "lede" | "base" | "caption";
 
   /**
-   * @todo
+   * The line-height for the text content.
    * @default normal
    */
   lineHeight?: "normal" | "title" | "font";
 
   /**
-   * @todo
+   * The overflow wrapping behavior for the text content.
    * @default normal
    */
   wrap?: "normal" | "breakWord" | "anywhere";
-};
+
+  /** @todo This should be an inherited HTML type, need to fix prior to merge */
+  cite?: any;
+}
 
 /**
  * A component which provides style for visible text elements.
@@ -110,7 +129,7 @@ const Text: FunctionComponent<Props> = (props) => {
     as = "p",
     color = "body",
     weight = "regular",
-    style = "normal",
+    fontStyle = "normal",
     transform = "none",
     size = "base",
     wrap = "normal",
@@ -127,7 +146,7 @@ const Text: FunctionComponent<Props> = (props) => {
     styles[as],
     styles[color + "Color"],
     styles[weight + "Weight"],
-    styles[style + "Style"],
+    styles[fontStyle + "Style"],
     styles[transform + "Transform"],
     styles[size + "Size"],
     styles[wrap + "Wrap"],

--- a/packages/odyssey-react/src/components/Text/index.tsx
+++ b/packages/odyssey-react/src/components/Text/index.tsx
@@ -10,44 +10,48 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import type { FunctionComponent, ReactText, ReactNode } from "react";
+import type { ReactNode, ComponentPropsWithRef } from "react";
+import { forwardRef } from "react";
 import { useCx, useOmit } from "../../utils";
 import styles from "./Text.module.scss";
 
-export interface Props {
+type TagProps =
+  | "address"
+  | "span"
+  | "div"
+  | "dfn"
+  | "p"
+  | "abbr"
+  | "em"
+  | "strong"
+  | "sup"
+  | "sub"
+  | "blockquote"
+  | "cite"
+  | "del"
+  | "pre"
+  | "var"
+  | "q"
+  | "s"
+  | "samp"
+  | "small"
+  | "kbd"
+  | "ins"
+  | "mark"
+  | "code";
+
+export interface Props
+  extends Omit<ComponentPropsWithRef<TagProps>, "style" | "className"> {
   /**
    * Text content to be rendered
    */
-  children: ReactText | ReactNode;
+  children: ReactNode;
 
   /**
    * The semantic element to be rendered in to the DOM
    * @default span
    */
-  as?:
-    | "address"
-    | "span"
-    | "div"
-    | "dfn"
-    | "p"
-    | "abbr"
-    | "em"
-    | "strong"
-    | "sup"
-    | "sub"
-    | "blockquote"
-    | "cite"
-    | "del"
-    | "pre"
-    | "var"
-    | "q"
-    | "s"
-    | "samp"
-    | "small"
-    | "kbd"
-    | "ins"
-    | "mark"
-    | "code";
+  as?: TagProps;
 
   /**
    * The text color style for the text content.
@@ -96,8 +100,6 @@ export interface Props {
    * @default normal
    */
   wrap?: "normal" | "breakWord" | "anywhere";
-
-  id?: string;
 }
 
 interface PropsCite extends Props {
@@ -110,46 +112,44 @@ interface PropsAbbr extends Props {
 
 /**
  * A component which provides style for visible text elements.
- *
- * @component
- * @example
- * <Text>Text label</Text>
  */
-const Text: FunctionComponent<Props | PropsCite | PropsAbbr> = (props) => {
-  const {
-    children,
-    as = "p",
-    color = "body",
-    weight = "regular",
-    fontStyle = "normal",
-    transform = "none",
-    size = "base",
-    wrap = "normal",
-    lineHeight = "normal",
-    ...rest
-  } = props;
+const Text = forwardRef<HTMLElement, Props | PropsCite | PropsAbbr>(
+  (props, ref) => {
+    const {
+      children,
+      as = "p",
+      color = "body",
+      weight = "regular",
+      fontStyle = "normal",
+      transform = "none",
+      size = "base",
+      wrap = "normal",
+      lineHeight = "normal",
+      ...rest
+    } = props;
 
-  const Tag = as;
+    const Tag = as;
 
-  const componentClass = useCx(
-    styles.root,
-    styles[as],
-    styles[color + "Color"],
-    styles[weight + "Weight"],
-    styles[fontStyle + "Style"],
-    styles[transform + "Transform"],
-    styles[size + "Size"],
-    styles[wrap + "Wrap"],
-    styles[lineHeight + "LineHeight"]
-  );
+    const componentClass = useCx(
+      styles.root,
+      styles[as],
+      styles[color + "Color"],
+      styles[weight + "Weight"],
+      styles[fontStyle + "Style"],
+      styles[transform + "Transform"],
+      styles[size + "Size"],
+      styles[wrap + "Wrap"],
+      styles[lineHeight + "LineHeight"]
+    );
 
-  const omitProps = useOmit(rest);
+    const omitProps = useOmit(rest);
 
-  return (
-    <Tag {...omitProps} className={componentClass}>
-      {children}
-    </Tag>
-  );
-};
+    return (
+      <Tag ref={ref} {...omitProps} className={componentClass}>
+        {children}
+      </Tag>
+    );
+  }
+);
 
 export default Text;

--- a/packages/odyssey-react/src/components/Text/index.tsx
+++ b/packages/odyssey-react/src/components/Text/index.tsx
@@ -18,7 +18,6 @@ import type {
 } from "react";
 import { useCx, useOmit } from "../../utils";
 import styles from "./Text.module.scss";
-import ScreenReaderText from "../ScreenReaderText";
 
 export interface Props extends HTMLAttributes<HTMLElement> {
   /**
@@ -27,22 +26,13 @@ export interface Props extends HTMLAttributes<HTMLElement> {
   children: ReactText | ReactNode;
 
   /**
-   * Prepends visually hidden assistive text to the child contents
-   */
-  a11yStart?: ReactText;
-
-  /**
-   * Appends visually hidden assistive text to the child contents
-   */
-  a11yEnd?: ReactText;
-
-  /**
    * The semantic element to be rendered in to the DOM
    * @default span
    */
   as?:
     | "address"
     | "span"
+    | "div"
     | "dfn"
     | "p"
     | "abbr"
@@ -134,8 +124,6 @@ const Text: FunctionComponent<Props> = (props) => {
     size = "base",
     wrap = "normal",
     lineHeight = "normal",
-    a11yStart,
-    a11yEnd,
     ...rest
   } = props;
 
@@ -157,9 +145,7 @@ const Text: FunctionComponent<Props> = (props) => {
 
   return (
     <Tag {...omitProps} className={componentClass}>
-      {a11yStart && <ScreenReaderText>{a11yStart}</ScreenReaderText>}
       {children}
-      {a11yEnd && <ScreenReaderText>{a11yEnd}</ScreenReaderText>}
     </Tag>
   );
 };

--- a/packages/odyssey-react/src/components/Text/index.tsx
+++ b/packages/odyssey-react/src/components/Text/index.tsx
@@ -10,16 +10,11 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import type {
-  FunctionComponent,
-  ReactText,
-  ReactNode,
-  HTMLAttributes,
-} from "react";
+import type { FunctionComponent, ReactText, ReactNode } from "react";
 import { useCx, useOmit } from "../../utils";
 import styles from "./Text.module.scss";
 
-export interface Props extends HTMLAttributes<HTMLElement> {
+export interface Props {
   /**
    * Text content to be rendered
    */
@@ -102,8 +97,15 @@ export interface Props extends HTMLAttributes<HTMLElement> {
    */
   wrap?: "normal" | "breakWord" | "anywhere";
 
-  /** @todo This should be an inherited HTML type, need to fix prior to merge */
-  cite?: any;
+  id?: string;
+}
+
+interface PropsCite extends Props {
+  cite?: string;
+}
+
+interface PropsAbbr extends Props {
+  title: string;
 }
 
 /**
@@ -113,7 +115,7 @@ export interface Props extends HTMLAttributes<HTMLElement> {
  * @example
  * <Text>Text label</Text>
  */
-const Text: FunctionComponent<Props> = (props) => {
+const Text: FunctionComponent<Props | PropsCite | PropsAbbr> = (props) => {
   const {
     children,
     as = "p",

--- a/packages/odyssey/src/scss/abstracts/_tokens.scss
+++ b/packages/odyssey/src/scss/abstracts/_tokens.scss
@@ -58,6 +58,7 @@ $focus-ring-danger: $color-danger-light;
 
 // Text Color
 $text-body: cv("gray", "900");
+$text-body-inverse: $white;
 $text-heading: cv("gray", "900");
 $text-sub: cv("gray", "600");
 $text-code: cv("gray", "900");


### PR DESCRIPTION
- [x] Complete unit tests
- [x] Figure out [small typescript issue](https://github.com/okta/odyssey/pull/1076/files#diff-99250ae2190754fd6764740884a64fcd30b3fc4d325ab09016ca9f8e2e7f2635R115-R117)
- Some Elements are missing from this PR, I didn't feel they were appropriate to include in the Text component and believe they are better served as their own components. Will log issues for the following
  - [x] [figure](https://oktainc.atlassian.net/browse/OKTA-431517)
  - [x] [hr](https://oktainc.atlassian.net/browse/OKTA-431518)
  - [x] [output](https://oktainc.atlassian.net/browse/OKTA-431519)
  - [x] [details (and summary)](https://oktainc.atlassian.net/browse/OKTA-431520)