### PR TITLE
build(odyssey-react): use odyssey-postcss-scss plugin

### DIFF
--- a/packages/odyssey-postcss-scss/package.json
+++ b/packages/odyssey-postcss-scss/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@okta/odyssey-postcss-scss",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "author": "Okta, Inc.",
+  "license": "Apache-2.0",
+  "private": true,
+  "scripts": {
+    "prepare": "tsc"
+  },
+  "dependencies": {
+    "sass": "^1.42.1"
+  },
+  "devDependencies": {
+    "@okta/odyssey-typescript": "^0.8.2",
+    "@types/sass": "^1.16.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.3.6"
+  }
+}

--- a/packages/odyssey-postcss-scss/src/index.ts
+++ b/packages/odyssey-postcss-scss/src/index.ts
@@ -1,0 +1,14 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+export * from "./plugin";
+export { default } from "./plugin";

--- a/packages/odyssey-postcss-scss/src/plugin.ts
+++ b/packages/odyssey-postcss-scss/src/plugin.ts
@@ -1,0 +1,35 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { renderSync } from "sass";
+import type { Plugin } from "postcss";
+
+interface PluginOptions {
+  importData: string;
+}
+
+const plugin = ({ importData }: PluginOptions): Plugin => ({
+  postcssPlugin: "odyssey-postcss-scss",
+  Once(root, { result, parse }) {
+    const { css: postcss } = root.toResult({ map: false });
+
+    const { css } = renderSync({
+      data: `${importData}\n${postcss}`,
+      file: result.opts.from,
+    });
+
+    result.root = parse(css, { from: result.opts.from });
+  },
+});
+
+plugin.postcss = true;
+export { plugin as default };

--- a/packages/odyssey-postcss-scss/tsconfig.json
+++ b/packages/odyssey-postcss-scss/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@okta/odyssey-typescript/tsconfig.node12.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/packages/odyssey-react/.postcssrc.js
+++ b/packages/odyssey-react/.postcssrc.js
@@ -10,6 +10,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+const { resolve } = require("path");
+const { default: postcssScss } = require("@okta/odyssey-postcss-scss");
 const {
   default: transformStyles,
 } = require("@okta/odyssey-transform-styles-postcss-preset");
@@ -33,7 +35,13 @@ module.exports = (ctx) => {
     }
   );
 
+  const partials = `functions colors mixins tokens`.split(" ");
+  const importDir = resolve(require.resolve("@okta/odyssey"), "../abstracts");
+  const importData = partials
+    .map((partial) => `@import '${importDir}/${partial}';`)
+    .join("\n");
+
   return {
-    plugins: [transformStyles(options)],
+    plugins: [postcssScss({ importData }), transformStyles(options)],
   };
 };

--- a/packages/odyssey-react/package.json
+++ b/packages/odyssey-react/package.json
@@ -21,6 +21,7 @@
     "@okta/odyssey-babel-preset": "^0.8.2",
     "@okta/odyssey-eslint": "^0.8.2",
     "@okta/odyssey-icons": "^0.8.2",
+    "@okta/odyssey-postcss-scss": "^0.0.0",
     "@okta/odyssey-stylelint": "^0.8.2",
     "@okta/odyssey-svgr": "^0.8.2",
     "@okta/odyssey-transform-styles-postcss-preset": "^0.8.2",

--- a/packages/odyssey-react/src/components/Select/Select.module.scss
+++ b/packages/odyssey-react/src/components/Select/Select.module.scss
@@ -193,7 +193,7 @@
 
 .root[data-type*="select-one"] {
   .button {
-    display: none; // remove this functionality for Single Select, unavailable via JS
+    display: none; /* remove this functionality for Single Select, unavailable via JS */
   }
 }
 
@@ -323,7 +323,8 @@
     font-size: $size-body-base;
     font-weight: 400;
     line-height: calc((#{$base-line-height} * 1em) - 2px);
-    // Adjust for pill border
+
+    /* Adjust for pill border */
     overflow-wrap: break-word;
     vertical-align: middle;
 

--- a/packages/odyssey-transform-styles-babel-plugin/package.json
+++ b/packages/odyssey-transform-styles-babel-plugin/package.json
@@ -11,20 +11,17 @@
   },
   "dependencies": {
     "@babel/types": "^7.15.6",
-    "@okta/odyssey": "^0.8.2",
-    "postcss-load-config": "^3.1.0",
-    "sass": "^1.42.1"
+    "postcss-load-config": "^3.1.0"
   },
   "devDependencies": {
     "@okta/odyssey-transform-styles-postcss-preset": "^0.8.2",
     "@okta/odyssey-typescript": "^0.8.2",
-    "@types/sass": "^1.16.1",
     "babel-jest": "^26.6.3",
     "jest": "^26.6.3",
     "postcss": "^8.3.6"
   },
   "peerDependencies": {
-    "@okta/odyssey-transform-styles-postcss-preset": "^0.0.0",
-    "postcss": "^8.3.6"
+    "@okta/odyssey-transform-styles-postcss-preset": ">= 0.8.2",
+    "postcss": ">= 8 <9"
   }
 }

--- a/packages/odyssey-transform-styles-babel-plugin/src/__tests__/__snapshots__/importVisitor.test.js.snap
+++ b/packages/odyssey-transform-styles-babel-plugin/src/__tests__/__snapshots__/importVisitor.test.js.snap
@@ -2,11 +2,11 @@
 
 exports[`transformStyles import visitor transforms styles as expected 1`] = `
 Object {
-  "__digest": "914958",
+  "__digest": "fdf87d",
   "__template": [Function],
   "autoprefixed": "ods-322606",
   "root": "ods-c0f206",
 }
 `;
 
