### PR TITLE
build(odyssey): remove sass build in prepare npm script

### DIFF
--- a/packages/odyssey/package.json
+++ b/packages/odyssey/package.json
@@ -12,7 +12,6 @@
   "main": "src/scss/odyssey.scss",
   "style": "src/scss/odyssey.scss",
   "scripts": {
-    "prepare": "yarn build",
     "build": "sass src/scss/odyssey.scss dist/odyssey.css"
   },
   "devDependencies": {


### PR DESCRIPTION
no need to execute sass to build the static CSS output for this package as part of our other npm lifecycle scripts as it is going to be removed :soon: 