### PR TITLE
fix(odyssey-lint-staged): amend commit with prettier changes

### DIFF
--- a/packages/odyssey-lint-staged/src/index.js
+++ b/packages/odyssey-lint-staged/src/index.js
@@ -11,7 +11,7 @@
  */
 
 module.exports = {
-  "*": "yarn prettier --check . --ignore-path .gitignore",
-  ".scss": "stylelint",
-  ".js,.jsx,.ts,.tsx": "eslint .",
+  "*": "prettier --ignore-unknown --ignore-path .gitignore --write",
+  "*.scss": "stylelint",
+  "*.{js,jsx,ts,tsx}": "eslint",
 };


### PR DESCRIPTION
Improve DX by automatically amending commits with prettier formatting changes.

This also fixes the stylelint and eslint commands to now run during the precommit hook