### PR TITLE
Fix: Select blemishes

### DIFF
--- a/packages/odyssey-react/.postcssrc.js
+++ b/packages/odyssey-react/.postcssrc.js
@@ -32,10 +32,6 @@ module.exports = (ctx) => {
         grid: "autoplace",
         env: "production",
       },
-      modules: {
-        ...ctx.transformStyles.modules,
-        generateScopedName: "ods-[local]-[hash:hex:6]",
-      },
     }
   );
 

--- a/packages/odyssey-react/.postcssrc.js
+++ b/packages/odyssey-react/.postcssrc.js
@@ -32,6 +32,10 @@ module.exports = (ctx) => {
         grid: "autoplace",
         env: "production",
       },
+      modules: {
+        ...ctx.transformStyles.modules,
+        generateScopedName: "ods-[local]-[hash:hex:6]",
+      },
     }
   );
 

--- a/packages/odyssey-react/src/components/Select/Select.module.scss
+++ b/packages/odyssey-react/src/components/Select/Select.module.scss
@@ -252,7 +252,7 @@
   width: 100%;
   padding-block: $spacing-xs-em;
   padding-inline-start: $spacing-s-em;
-  padding-inline-end: $spacing-m-em;
+  padding-inline-end: $spacing-m-em + $spacing-xs-em;
   overflow: hidden;
   transition-property: border-color, background-color, box-shadow;
   transition-duration: $base-duration;

--- a/packages/odyssey-react/src/components/Select/Select.module.scss
+++ b/packages/odyssey-react/src/components/Select/Select.module.scss
@@ -208,15 +208,18 @@
     @include border-radius(100%);
 
     display: inline-block;
-    position: relative;
+    position: absolute;
+    inset-block-start: 50%;
+    inset-inline-end: $spacing-xs-em / 2;
     width: 1em;
     height: 1em;
     margin-block-start: 0;
     margin-inline-end: 0;
     margin-block-end: 0;
-    margin-inline-start: $spacing-s;
+    margin-inline-start: 0;
     padding-block: 0;
     padding-inline: 0;
+    transform: translateY(-50%);
     opacity: 1;
     background-color: cv("blue", "400");
     line-height: 1;
@@ -248,7 +251,8 @@
   display: inline-block;
   width: 100%;
   padding-block: $spacing-xs-em;
-  padding-inline: $spacing-s-em;
+  padding-inline-start: $spacing-s-em;
+  padding-inline-end: $spacing-m-em;
   overflow: hidden;
   transition-property: border-color, background-color, box-shadow;
   transition-duration: $base-duration;
@@ -313,6 +317,8 @@
     @include border-radius(1em);
 
     display: inline-block;
+    position: relative;
+    max-width: 100%;
     margin-inline-end: $spacing-xs;
     margin-block-end: $spacing-xs;
     padding-block: 0;
@@ -329,7 +335,7 @@
     vertical-align: middle;
 
     &[data-deletable] {
-      padding-inline-end: $spacing-xs;
+      padding-inline-end: $spacing-m-em + $spacing-xs-em;
     }
 
     [dir="rtl"] & {

--- a/packages/odyssey-storybook/src/components/Select/Select.stories.tsx
+++ b/packages/odyssey-storybook/src/components/Select/Select.stories.tsx
@@ -23,7 +23,7 @@ const options = [
   "Barnard's Star",
   "WISE 1049-5319",
   "Wolf 359",
-  "Lalande 21185",
+  "Lalande21185LagrangeAlpha1978Lalande21185LagrangeAlpha1978",
   "Sirius A",
   "Sirius B",
 ];


### PR DESCRIPTION
<img width="552" alt="Screen Shot 2021-12-15 at 2 12 26 PM" src="https://user-images.githubusercontent.com/36284167/146273165-c3022458-7f28-4aca-98ee-087e0be61fca.png">

- Absolutely positions "remove" buttons to ensure vertical alignment
- Remove button inline padding now matches block
- Sets a max-width on multi-select items to prevent overflow
- Increases dropdown indicator padding to prevent overlap