### PR TITLE
Fix: Search/Select icon layering

### DIFF
--- a/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
@@ -42,7 +42,6 @@
   position: absolute;
   inset-block-start: 50%;
   inset-inline-start: $spacing-s;
-  z-index: 1;
   transform: translateY(-50%);
   font-size: ms(1);
   line-height: 1;

--- a/packages/odyssey-react/src/components/TextInput/index.tsx
+++ b/packages/odyssey-react/src/components/TextInput/index.tsx
@@ -160,10 +160,10 @@ let TextInput: FunctionComponent<Props> = (props) => {
 
   const search = (
     <span className={styles.outer}>
+      {input}
       <span className={styles.indicator} role="presentation">
         <SearchIcon />
       </span>
-      {input}
     </span>
   );
 

--- a/packages/odyssey-storybook/src/components/FieldGroup/FieldGroup.stories.tsx
+++ b/packages/odyssey-storybook/src/components/FieldGroup/FieldGroup.stories.tsx
@@ -15,8 +15,9 @@ import { Story } from "@storybook/react";
 import {
   FieldGroup,
   FieldGroupProps,
-  TextInput,
   Infobox,
+  Select,
+  TextInput,
 } from "@okta/odyssey-react";
 import { FieldGroup as Source } from "../../../../odyssey-react/src";
 
@@ -48,7 +49,12 @@ const Template: Story<FieldGroupProps> = ({ title, desc }) => (
         content="this is an error"
       />
     </FieldGroup.Error>
-    <TextInput label="Foo" hint="Bar" />
+    <Select label="Destination" name="destination">
+      <Select.Option children="Venus" />
+      <Select.Option children="Nessus" />
+      <Select.Option children="Europa" />
+    </Select>
+    <TextInput label="Flight identifier" type="search" />
   </FieldGroup>
 );
 


### PR DESCRIPTION
Fixes the layer height of our Search Icon to prevent it from leaking across layers. This also improves tab ordering for any outdated screen readers that ignore `presentation`.

![searchiconfix](https://user-images.githubusercontent.com/36284167/145878846-27fdb5cd-d3e0-4d02-9943-76fd59c68bb8.gif)
