### PR TITLE
Text/Box Docs

### DIFF
--- a/packages/odyssey-storybook/.storybook/preview.js
+++ b/packages/odyssey-storybook/.storybook/preview.js
@@ -14,10 +14,10 @@ export const parameters = {
       method: "",
       order: [
         "Welcome",
+        ["Introduction (README)", "Docs Status"],
         "Contributing",
         "Guidelines",
         "Components",
-        "Utilities",
       ],
       locales: "",
     },

--- a/packages/odyssey-storybook/src/components/Box/Box.mdx
+++ b/packages/odyssey-storybook/src/components/Box/Box.mdx
@@ -1,0 +1,70 @@
+import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+
+# Box
+
+**WARNING: This utility component is not feature complete. Information here is currently intended for internal alignment. This page will be updated as the API and recommended use cases are solidified.**
+
+Box is a polymorphic component that acts as the root for most components.
+
+A simple `<Button>` component might look like this:
+
+```jsx
+<Box as="button" ref={ref} className={componentClass}>
+  {label}
+</Box>
+```
+
+[View the source on GitHub](https://github.com/okta/odyssey/tree/master/packages/odyssey-react/src/components/Box)
+
+## Props
+
+<ArgsTable />
+
+## Behavior
+
+Box uses an `as="abbr"` polymorphic API to ensure semantic elements can be used as necessary. This helps improve the quality of the resulting DOM output. This improves outcomes for accessibility, testing, use-ability, and long term maintenance.
+
+Box also provides a minimal set of styles for the component and its children. This allows Box to house design tokens for inheritable styles without the need for globally applied CSS.
+
+#### Inheritable styles
+
+Box includes these defaults:
+
+- `color: $text-body`
+- `font-family: $body-font-family`
+- `font-weight: 400`
+- `line-height: $base-line-height`
+
+Box includes these parent resets:
+
+- `border: 0`
+- `box-sizing: border-box`
+- `font-feature-settings: "lnum", "pnum"`
+- `font-size: 100%`
+- `font-style: normal`
+- `font: inherit`
+- `letter-spacing: 0`
+- `margin-block: 0`
+- `margin-inline: 0`
+- `padding-block: 0`
+- `padding-inline: 0`
+- `text-decoration-skip-ink: all`
+- `vertical-align: baseline`
+
+## Usage
+
+As noted above, Box is best used as the root element for other components. By utilizing the `as` prop, components will be rendered as the proper HTML element.
+
+In addition to the default styles provided, Box provides an API for styling of certain layout properties via utility classes. (e.g., `padding`, `margin`).
+
+Box also accepts a `className` prop for applying component-specific styling to the polymorphic root element it composes. This same element is also available as the `ref` prop. This prevents the need for Box to define every style for all use cases. This technique is best reserved for new, bespoke components. If additional variants for existing components are desired, please [make a request](https://github.com/okta/odyssey/issues/new/choose) against the component.
+
+## Accessibility
+
+By setting Box to the appropriate element, you help ensure a good foundation for accessibility. However, this may not cover all a11y concerns specific to your component or use case. Please reference individual components or our general guidelines for more information.
+
+## References
+
+### Related Components
+
+- [Text](?path=/docs/components-text-elements--span)

--- a/packages/odyssey-storybook/src/components/Box/Box.stories.tsx
+++ b/packages/odyssey-storybook/src/components/Box/Box.stories.tsx
@@ -15,9 +15,16 @@ import { Story } from "@storybook/react";
 import { Box as Source } from "../../../../odyssey-react/src";
 import { Box, BoxProps } from "@okta/odyssey-react";
 
+import BoxMdx from "./Box.mdx";
+
 export default {
   title: `Components/Box`,
   component: Source,
+  parameters: {
+    docs: {
+      page: BoxMdx,
+    },
+  },
 };
 
 const Template: Story<BoxProps> = (args) => <Box {...args}>Box</Box>;

--- a/packages/odyssey-storybook/src/components/ScreenReaderText/ScreenReaderText.stories.tsx
+++ b/packages/odyssey-storybook/src/components/ScreenReaderText/ScreenReaderText.stories.tsx
@@ -16,7 +16,7 @@ import { ScreenReaderText, ScreenReaderTextProps } from "@okta/odyssey-react";
 import { ScreenReaderText as Source } from "../../../../odyssey-react/src";
 
 export default {
-  title: `Utilities/ScreenReaderText`,
+  title: `Components/ScreenReaderText`,
   component: Source,
 };
 

--- a/packages/odyssey-storybook/src/components/Text/Text.mdx
+++ b/packages/odyssey-storybook/src/components/Text/Text.mdx
@@ -1,0 +1,237 @@
+import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+
+# Text
+
+Text is a bounded polymorphic component used to insert various styled HTML elements.
+
+[View source on GitHub](https://github.com/okta/odyssey/tree/master/packages/odyssey-react/src/components/Text)
+
+## Props
+
+<ArgsTable />
+
+## Variants
+
+### span (default)
+
+> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+
+<Canvas>
+  <Story id="components-text-elements--span" />
+</Canvas>
+
+### abbr
+
+> The HTML `<abbr>` element represents an abbreviation or acronym; the optional title attribute can provide an expansion or description for the abbreviation. If present, title must contain this full description and nothing else. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr)
+
+<Canvas>
+  <Story id="components-text-elements--abbr" />
+</Canvas>
+
+### address
+
+> The HTML `<address>` element indicates that the enclosed HTML provides contact information for a person or people, or for an organization. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address)",
+
+<Canvas>
+  <Story id="components-text-elements--address" />
+</Canvas>
+
+### blockquote
+
+> The `<blockquote>` HTML element indicates that the enclosed text is an extended quotation. Usually, this is rendered visually by indentation (see Notes for how to change it). A URL for the source of the quotation may be given using the cite attribute, while a text representation of the source can be given using the `<cite>` element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote)",
+
+<Canvas>
+  <Story id="components-text-elements--blockquote" />
+</Canvas>
+
+### cite
+
+> The HTML Citation element (`<cite>`) is used to describe a reference to a cited creative work, and must include the title of that work. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite)
+
+<Canvas>
+  <Story id="components-text-elements--cite" />
+</Canvas>
+
+### code
+
+> The `<code>` HTML element displays its contents styled in a fashion intended to indicate that the text is a short fragment of computer code. By default, the content text is displayed using the user agent's default monospace font. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code)
+
+<Canvas>
+  <Story id="components-text-elements--code" />
+</Canvas>
+
+### del
+
+> The `del` HTML element represents a range of text that has been deleted from a document. This can be used when rendering "track changes" or source code diff information, for example. The `ins` element can be used for the opposite purpose: to indicate text that has been added to the document. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del)
+
+#### Accessibility
+
+Many screen readers do not let users know of the presence of `del`. To fix this, you should consider using the ScreenReaderText component to prepend and append assistive text to the contents of the tag. In the above example, there are additional spaces before and after the text, this is intentional. Not adding these spaces will cause the content within the tag to run into the text within the tag.
+
+<Canvas>
+  <Story id="components-text-elements--del" />
+</Canvas>
+
+### dfn
+
+> The `dfn` is used to indicate the term being defined within the context of a definition phrase or sentence. The `p` element, the `dt`/`dd` pairing, or the `section` element which is the nearest ancestor of the `dfn` is considered to be the definition of the term. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Eldfnent/dfn)
+
+There are multiple, valid ways to use `dfn`. For the sake of usability, Odyssey recommends you follow one of two formats.
+
+For most terms, the content of `dfn` should be term you are defining.
+
+<Canvas>
+  <Story id="components-text-elements--dfn" />
+</Canvas>
+
+### span (default)
+
+> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+
+<Canvas>
+  <Story id="components-text-elements--span" />
+</Canvas>
+
+### span (default)
+
+> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+
+<Canvas>
+  <Story id="components-text-elements--span" />
+</Canvas>
+
+### span (default)
+
+> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+
+<Canvas>
+  <Story id="components-text-elements--span" />
+</Canvas>
+
+### span (default)
+
+> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+
+<Canvas>
+  <Story id="components-text-elements--span" />
+</Canvas>
+
+### span (default)
+
+> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+
+<Canvas>
+  <Story id="components-text-elements--span" />
+</Canvas>
+
+### span (default)
+
+> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+
+<Canvas>
+  <Story id="components-text-elements--span" />
+</Canvas>
+
+### span (default)
+
+> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+
+<Canvas>
+  <Story id="components-text-elements--span" />
+</Canvas>
+
+### span (default)
+
+> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+
+<Canvas>
+  <Story id="components-text-elements--span" />
+</Canvas>
+
+### span (default)
+
+> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+
+<Canvas>
+  <Story id="components-text-elements--span" />
+</Canvas>
+
+### span (default)
+
+> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+
+<Canvas>
+  <Story id="components-text-elements--span" />
+</Canvas>
+
+### span (default)
+
+> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+
+<Canvas>
+  <Story id="components-text-elements--span" />
+</Canvas>
+
+### span (default)
+
+> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+
+<Canvas>
+  <Story id="components-text-elements--span" />
+</Canvas>
+
+### span (default)
+
+> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+
+<Canvas>
+  <Story id="components-text-elements--span" />
+</Canvas>
+
+### span (default)
+
+> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+
+<Canvas>
+  <Story id="components-text-elements--span" />
+</Canvas>
+
+## Usage
+
+### Styled element insertion
+
+Text enables authors and components to insert styled HTML elements without the need for a global CSS sheet.
+
+```jsx
+<Text as="p">
+  We <Text as="em">really</Text> need to get off this planet.
+</Text>
+```
+
+A more complicated example might look like this:
+
+```jsx
+<Text as="blockquote">
+  <Text as="p">
+    The important thing is not to stop questioning. Curiosity has its own reason
+    for existence.
+  </Text>
+  <footer>
+    Albert Einstein,
+    <Text as="cite">
+      Old Man's Advice to Youth: "Never Lose a Holy Curiosity," LIFE magazine (2
+      May 1955) statement to William Miller, p. 64.
+    </Text>
+  </footer>
+</Text>
+```
+
+## Accessibility
+
+Please refer to individual variants above for their a11y concerns.
+
+## References
+
+### Related Components
+
+- [Box](?path=/docs/components-box--default)

