### PR TITLE
feat(odyssey-react): add Text component to Button

### DIFF
--- a/packages/odyssey-react/src/components/Button/Button.module.scss
+++ b/packages/odyssey-react/src/components/Button/Button.module.scss
@@ -101,7 +101,8 @@
   }
 }
 
-.dismissVariant {
+.dismissVariant,
+.dismissInvertedVariant {
   padding-block: ($spacing-xs-em * 0.5);
   padding-inline: ($spacing-xs-em * 0.5);
   border: 0;
@@ -128,6 +129,10 @@
     margin-block-end: -0.0625em;
     line-height: 0.9;
   }
+}
+
+.dismissInvertedVariant:focus {
+  box-shadow: 0 0 0 2px $white;
 }
 
 .clearVariant {

--- a/packages/odyssey-react/src/components/Button/Button.module.scss
+++ b/packages/odyssey-react/src/components/Button/Button.module.scss
@@ -25,12 +25,6 @@
   border: 1px solid transparent;
   background-color: $color-primary-base;
   box-shadow: 0 0 0 0 $color-primary-light;
-  color: $white;
-  font-family: $body-font-family;
-  font-size: ms(0);
-  font-weight: 600;
-  line-height: $base-line-height;
-  white-space: nowrap;
 
   &:hover {
     border-color: $color-primary-dark;
@@ -70,24 +64,20 @@
 .secondaryVariant {
   border-color: $color-primary-base;
   background-color: $white;
-  color: $color-primary-base;
 
   &:hover {
     border-color: $color-primary-base;
     background-color: $color-primary-base;
-    color: $white;
   }
 
   &:focus {
     border-color: $color-primary-base;
     background-color: $white;
-    color: $color-primary-base;
   }
 
   &:disabled {
     border-color: $color-primary-light;
     background-color: $white;
-    color: $color-primary-light;
   }
 }
 
@@ -116,7 +106,6 @@
   padding-inline: ($spacing-xs-em * 0.5);
   border: 0;
   background-color: transparent;
-  color: inherit;
   line-height: 1;
 
   &:hover {
@@ -131,7 +120,6 @@
 
   &:disabled {
     background-color: transparentize(cv("gray", "100"), 0.6);
-    color: cv("gray", "600");
   }
 
   .icon {
@@ -144,22 +132,18 @@
 
 .clearVariant {
   background-color: transparent;
-  color: $color-primary-base;
 
   &:hover {
     border-color: transparent;
     background-color: cv("blue", "000");
-    color: $color-primary-dark;
   }
 
   &:focus {
     background-color: $white;
-    color: $color-primary-base;
   }
 
   &:disabled {
     background-color: transparent;
-    color: $color-primary-light;
   }
 }
 

--- a/packages/odyssey-react/src/components/Button/Button.tsx
+++ b/packages/odyssey-react/src/components/Button/Button.tsx
@@ -19,7 +19,7 @@ import styles from "./Button.module.scss";
 interface CommonProps
   extends Omit<ComponentPropsWithRef<"button">, "style" | "className"> {
   /**
-   * Text content to be rendered within the button, usualy label text.
+   * Text content to be rendered within the button, usually label text.
    */
   children?: ReactText;
 
@@ -38,7 +38,13 @@ interface CommonProps
    * The visual variant to be displayed to the user.
    * @default primary
    */
-  variant?: "primary" | "secondary" | "danger" | "dismiss" | "clear";
+  variant?:
+    | "primary"
+    | "secondary"
+    | "danger"
+    | "dismiss"
+    | "dismissInverted"
+    | "clear";
 
   /**
    * Extends the width of the button to that of its' parent.
@@ -55,6 +61,40 @@ interface IconProps extends CommonProps {
 }
 
 export type ButtonProps = IconProps | ChildrenProps;
+
+function buildColors(variant: ButtonProps["variant"]) {
+  let textColor: TextProps["color"] = "bodyInverse";
+  let parentHoveredColor: TextProps["parentHoveredColor"] = "bodyInverse";
+  let parentFocusedColor: TextProps["parentFocusedColor"] = "bodyInverse";
+  let parentDisabledColor: TextProps["parentDisabledColor"] = "bodyInverse";
+
+  if (variant === "secondary" || variant === "clear") {
+    textColor = "primary";
+    parentFocusedColor = "primary";
+    parentDisabledColor = "primaryLight";
+  }
+
+  if (variant === "clear") {
+    parentHoveredColor = "primaryDark";
+  }
+
+  if (variant === "dismiss" || variant === "dismissInverted") {
+    parentDisabledColor = "sub";
+  }
+
+  if (variant === "dismiss") {
+    textColor = "body";
+    parentHoveredColor = "body";
+    parentFocusedColor = "body";
+  }
+
+  return {
+    textColor,
+    parentHoveredColor,
+    parentFocusedColor,
+    parentDisabledColor,
+  };
+}
 
 /**
  * A clickable button used for form submissions and most in-page interactions.
@@ -76,40 +116,25 @@ let Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
     wide && styles.wideLayout
   );
 
-  let textColor: TextProps["color"] = "bodyInverse";
-  let hoverColor: TextProps["hoverColor"] = "bodyInverse";
-  let focusColor: TextProps["focusColor"] = "bodyInverse";
-  let disabledColor: TextProps["disabledColor"] = "bodyInverse";
-
-  if (variant === "secondary" || variant === "clear") {
-    textColor = "primary";
-    focusColor = "primary";
-    disabledColor = "primaryLight";
-  }
-
-  if (variant === "clear") {
-    hoverColor = "primaryDark";
-  }
-
-  if (variant === "dismiss") {
-    textColor = "body";
-    hoverColor = "body";
-    focusColor = "body";
-    disabledColor = "sub";
-  }
-
+  const {
+    textColor,
+    parentHoveredColor,
+    parentFocusedColor,
+    parentDisabledColor,
+  } = buildColors(variant);
   const omitProps = useOmit(rest);
-
   return (
     <button {...omitProps} ref={ref} className={componentClass}>
       <Text
         color={textColor}
-        hoverColor={hoverColor}
-        focusColor={focusColor}
-        disabledColor={disabledColor}
+        parentHoveredColor={parentHoveredColor}
+        parentFocusedColor={parentFocusedColor}
+        parentDisabledColor={parentDisabledColor}
         weight="bold"
         wrap="nowrap"
         transition="inherit"
+        size={size === "s" ? "caption" : "base"}
+        lineHeight={size === "s" ? "title" : "normal"}
       >
         {icon && <span className={styles.icon}>{icon}</span>}
         {children && <span className={styles.label}>{children}</span>}

--- a/packages/odyssey-react/src/components/Button/Button.tsx
+++ b/packages/odyssey-react/src/components/Button/Button.tsx
@@ -12,6 +12,7 @@
 
 import React, { forwardRef } from "react";
 import type { ComponentPropsWithRef, ReactElement, ReactText } from "react";
+import { Text, TextProps } from "../Text";
 import { withStyles, useCx, useOmit } from "../../utils";
 import styles from "./Button.module.scss";
 
@@ -75,12 +76,44 @@ let Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
     wide && styles.wideLayout
   );
 
+  let textColor: TextProps["color"] = "bodyInverse";
+  let hoverColor: TextProps["hoverColor"] = "bodyInverse";
+  let focusColor: TextProps["focusColor"] = "bodyInverse";
+  let disabledColor: TextProps["disabledColor"] = "bodyInverse";
+
+  if (variant === "secondary" || variant === "clear") {
+    textColor = "primary";
+    focusColor = "primary";
+    disabledColor = "primaryLight";
+  }
+
+  if (variant === "clear") {
+    hoverColor = "primaryDark";
+  }
+
+  if (variant === "dismiss") {
+    textColor = "body";
+    hoverColor = "body";
+    focusColor = "body";
+    disabledColor = "sub";
+  }
+
   const omitProps = useOmit(rest);
 
   return (
     <button {...omitProps} ref={ref} className={componentClass}>
-      {icon && <span className={styles.icon}>{icon}</span>}
-      {children && <span className={styles.label}>{children}</span>}
+      <Text
+        color={textColor}
+        hoverColor={hoverColor}
+        focusColor={focusColor}
+        disabledColor={disabledColor}
+        weight="bold"
+        wrap="nowrap"
+        transition="inherit"
+      >
+        {icon && <span className={styles.icon}>{icon}</span>}
+        {children && <span className={styles.label}>{children}</span>}
+      </Text>
     </button>
   );
 });

--- a/packages/odyssey-react/src/components/Text/Text.module.scss
+++ b/packages/odyssey-react/src/components/Text/Text.module.scss
@@ -359,47 +359,49 @@
 }
 
 // Hover
-:hover > .bodyHoverColor,
+:hover > .bodyParentHoveredColor,
 .bodyHoverColor:hover {
   color: $text-body;
 }
-:hover > .bodyInverseHoverColor,
+
+:hover > .bodyInverseParentHoveredColor,
 .bodyInverseHoverColor:hover {
   color: $text-body-inverse;
 }
-:hover > .primaryDarkHoverColor,
+
+:hover > .primaryDarkParentHoveredColor,
 .primaryDarkHoverColor:hover {
   color: $color-primary-dark;
 }
 
 // Focus
-:focus > .bodyFocusColor,
+:focus > .bodyParentFocusedColor,
 .bodyFocusColor:focus {
   color: $text-body;
 }
 
-:focus > .bodyInverseFocusColor,
+:focus > .bodyInverseParentFocusedColor,
 .bodyInverseFocusColor:focus {
   color: $text-body-inverse;
 }
 
-:focus > .primaryFocusColor,
+:focus > .primaryParentFocusedColor,
 .primaryFocusColor:focus {
   color: $color-primary-base;
 }
 
 // Disabled
-:disabled > .bodyInverseDisabledColor,
+:disabled > .bodyInverseParentDisabledColor,
 .bodyInverseDisabledColor:disabled {
   color: $text-body-inverse;
 }
 
-:disabled > .primaryLightDisabledColor,
+:disabled > .primaryLightParentDisabledColor,
 .primaryLightDisabledColor:disabled {
   color: $color-primary-light;
 }
 
-:disabled > .subDisabledColor,
+:disabled > .subParentDisabledColor,
 .subDisabledColor:disabled {
   color: $text-sub;
 }

--- a/packages/odyssey-react/src/components/Text/Text.module.scss
+++ b/packages/odyssey-react/src/components/Text/Text.module.scss
@@ -268,6 +268,10 @@
   color: $text-danger-disabled;
 }
 
+.primaryColor {
+  color: $color-primary-base;
+}
+
 // Weight
 .boldWeight {
   font-weight: 600;
@@ -337,6 +341,10 @@
   overflow-wrap: anywhere;
 }
 
+.nowrapWrap {
+  white-space: nowrap;
+}
+
 // Line height
 .normalLineHeight {
   line-height: $base-line-height;
@@ -348,4 +356,55 @@
 
 .fontLineHeight {
   line-height: 1;
+}
+
+// Hover
+:hover > .bodyHoverColor,
+.bodyHoverColor:hover {
+  color: $text-body;
+}
+:hover > .bodyInverseHoverColor,
+.bodyInverseHoverColor:hover {
+  color: $text-body-inverse;
+}
+:hover > .primaryDarkHoverColor,
+.primaryDarkHoverColor:hover {
+  color: $color-primary-dark;
+}
+
+// Focus
+:focus > .bodyFocusColor,
+.bodyFocusColor:focus {
+  color: $text-body;
+}
+
+:focus > .bodyInverseFocusColor,
+.bodyInverseFocusColor:focus {
+  color: $text-body-inverse;
+}
+
+:focus > .primaryFocusColor,
+.primaryFocusColor:focus {
+  color: $color-primary-base;
+}
+
+// Disabled
+:disabled > .bodyInverseDisabledColor,
+.bodyInverseDisabledColor:disabled {
+  color: $text-body-inverse;
+}
+
+:disabled > .primaryLightDisabledColor,
+.primaryLightDisabledColor:disabled {
+  color: $color-primary-light;
+}
+
+:disabled > .subDisabledColor,
+.subDisabledColor:disabled {
+  color: $text-sub;
+}
+
+// Transition
+.inheritTransition {
+  transition: inherit;
 }

--- a/packages/odyssey-react/src/components/Text/Text.tsx
+++ b/packages/odyssey-react/src/components/Text/Text.tsx
@@ -112,14 +112,29 @@ export interface TextProps {
   hoverColor?: "body" | "bodyInverse" | "primaryDark";
 
   /**
-   * The text color style on hover.
+   * The text color style on focus.
    */
   focusColor?: "body" | "bodyInverse" | "primary";
 
   /**
-   * The text color style on hover.
+   * The text color style when disabled.
    */
   disabledColor?: "bodyInverse" | "primaryLight" | "sub";
+
+  /**
+   * The text color style when the parent element is hovered.
+   */
+  parentHoveredColor?: "body" | "bodyInverse" | "primaryDark";
+
+  /**
+   * The text color style when the parent element has focus.
+   */
+  parentFocusedColor?: "body" | "bodyInverse" | "primary";
+
+  /**
+   * The text color style when the parent element is disabled.
+   */
+  parentDisabledColor?: "bodyInverse" | "primaryLight" | "sub";
 
   /**
    * Transitions
@@ -144,6 +159,9 @@ let Text = forwardRef((props, ref) => {
     hoverColor,
     focusColor,
     disabledColor,
+    parentHoveredColor,
+    parentFocusedColor,
+    parentDisabledColor,
     transition,
     ...rest
   } = props;
@@ -163,9 +181,12 @@ let Text = forwardRef((props, ref) => {
     styles[hoverColor + "HoverColor"],
     styles[focusColor + "FocusColor"],
     styles[disabledColor + "DisabledColor"],
+    styles[parentHoveredColor + "ParentHoveredColor"],
+    styles[parentFocusedColor + "ParentFocusedColor"],
+    styles[parentDisabledColor + "ParentDisabledColor"],
     styles[transition + "Transition"]
   );
-
+  console.log(componentClass);
   const omitProps = useOmit(rest);
 
   return (

--- a/packages/odyssey-react/src/components/Text/Text.tsx
+++ b/packages/odyssey-react/src/components/Text/Text.tsx
@@ -55,7 +55,14 @@ export interface TextProps {
    * The text color style for the text content.
    * @default body
    */
-  color?: "body" | "bodyInverse" | "code" | "danger" | "dangerDisabled" | "sub";
+  color?:
+    | "body"
+    | "bodyInverse"
+    | "code"
+    | "danger"
+    | "dangerDisabled"
+    | "sub"
+    | "primary";
 
   /**
    * The font weight for the text content.
@@ -97,7 +104,27 @@ export interface TextProps {
    * The overflow wrapping behavior for the text content.
    * @default normal
    */
-  wrap?: "normal" | "breakWord" | "anywhere";
+  wrap?: "normal" | "breakWord" | "anywhere" | "nowrap";
+
+  /**
+   * The text color style on hover.
+   */
+  hoverColor?: "body" | "bodyInverse" | "primaryDark";
+
+  /**
+   * The text color style on hover.
+   */
+  focusColor?: "body" | "bodyInverse" | "primary";
+
+  /**
+   * The text color style on hover.
+   */
+  disabledColor?: "bodyInverse" | "primaryLight" | "sub";
+
+  /**
+   * Transitions
+   */
+  transition?: "inherit";
 }
 
 /**
@@ -114,6 +141,10 @@ let Text = forwardRef((props, ref) => {
     size = "base",
     wrap = "normal",
     lineHeight = "normal",
+    hoverColor,
+    focusColor,
+    disabledColor,
+    transition,
     ...rest
   } = props;
 
@@ -128,7 +159,11 @@ let Text = forwardRef((props, ref) => {
     styles[transform + "Transform"],
     styles[size + "Size"],
     styles[wrap + "Wrap"],
-    styles[lineHeight + "LineHeight"]
+    styles[lineHeight + "LineHeight"],
+    styles[hoverColor + "HoverColor"],
+    styles[focusColor + "FocusColor"],
+    styles[disabledColor + "DisabledColor"],
+    styles[transition + "Transition"]
   );
 
   const omitProps = useOmit(rest);

--- a/packages/odyssey-react/src/components/Text/Text.tsx
+++ b/packages/odyssey-react/src/components/Text/Text.tsx
@@ -186,7 +186,6 @@ let Text = forwardRef((props, ref) => {
     styles[parentDisabledColor + "ParentDisabledColor"],
     styles[transition + "Transition"]
   );
-  console.log(componentClass);
   const omitProps = useOmit(rest);
 
   return (

--- a/packages/odyssey-react/src/components/Toast/Toast.tsx
+++ b/packages/odyssey-react/src/components/Toast/Toast.tsx
@@ -142,7 +142,7 @@ let Toast = forwardRefWithStatics<HTMLElement, ToastProps, Statics>(
         {body && <p className={styles.body}>{body}</p>}
         <span className={styles.dismiss}>
           <Button
-            variant="dismiss"
+            variant={variant === "caution" ? "dismiss" : "dismissInverted"}
             onClick={onDismiss}
             icon={<CloseIcon title={dismissButtonLabel} />}
           />


### PR DESCRIPTION
 Removes dependency on global text styles.

The interactive states of button required the addition of Text styles to enable hover, focus, and disabled states. Having Text as a child of button also means that those style are currently enabled via descendant selectors.