### PR TITLE
build: use conventional commits for changelog and lint

### DIFF
--- a/packages/conventional-changelog-odyssey/index.js
+++ b/packages/conventional-changelog-odyssey/index.js
@@ -10,19 +10,9 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-const angular = require("conventional-changelog-angular");
+const conventional = require("conventional-changelog-conventionalcommits");
 
-module.exports = angular.then((config) => ({
-  ...config,
-  recommendedBumpOpts: {
-    ...config.recommendedBumpOpts,
-    whatBump(...args) {
-      const result = config.recommendedBumpOpts.whatBump(...args);
-      // NOTE: Our 0.x.x versioning scheme calls for new features to be
-      // patch level bumps. Once we reach 1.0.0 this package can be
-      // removed in favor of the using the angular defaults directly!
-      result.level = Math.min(result.level + 1, 2);
-      return result;
-    },
-  },
-}));
+// NOTE: Our 0.x.x (preMajor) versioning scheme calls for new features
+// to be patch level bumps. Once we reach 1.0.0 this package can be
+// removed in favor of the using the conventional defaults directly!
+module.exports = conventional({ preMajor: true });

--- a/packages/conventional-changelog-odyssey/package.json
+++ b/packages/conventional-changelog-odyssey/package.json
@@ -6,6 +6,6 @@
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
-    "conventional-changelog-angular": "^5.0.12"
+    "conventional-changelog-conventionalcommits": "^4.6.1"
   }
 }

--- a/packages/odyssey-commitlint/package.json
+++ b/packages/odyssey-commitlint/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@commitlint/cli": "^14.0.0",
-    "@commitlint/config-angular": "^14.0.0",
+    "@commitlint/config-conventional": "^14.0.0",
     "@commitlint/config-lerna-scopes": "^14.0.0",
     "husky": "^6.0.0"
   }

--- a/packages/odyssey-commitlint/src/index.js
+++ b/packages/odyssey-commitlint/src/index.js
@@ -11,5 +11,8 @@
  */
 
 module.exports = {
-  extends: ["@commitlint/config-lerna-scopes", "@commitlint/config-angular"],
+  extends: [
+    "@commitlint/config-lerna-scopes",
+    "@commitlint/config-conventional",
+  ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2612,17 +2612,12 @@
     resolve-global "1.0.0"
     yargs "^17.0.0"
 
-"@commitlint/config-angular-type-enum@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.npmjs.org/@commitlint/config-angular-type-enum/-/config-angular-type-enum-14.0.0.tgz#29f05fc212b4320e11b1a6bf538d68bba7178464"
-  integrity sha512-c4MX+h4+8TmqELehb6IJfGQ7v/Wp07OfJQpnSnUPksHskjCkojrVnX3JI9Z5BtK7KQHCzJlI6j1CcvehnLSzWw==
-
-"@commitlint/config-angular@^14.0.0":
+"@commitlint/config-conventional@^14.0.0":
   version "14.1.0"
-  resolved "https://registry.npmjs.org/@commitlint/config-angular/-/config-angular-14.1.0.tgz#0ddfb7c0eb83c44ef6f2c35b9444649eb639bd8a"
-  integrity sha512-LuI3W0uUR12LAqL9AEtbf+AfvkUzRkzkp/C1//Q7t0nC4+BXrN4MtF0V8B5VHeEqBdVqDzL1w0B1G446OrZmCA==
+  resolved "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-14.1.0.tgz#29e386ef200fa72d43418153ab1c490c89024dee"
+  integrity sha512-JuhCqkEv8jyqmd54EpXPsQFpYc/8k7sfP1UziRdEvZSJUCLxz+8Pk4cNS0oF1BtjaWO7ITgXPlIZg47PyApGmg==
   dependencies:
-    "@commitlint/config-angular-type-enum" "^14.0.0"
+    conventional-changelog-conventionalcommits "^4.3.1"
 
 "@commitlint/config-lerna-scopes@^14.0.0":
   version "14.0.0"
@@ -7678,6 +7673,15 @@ conventional-changelog-angular@^5.0.11, conventional-changelog-angular@^5.0.12:
   integrity sha512-5GLsbnkR/7A89RyHLvvoExbiGbd9xKdKqDTrArnPbOqBqG/2wIosu0fHwpeIRI8Tl94MhVNBXcLJZl92ZQ5USw==
   dependencies:
     compare-func "^2.0.0"
+    q "^1.5.1"
+
+conventional-changelog-conventionalcommits@^4.3.1, conventional-changelog-conventionalcommits@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.1.tgz#f4c0921937050674e578dc7875f908351ccf4014"
+  integrity sha512-lzWJpPZhbM1R0PIzkwzGBCnAkH5RKJzJfFQZcl/D+2lsJxAwGnDKBqn/F4C1RD31GJNn8NuKWQzAZDAVXPp2Mw==
+  dependencies:
+    compare-func "^2.0.0"
+    lodash "^4.17.15"
     q "^1.5.1"
 
 conventional-changelog-core@^4.2.2:


### PR DESCRIPTION
Moving us back to the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/#specification) after finding the concrete implementation I couldn't find last week 😅 