--- a/packages/odyssey-storybook/src/components/Text/Text.mdx
+++ b/packages/odyssey-storybook/src/components/Text/Text.mdx
@@ -1,5 +1,7 @@
 import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
 
+import { Text } from "../../../../odyssey-react/src";
+
 # Text
 
 Text is a bounded polymorphic component used to insert various styled HTML elements.
@@ -84,116 +86,133 @@ For most terms, the content of `dfn` should be term you are defining.
   <Story id="components-text-elements--dfn" />
 </Canvas>
 
-### span (default)
-
-> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+If you're referencing an acronym or abbreviation, you may also combine it with `<abbr>`:
 
 <Canvas>
-  <Story id="components-text-elements--span" />
+  <Text as="p">
+    <Text as="dfn" id="def-apf">
+      <Text as="abbr" title="All Purpose Flour">
+        APF
+      </Text>
+    </Text>{" "}
+    is general-use, unbleached wheat flour.
+  </Text>
 </Canvas>
 
-### span (default)
+### em
 
-> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+> The `<em>` HTML element marks text that has stress emphasis. The `<em>` element can be nested, with each level of nesting indicating a greater degree of emphasis. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em)
 
 <Canvas>
-  <Story id="components-text-elements--span" />
+  <Story id="components-text-elements--em" />
 </Canvas>
 
