### PR TITLE
withTheme for Status

### DIFF
--- a/packages/odyssey-design-tokens/src/color/functional.json
+++ b/packages/odyssey-design-tokens/src/color/functional.json
@@ -10,6 +10,15 @@
       "base": { "value": "{color.palette.red.500.value}" },
       "dark": { "value": "{color.palette.red.900.value}" }
     },
+    "caution": {
+      "base": { "value": "{color.palette.yellow.500.value}" }
+    },
+    "success": {
+      "base": { "value": "{color.palette.green.500.value}" }
+    },
+    "neutral": {
+      "base": { "value": "{color.palette.neutral.600.value}" }
+    },
     "text": {
       "body": {
         "comment": "Base text color used for most typography",

--- a/packages/odyssey-design-tokens/src/font.json
+++ b/packages/odyssey-design-tokens/src/font.json
@@ -26,6 +26,9 @@
         "level-5": { "value": "" },
         "level-6": { "value": "" }
       }
+    },
+    "weight": {
+      "bold": { "value": "600" }
     }
   }
 }

--- a/packages/odyssey-design-tokens/src/space.json
+++ b/packages/odyssey-design-tokens/src/space.json
@@ -1,13 +1,13 @@
 {
   "space": {
-    "fixed" : {
+    "fixed": {
       "xs": { "value": "0.375rem" },
       "s": { "value": "0.75rem" },
       "m": { "value": "1.5rem" },
       "l": { "value": "3rem" },
       "xl": { "value": "6rem" }
     },
-    "relative" : {
+    "relative": {
       "xs": { "value": "0.375em" },
       "s": { "value": "0.75em" },
       "m": { "value": "1.5em" },

--- a/packages/odyssey-design-tokens/src/space.json
+++ b/packages/odyssey-design-tokens/src/space.json
@@ -1,9 +1,18 @@
 {
   "space": {
-    "xs": { "value": "0.375rem" },
-    "s": { "value": "0.75rem" },
-    "m": { "value": "1.5rem" },
-    "l": { "value": "3rem" },
-    "xl": { "value": "6rem" }
+    "fixed" : {
+      "xs": { "value": "0.375rem" },
+      "s": { "value": "0.75rem" },
+      "m": { "value": "1.5rem" },
+      "l": { "value": "3rem" },
+      "xl": { "value": "6rem" }
+    },
+    "relative" : {
+      "xs": { "value": "0.375em" },
+      "s": { "value": "0.75em" },
+      "m": { "value": "1.5em" },
+      "l": { "value": "3em" },
+      "xl": { "value": "6em" }
+    }
   }
 }

--- a/packages/odyssey-design-tokens/src/space.json
+++ b/packages/odyssey-design-tokens/src/space.json
@@ -1,9 +1,9 @@
 {
   "space": {
-    "m": "",
-    "l": "",
-    "xl": "",
-    "s": "",
-    "xs": ""
+    "xs": { "value": "0.375rem" },
+    "s": { "value": "0.75rem" },
+    "m": { "value": "1.5rem" },
+    "l": { "value": "3rem" },
+    "xl": { "value": "6rem" }
   }
 }

--- a/packages/odyssey-react/src/components/Status/Status.module.scss
+++ b/packages/odyssey-react/src/components/Status/Status.module.scss
@@ -34,7 +34,7 @@ $status-indicator-size: 1em * 0.5;
     height: $status-indicator-size;
     margin-inline-end: $spacing-xs;
     transform: translateY(-50%);
-    background-color: cv("gray", "600");
+    background-color: var(--ColorIndicatorNeutral);
   }
 }
 
@@ -42,18 +42,18 @@ $status-indicator-size: 1em * 0.5;
 
 .successVariant {
   &::before {
-    background-color: $color-success-base;
+    background-color: var(--ColorIndicatorSuccess);
   }
 }
 
 .cautionVariant {
   &::before {
-    background-color: $color-caution-base;
+    background-color: var(--ColorIndicatorCaution);
   }
 }
 
 .dangerVariant {
   &::before {
-    background-color: $color-danger-base;
+    background-color: var(--ColorIndicatorDanger);
   }
 }

--- a/packages/odyssey-react/src/components/Status/Status.module.scss
+++ b/packages/odyssey-react/src/components/Status/Status.module.scss
@@ -11,21 +11,21 @@
  */
 
 $status-indicator-size: 1em * 0.5;
+$status-border-radius: 1em;
 
 .label {
   display: block;
   margin-block-end: var(--SpaceFixedXs);
-  font-weight: 600;
+  font-weight: var(--FontWeightBold);
 }
 
 .value {
   position: relative;
-  // padding-inline-start: calc(#{$status-indicator-size + var(--SpaceRelativeXs));
   padding-inline-start: $status-indicator-size + $spacing-xs-em;
   background-color: transparent;
 
   &::before {
-    @include border-radius(1em);
+    @include border-radius($status-border-radius);
 
     content: "";
     position: absolute;

--- a/packages/odyssey-react/src/components/Status/Status.module.scss
+++ b/packages/odyssey-react/src/components/Status/Status.module.scss
@@ -20,6 +20,7 @@ $status-indicator-size: 1em * 0.5;
 
 .value {
   position: relative;
+  // padding-inline-start: calc(#{$status-indicator-size + var(--SpaceRelativeXs));
   padding-inline-start: $status-indicator-size + $spacing-xs-em;
   background-color: transparent;
 

--- a/packages/odyssey-react/src/components/Status/Status.module.scss
+++ b/packages/odyssey-react/src/components/Status/Status.module.scss
@@ -10,17 +10,17 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-$status-indicator-size: 1em * 0.5;
+$status-indicator-size: 1rem * 0.5;
 
 .label {
   display: block;
-  margin-block-end: $spacing-xs;
+  margin-block-end: calc(var(--SpaceXs));
   font-weight: 600;
 }
 
 .value {
   position: relative;
-  padding-inline-start: $status-indicator-size + $spacing-xs-em;
+  padding-inline-start: $status-indicator-size + $spacing-xs;
   background-color: transparent;
 
   &::before {
@@ -32,7 +32,7 @@ $status-indicator-size: 1em * 0.5;
     inset-inline-start: 0;
     width: $status-indicator-size;
     height: $status-indicator-size;
-    margin-inline-end: $spacing-xs;
+    margin-inline-end: var(--SpaceXs);
     transform: translateY(-50%);
     background-color: var(--ColorIndicatorNeutral);
   }

--- a/packages/odyssey-react/src/components/Status/Status.module.scss
+++ b/packages/odyssey-react/src/components/Status/Status.module.scss
@@ -10,17 +10,17 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-$status-indicator-size: 1rem * 0.5;
+$status-indicator-size: 1em * 0.5;
 
 .label {
   display: block;
-  margin-block-end: calc(var(--SpaceXs));
+  margin-block-end: var(--SpaceFixedXs);
   font-weight: 600;
 }
 
 .value {
   position: relative;
-  padding-inline-start: $status-indicator-size + $spacing-xs;
+  padding-inline-start: $status-indicator-size + $spacing-xs-em;
   background-color: transparent;
 
   &::before {
@@ -32,7 +32,7 @@ $status-indicator-size: 1rem * 0.5;
     inset-inline-start: 0;
     width: $status-indicator-size;
     height: $status-indicator-size;
-    margin-inline-end: var(--SpaceXs);
+    margin-inline-end: var(--SpaceFixedXs);
     transform: translateY(-50%);
     background-color: var(--ColorIndicatorNeutral);
   }

--- a/packages/odyssey-react/src/components/Status/Status.theme.ts
+++ b/packages/odyssey-react/src/components/Status/Status.theme.ts
@@ -14,7 +14,8 @@ import type { ThemeReducer } from "@okta/odyssey-react-theme";
 
 export const theme: ThemeReducer = (theme) => ({
   // Space
-  SpaceXs: theme.SpaceXs,
+  SpaceFixedXs: theme.SpaceFixedXs,
+  SpaceRelativeXs: theme.SpaceRelativeXs,
 
   // Caution Variant
   ColorIndicatorCaution: theme.ColorCautionBase,

--- a/packages/odyssey-react/src/components/Status/Status.theme.ts
+++ b/packages/odyssey-react/src/components/Status/Status.theme.ts
@@ -1,0 +1,27 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import type { ThemeReducer } from "@okta/odyssey-react-theme";
+
+export const theme: ThemeReducer = (theme) => ({
+  // Caution Variant
+  ColorIndicatorCaution: theme.ColorCautionBase,
+
+  // Danger Variant
+  ColorIndicatorDanger: theme.ColorDangerBase,
+
+  // Neutral Variant
+  ColorIndicatorNeutral: theme.ColorNeutralBase,
+
+  // Success Variant
+  ColorIndicatorSuccess: theme.ColorSuccessBase,
+});

--- a/packages/odyssey-react/src/components/Status/Status.theme.ts
+++ b/packages/odyssey-react/src/components/Status/Status.theme.ts
@@ -13,6 +13,9 @@
 import type { ThemeReducer } from "@okta/odyssey-react-theme";
 
 export const theme: ThemeReducer = (theme) => ({
+  // Type
+  FontWeightBold: theme.FontWeightBold,
+
   // Space
   SpaceFixedXs: theme.SpaceFixedXs,
   SpaceRelativeXs: theme.SpaceRelativeXs,

--- a/packages/odyssey-react/src/components/Status/Status.theme.ts
+++ b/packages/odyssey-react/src/components/Status/Status.theme.ts
@@ -13,6 +13,9 @@
 import type { ThemeReducer } from "@okta/odyssey-react-theme";
 
 export const theme: ThemeReducer = (theme) => ({
+  // Space
+  SpaceXs: theme.SpaceXs,
+
   // Caution Variant
   ColorIndicatorCaution: theme.ColorCautionBase,
 

--- a/packages/odyssey-react/src/components/Status/Status.tsx
+++ b/packages/odyssey-react/src/components/Status/Status.tsx
@@ -17,6 +17,7 @@ import { useCx, useOmit } from "../../utils";
 import { ScreenReaderText } from "../ScreenReaderText";
 import { Box } from "../Box";
 import styles from "./Status.module.scss";
+import { theme } from "./Status.theme";
 
 export interface StatusProps
   extends Omit<ComponentPropsWithRef<"div">, "style" | "className" | "role"> {
@@ -48,7 +49,7 @@ export interface StatusProps
  * operational states as well as granular states like user status.
  */
 export const Status = withTheme(
-  () => ({}),
+  theme,
   styles
 )(
   forwardRef<HTMLDivElement, StatusProps>((props, ref) => {


### PR DESCRIPTION
Updates Status to use design tokens.

Creates new tokens for:
- Color: Caution, Success, and Neutral bases
- Spacing: relative and fixed units (these are hard coded and not generated)
- Font: bold weight

Two types of values have not been converted:

- Private, component-specific variables that need not be themed (yet)
- Values that rely on `calc()`