### PR TITLE
theme cleanup

### DIFF
--- a/packages/odyssey-postcss-theme/src/plugin.test.js
+++ b/packages/odyssey-postcss-theme/src/plugin.test.js
@@ -22,13 +22,13 @@ async function run(input, output) {
 it("transforms css custom properties", async () => {
   await run(
     "a { color: var(--linkColor); }",
-    "a { color: ${theme.linkColor || 'inherit'}; }"
+    "a { color: ${theme.linkColor}; }"
   );
 });
 
 it("transforms css custom properties within shorthand syntax", async () => {
   await run(
     "a { margin: var(--linkMarginTop) 2rem var(--linkMarginBottom) 1rem; }",
-    "a { margin: ${theme.linkMarginTop || 'inherit'} 2rem ${theme.linkMarginBottom || 'inherit'} 1rem; }"
+    "a { margin: ${theme.linkMarginTop} 2rem ${theme.linkMarginBottom} 1rem; }"
   );
 });

--- a/packages/odyssey-react-theme/src/withTheme/utils.ts
+++ b/packages/odyssey-react-theme/src/withTheme/utils.ts
@@ -10,20 +10,10 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import type { PluginCreator } from "postcss";
-
-const customPropRegex = /var\(--([A-z][\w-]*)\)/g;
-
-const plugin: PluginCreator<never> = () => ({
-  postcssPlugin: "odyssey-postcss-theme",
-  Declaration: (decl) => {
-    const replaced = decl.value.replace(
-      customPropRegex,
-      (_, capture) => `\$\{theme.${capture}\}`
-    );
-    decl.value = replaced;
-  },
-});
-
-plugin.postcss = true;
-export { plugin as default };
+export const supportsCustomProperties: boolean = (() => {
+  try {
+    return window.CSS.supports("--custom: properties");
+  } catch (_) {
+    return false;
+  }
+})();


### PR DESCRIPTION
* use fallback values directly for browser that do not support custom properties i.e. IE11
* refactor `WithTheme` implementation for better type safety and clarity
* pass shallow copy of theme to reducer to avoid accidental mutation of context value/props
* throw when invalid theme value is referenced in style module to avoid typo errors (no type safety in CSS afterall)