-### span (default)
+### ins
 
-> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+> The HTML `<ins>` element represents a range of text that has been added to a document. You can use the `<del>` element to similarly represent a range of text that has been deleted from the document. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins)
+
+### Accessibility
+
+Many screen readers do not let users know of the presence of `ins`. To fix this, you should consider using the ScreenReaderText component, prepend and append assistive text to the contents of the tag. In the above example, there are additional spaces before and after the text, this is intentional. Not adding these spaces will cause the content within the tag to run into the text within the tag.
 
 <Canvas>
-  <Story id="components-text-elements--span" />
+  <Story id="components-text-elements--ins" />
 </Canvas>
 
-### span (default)
+### kbd
 
-> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+> The `<kbd>` HTML element represents a span of inline text denoting textual user input from a keyboard, voice input, or any other text entry device. By convention, the user agent defaults to rendering the contents of a `<kbd>` element using its default monospace font, although this is not mandated by the HTML standard. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd)
 
 <Canvas>
-  <Story id="components-text-elements--span" />
+  <Story id="components-text-elements--kbd" />
 </Canvas>
 
-### span (default)
+### mark
 
-> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+> The `<mark>` HTML element represents a span of inline text denoting textual user input from a keyboard, voice input, or any other text entry device. By convention, the user agent defaults to rendering the contents of a `<mark>` element using its default monospace font, although this is not mandated by the HTML standard. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark)
 
 <Canvas>