-exports[`transformStyles import visitor transforms styles template as expected 1`] = `".ods-c0f206:dir(ltr){border-top-left-radius:4px}.ods-c0f206:dir(rtl){border-top-right-radius:4px}.ods-c0f206:dir(ltr){border-top-right-radius:4px}.ods-c0f206:dir(rtl){border-top-left-radius:4px}.ods-c0f206:dir(ltr){border-bottom-right-radius:4px}.ods-c0f206:dir(rtl){border-bottom-left-radius:4px}.ods-c0f206:dir(ltr){border-bottom-left-radius:4px}.ods-c0f206:dir(rtl){border-bottom-right-radius:4px}.ods-c0f206:dir(ltr){margin-left:0}.ods-c0f206:dir(rtl){margin-right:0}.ods-c0f206:dir(ltr){margin-right:.375rem}.ods-c0f206:dir(rtl){margin-left:.375rem}.ods-c0f206{background:#ebebed;color:#1d1d21;display:inline-block;margin-bottom:.375rem;margin-top:0;padding:0 .375em}@supports not (border-end-end-radius:1px){.ods-c0f206,[dir=rtl] .ods-c0f206{border-bottom-left-radius:4px;border-bottom-right-radius:4px;border-top-left-radius:4px;border-top-right-radius:4px}}.ods-322606 ::-moz-placeholder{color:#bada55}.ods-322606 :-ms-input-placeholder{color:#bada55}.ods-322606 ::placeholder{color:#bada55}"`;
+exports[`transformStyles import visitor transforms styles template as expected 1`] = `".ods-c0f206:dir(ltr){margin-left:0}.ods-c0f206:dir(rtl){margin-right:0}.ods-c0f206:dir(ltr){margin-right:.375rem}.ods-c0f206:dir(rtl){margin-left:.375rem}.ods-c0f206{background:#ebebed;color:#1d1d21;display:inline-block;margin-bottom:.375rem;margin-top:0;padding:0 .375em}.ods-322606{::-moz-placeholder{color:#bada55}:-ms-input-placeholder{color:#bada55}::placeholder{color:#bada55}}"`;

--- a/packages/odyssey-transform-styles-babel-plugin/src/__tests__/__snapshots__/requireVisitor.test.js.snap
+++ b/packages/odyssey-transform-styles-babel-plugin/src/__tests__/__snapshots__/requireVisitor.test.js.snap
@@ -2,11 +2,11 @@
 
 exports[`transformStyles require visitor transforms styles as expected 1`] = `
 Object {
-  "__digest": "914958",
+  "__digest": "fdf87d",
   "__template": [Function],
   "autoprefixed": "ods-322606",
   "root": "ods-c0f206",
 }
 `;
 
-exports[`transformStyles require visitor transforms styles template as expected 1`] = `".ods-c0f206:dir(ltr){border-top-left-radius:4px}.ods-c0f206:dir(rtl){border-top-right-radius:4px}.ods-c0f206:dir(ltr){border-top-right-radius:4px}.ods-c0f206:dir(rtl){border-top-left-radius:4px}.ods-c0f206:dir(ltr){border-bottom-right-radius:4px}.ods-c0f206:dir(rtl){border-bottom-left-radius:4px}.ods-c0f206:dir(ltr){border-bottom-left-radius:4px}.ods-c0f206:dir(rtl){border-bottom-right-radius:4px}.ods-c0f206:dir(ltr){margin-left:0}.ods-c0f206:dir(rtl){margin-right:0}.ods-c0f206:dir(ltr){margin-right:.375rem}.ods-c0f206:dir(rtl){margin-left:.375rem}.ods-c0f206{background:#ebebed;color:#1d1d21;display:inline-block;margin-bottom:.375rem;margin-top:0;padding:0 .375em}@supports not (border-end-end-radius:1px){.ods-c0f206,[dir=rtl] .ods-c0f206{border-bottom-left-radius:4px;border-bottom-right-radius:4px;border-top-left-radius:4px;border-top-right-radius:4px}}.ods-322606 ::-moz-placeholder{color:#bada55}.ods-322606 :-ms-input-placeholder{color:#bada55}.ods-322606 ::placeholder{color:#bada55}"`;
+exports[`transformStyles require visitor transforms styles template as expected 1`] = `".ods-c0f206:dir(ltr){margin-left:0}.ods-c0f206:dir(rtl){margin-right:0}.ods-c0f206:dir(ltr){margin-right:.375rem}.ods-c0f206:dir(rtl){margin-left:.375rem}.ods-c0f206{background:#ebebed;color:#1d1d21;display:inline-block;margin-bottom:.375rem;margin-top:0;padding:0 .375em}.ods-322606{::-moz-placeholder{color:#bada55}:-ms-input-placeholder{color:#bada55}::placeholder{color:#bada55}}"`;

--- a/packages/odyssey-transform-styles-babel-plugin/src/__tests__/fixture.module.scss
+++ b/packages/odyssey-transform-styles-babel-plugin/src/__tests__/fixture.module.scss
@@ -11,17 +11,15 @@
  */
 
 .root {
-  @include border-radius($base-border-radius);
-
   display: inline-block;
   margin-block-start: 0;
-  margin-block-end: $spacing-xs;
+  margin-block-end: 0.375rem;
   margin-inline-start: 0;
-  margin-inline-end: $spacing-xs;
+  margin-inline-end: 0.375rem;
   padding-block: 0;
-  padding-inline: $spacing-xs-em;
-  background: cv("gray", "100");
-  color: $text-body;
+  padding-inline: 0.375em;
+  background: #ebebed;
+  color: #1d1d21;
 }
 
 .autoprefixed {


### PR DESCRIPTION
The motivation here is to remove a dependency on sass in our shared tooling that will be distributed downstream to other teams in the future.