### PR TITLE
fix(odyssey-react): constrain FieldGroup width

### DIFF
--- a/packages/odyssey-react/src/components/FieldGroup/FieldGroup.module.scss
+++ b/packages/odyssey-react/src/components/FieldGroup/FieldGroup.module.scss
@@ -11,6 +11,7 @@
  */
 
 .root {
+  max-width: $max-line-length;
   margin-block-start: 0;
   margin-block-end: $spacing-m;
   padding-block-end: $spacing-m;


### PR DESCRIPTION
### Before

<img width="524" alt="Screen Shot 2021-10-25 at 3 46 18 PM" src="https://user-images.githubusercontent.com/36284167/139112539-e65bfb0b-2c7f-4696-8fb1-4e5847c9ad90.png">

### After

<img width="530" alt="Screen Shot 2021-10-27 at 9 59 15 AM" src="https://user-images.githubusercontent.com/36284167/139112562-1095508e-f7d0-4e1c-a4ca-875420d2a3c3.png">