-  <Story id="components-text-elements--span" />
+  <Story id="components-text-elements--mark" />
 </Canvas>
 
-### span (default)
+### p
 
-> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+> The `<p>` HTML element represents a paragraph. Paragraphs are usually represented in visual media as blocks of text separated from adjacent blocks by blank lines and/or first-line indentation, but HTML paragraphs can be any structural grouping of related content, such as images or form fields. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p)",
 
 <Canvas>
-  <Story id="components-text-elements--span" />
+  <Story id="components-text-elements--p" />
 </Canvas>
 
-### span (default)
+### pre
 
-> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+> The `<pre>` HTML element represents preformatted text which is to be presented exactly as written in the HTML file. The text is typically rendered using a non-proportional, or "monospaced, font. Whitespace inside this element is displayed as written. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre)
 
 <Canvas>
-  <Story id="components-text-elements--span" />
+  <Story id="components-text-elements--pre" />
 </Canvas>
 
-### span (default)
+### q
 
-> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+> The HTML `<q>` element indicates that the enclosed text is a short inline quotation. Most modern browsers implement this by surrounding the text in quotation marks. This element is intended for short quotations that don't require paragraph breaks; for long quotations use the `<blockquote>` element - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q)
 
 <Canvas>
-  <Story id="components-text-elements--span" />
+  <Story id="components-text-elements--q" />
 </Canvas>
 
-### span (default)
+### s
 
-> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+> The HTML `<s>` element renders text with a strikethrough, or a line through it. Use the `<s>` element to represent things that are no longer relevant or no longer accurate. However, `<s>` is not appropriate when indicating document edits; for that, use the `<del>` and `<ins>` elements, as appropriate. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s)
 
 <Canvas>
-  <Story id="components-text-elements--span" />
+  <Story id="components-text-elements--s" />
 </Canvas>
 
-### span (default)
+### samp
 
-> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+> The HTML Sample Element (`<samp>`) is used to enclose inline text which represents sample (or quoted) output from a computer program. Its contents are typically rendered using the browser's default monospaced font (such as Courier or Lucida Console). - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp)
 
 <Canvas>
-  <Story id="components-text-elements--span" />
+  <Story id="components-text-elements--samp" />
 </Canvas>
 
-### span (default)
+### small
 
-> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+> The `<small>` HTML element represents side-comments and small print, like copyright and legal text, independent of its styled presentation. By default, it renders text within it one font-size smaller, such as from small to x-small. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small)
 
 <Canvas>
-  <Story id="components-text-elements--span" />
+  <Story id="components-text-elements--small" />
 </Canvas>
 
-### span (default)
+### strong
 
-> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+> The `<strong>` HTML element indicates that its contents have strong importance, seriousness, or urgency. Browsers typically render the contents in bold type. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong)
 
 <Canvas>
-  <Story id="components-text-elements--span" />
+  <Story id="components-text-elements--strong" />
 </Canvas>
 
-### span (default)
+### sub
 
-> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+> The `<sub>` HTML element specifies inline text which should be displayed as subscript for solely typographical reasons. Subscripts are typically rendered with a lowered baseline using smaller text. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub)",
 
 <Canvas>
-  <Story id="components-text-elements--span" />
+  <Story id="components-text-elements--sub" />
 </Canvas>
 
-### span (default)
+### sup
 
-> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+> The `<sup>` HTML element specifies inline text which is to be displayed as superscript for solely typographical reasons. Superscripts are usually rendered with a raised baseline using smaller text. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup)",
 
 <Canvas>
-  <Story id="components-text-elements--span" />
+  <Story id="components-text-elements--sup" />
+</Canvas>
+
+### var
+
+> The `<var>` HTML element represents the name of a variable in a mathematical expression or a programming context. It's typically presented using an italicized version of the current typeface, although that behavior is browser-dependent. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var)",
+
+<Canvas>
+  <Story id="components-text-elements--var" />
 </Canvas>
 
 ## Usage

--- a/packages/odyssey-storybook/src/components/Text/TextElements.stories.tsx
+++ b/packages/odyssey-storybook/src/components/Text/TextElements.stories.tsx
@@ -16,12 +16,19 @@ import { Text, Heading, Link, ScreenReaderText } from "@okta/odyssey-react";
 import type { TextProps } from "@okta/odyssey-react";
 import { Text as Source } from "../../../../odyssey-react/src";
 
+import TextMdx from "./Text.mdx";
+
 export default {
   title: `Components/Text/Elements`,
   component: Source,
   argTypes: {
     children: {
       control: { type: "string" },
+    },
+  },
+  parameters: {
+    docs: {
+      page: TextMdx,
     },
   },
 };
@@ -55,14 +62,14 @@ abbr.parameters = {
 abbr.args = {
   children: (
     <Text as="p">
-      If you are a
+      If you are a{" "}
       <Text as="abbr" title="Back-end">
         BE
-      </Text>
-      or
+      </Text>{" "}
+      or{" "}
       <Text as="abbr" title="Front-end">
         FE
-      </Text>
+      </Text>{" "}
       developer, you should checkout our dev docs.
     </Text>
   ),

--- a/packages/odyssey-storybook/src/components/Text/TextElements.stories.tsx
+++ b/packages/odyssey-storybook/src/components/Text/TextElements.stories.tsx
@@ -37,28 +37,12 @@ const Template: Story<TextProps> = (props) => <Text as="span" {...props} />;
 
 export const span = Template.bind({});
 span.storyName = "span (default)";
-span.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a `<div>` element, but `<div>` is a block-level element whereas a `<span>` is an inline element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)",
-    },
-  },
-};
 span.args = {
   children: "Text based content",
 };
 
 export const abbr = Template.bind({});
 abbr.storyName = "abbr";
-abbr.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The HTML `<abbr>` element represents an abbreviation or acronym; the optional title attribute can provide an expansion or description for the abbreviation. If present, title must contain this full description and nothing else. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr)",
-    },
-  },
-};
 abbr.args = {
   children: (
     <Text as="p">
@@ -78,14 +62,6 @@ abbr.args = {
 
 export const address = Template.bind({});
 address.storyName = "address";
-address.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The HTML `<address>` element indicates that the enclosed HTML provides contact information for a person or people, or for an organization. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address)",
-    },
-  },
-};
 address.args = {
   children: "address",
   as: "address",
@@ -93,14 +69,6 @@ address.args = {
 
 export const blockquote = Template.bind({});
 blockquote.storyName = "blockquote";
-blockquote.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The `<blockquote>` HTML element indicates that the enclosed text is an extended quotation. Usually, this is rendered visually by indentation (see Notes for how to change it). A URL for the source of the quotation may be given using the cite attribute, while a text representation of the source can be given using the `<cite>` element. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote)",
-    },
-  },
-};
 blockquote.args = {
   children: (
     <Text>
@@ -122,14 +90,6 @@ blockquote.args = {
 
 export const cite = Template.bind({});
 cite.storyName = "cite";
-cite.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The HTML Citation element (`<cite>`) is used to describe a reference to a cited creative work, and must include the title of that work. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite)",
-    },
-  },
-};
 cite.args = {
   children: (
     <Text as="blockquote">
@@ -152,14 +112,6 @@ cite.args = {
 
 export const code = Template.bind({});
 code.storyName = "code";
-code.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The `<code>` HTML element displays its contents styled in a fashion intended to indicate that the text is a short fragment of computer code. By default, the content text is displayed using the user agent's default monospace font. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code)",
-    },
-  },
-};
 code.args = {
   children: "console.log(`Hello world`);",
   as: "code",
@@ -167,21 +119,6 @@ code.args = {
 
 export const del = Template.bind({});
 del.storyName = "del";
-del.parameters = {
-  docs: {
-    description: {
-      story: `> The &lt;del&gt; HTML element represents a range of text that has been deleted from a document. This can be used when rendering "track changes"
-        or source code diff information, for example. The &lt;ins&gt; element can be used for the opposite purpose: to indicate text that has been added
-        to the document. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del)
-
-### Accessibility
-
-Many screen readers do not let users know of the presence of &lt;del&gt;. To fix this, you should consider using the ScreenReaderText component to
-prepend and append assistive text to the contents of the tag. In the above example, there are additional spaces before and after the text,
-this is intentional. Not adding these spaces will cause the content within the tag to run into the text within the tag.`,
-    },
-  },
-};
 del.args = {
   children: (
     <Text>
@@ -191,7 +128,7 @@ del.args = {
         nothing
         <ScreenReaderText>[deletion end]</ScreenReaderText>
       </Text>{" "}
-      <Text as="del">
+      <Text as="ins">
         <ScreenReaderText>[insertion start]</ScreenReaderText>
         no code <ScreenReaderText>[insertion start]</ScreenReaderText>
       </Text>{" "}
@@ -204,17 +141,6 @@ del.args = {
 /** @todo revisit this example, its a complex one */
 export const dfn = Template.bind({});
 dfn.storyName = "dfn";
-dfn.parameters = {
-  docs: {
-    description: {
-      story: `> The &lt;dfn&gt; is used to indicate the term being defined within the context of a definition phrase or sentence. The &lt;p&gt; element, the &lt;dt&gt;/&lt;dd&gt; pairing, or the &lt;section&gt; element which is the nearest ancestor of the &lt;dfn&gt; is considered to be the definition of the term. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Eldfnent/dfn)
-        There are multiple, valid ways to use &lt;dfn&gt;.
-
-For the sake of usability, Odyssey recommends you follow one of two formats.
-For most terms, the content of &lt;dfn&gt; should be term you are defining:`,
-    },
-  },
-};
 dfn.args = {
   children: (
     <Text as="p">
@@ -229,14 +155,6 @@ dfn.args = {
 
 export const em = Template.bind({});
 em.storyName = "em";
-em.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The `<em>` HTML element marks text that has stress emphasis. The `<em>` element can be nested, with each level of nesting indicating a greater degree of emphasis. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em)",
-    },
-  },
-};
 em.args = {
   children: "This text is emphasized",
   as: "em",
@@ -244,17 +162,6 @@ em.args = {
 
 export const ins = Template.bind({});
 ins.storyName = "ins";
-ins.parameters = {
-  docs: {
-    description: {
-      story: `> The HTML &lt;ins&gt; element represents a range of text that has been added to a document. You can use the <del> element to similarly represent a range of text that has been deleted from the document. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins)
-
-### Accessibility
-
-Many screen readers do not let users know of the presence of ins. To fix this, you should consider using the ScreenReaderText component, prepend and append assistive text to the contents of the tag. In the above example, there are additional spaces before and after the text, this is intentional. Not adding these spaces will cause the content within the tag to run into the text within the tag.`,
-    },
-  },
-};
 ins.args = {
   children: (
     <>
@@ -271,14 +178,6 @@ ins.args = {
 
 export const kbd = Template.bind({});
 kbd.storyName = "kbd";
-kbd.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The `<kbd>` HTML element represents a span of inline text denoting textual user input from a keyboard, voice input, or any other text entry device. By convention, the user agent defaults to rendering the contents of a <kbd> element using its default monospace font, although this is not mandated by the HTML standard. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd)",
-    },
-  },
-};
 kbd.args = {
   children: (
     <Text as="p">
@@ -290,14 +189,6 @@ kbd.args = {
 
 export const mark = Template.bind({});
 mark.storyName = "mark";
-mark.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The `<mark>` HTML element represents a span of inline text denoting textual user input from a keyboard, voice input, or any other text entry device. By convention, the user agent defaults to rendering the contents of a <mark> element using its default monospace font, although this is not mandated by the HTML standard. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark)",
-    },
-  },
-};
 mark.args = {
   children: (
     <Text>
@@ -319,14 +210,6 @@ mark.args = {
 
 export const p = Template.bind({});
 p.storyName = "p";
-p.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The `<p>` HTML element represents a paragraph. Paragraphs are usually represented in visual media as blocks of text separated from adjacent blocks by blank lines and/or first-line indentation, but HTML paragraphs can be any structural grouping of related content, such as images or form fields. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p)",
-    },
-  },
-};
 p.args = {
   children:
     "Odyssey is Okta’s official design system built for use across all Okta products and sites. We aim to enable designers and developers to build efficiently and consistently while optimizing for user experience and accessibility.",
@@ -335,14 +218,6 @@ p.args = {
 
 export const pre = Template.bind({});
 pre.storyName = "pre";
-pre.parameters = {
-  docs: {
-    description: {
-      story:
-        '> The `<pre>` HTML element represents preformatted text which is to be presented exactly as written in the HTML file. The text is typically rendered using a non-proportional, or "monospaced, font. Whitespace inside this element is displayed as written. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre)',
-    },
-  },
-};
 pre.args = {
   children: (
     <Text as="pre">
@@ -359,14 +234,6 @@ pre.args = {
 
 export const q = Template.bind({});
 q.storyName = "q";
-q.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The HTML `<q>` element indicates that the enclosed text is a short inline quotation. Most modern browsers implement this by surrounding the text in quotation marks. This element is intended for short quotations that don't require paragraph breaks; for long quotations use the <blockquote> element - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q)",
-    },
-  },
-};
 q.args = {
   children: (
     <Text as="p">
@@ -380,14 +247,6 @@ q.args = {
 
 export const s = Template.bind({});
 s.storyName = "s";
-s.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The HTML `<s>` element renders text with a strikethrough, or a line through it. Use the <s> element to represent things that are no longer relevant or no longer accurate. However, <s> is not appropriate when indicating document edits; for that, use the <del> and <ins> elements, as appropriate. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s)",
-    },
-  },
-};
 s.args = {
   children: (
     <>
@@ -407,14 +266,6 @@ s.args = {
 
 export const samp = Template.bind({});
 samp.storyName = "samp";
-samp.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The HTML Sample Element (`<samp>`) is used to enclose inline text which represents sample (or quoted) output from a computer program. Its contents are typically rendered using the browser's default monospaced font (such as Courier or Lucida Console). - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp)",
-    },
-  },
-};
 samp.args = {
   children: (
     <Text as="p">
@@ -428,14 +279,6 @@ samp.args = {
 
 export const small = Template.bind({});
 small.storyName = "small";
-small.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The `<small>` HTML element indicates that its contents have small importance, seriousness, or urgency. Browsers typically render the contents in bold type. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small)",
-    },
-  },
-};
 small.args = {
   children: <>&copy; 2020 Atko, Inc. All Rights Reserved.</>,
   as: "small",
@@ -443,14 +286,6 @@ small.args = {
 
 export const strong = Template.bind({});
 strong.storyName = "strong";
-strong.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The `<strong>` HTML element indicates that its contents have strong importance, seriousness, or urgency. Browsers typically render the contents in bold type. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong)",
-    },
-  },
-};
 strong.args = {
   children: (
     <Text as="p">
@@ -463,14 +298,6 @@ strong.args = {
 
 export const sub = Template.bind({});
 sub.storyName = "sub";
-sub.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The `<sub>` HTML element specifies inline text which should be displayed as subscript for solely typographical reasons. Subscripts are typically rendered with a lowered baseline using smaller text. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub)",
-    },
-  },
-};
 sub.args = {
   children: (
     <Text>
@@ -483,14 +310,6 @@ sub.args = {
 
 export const sup = Template.bind({});
 sup.storyName = "sup";
-sup.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The `<sup>` HTML element specifies inline text which is to be displayed as superscript for solely typographical reasons. Superscripts are usually rendered with a raised baseline using smaller text. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup)",
-    },
-  },
-};
 sup.args = {
   children: (
     <Text>
@@ -502,14 +321,6 @@ sup.args = {
 
 export const varElement = Template.bind({});
 varElement.storyName = "var";
-varElement.parameters = {
-  docs: {
-    description: {
-      story:
-        "> The `<var>` HTML element represents the name of a variable in a mathematical expression or a programming context. It's typically presented using an italicized version of the current typeface, although that behavior is browser-dependent. - [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var)",
-    },
-  },
-};
 varElement.args = {
   children: (
     <>


### PR DESCRIPTION
This PR adds baseline documentation for Text and Box. It also migrates our Text "descriptions" out of CSF and into MDX.

Prior conversation can be found here: https://github.com/okta/odyssey/pull/1188