### PR TITLE
chore(odyssey-postcss-theme): replace values in OnceExit event

### DIFF
--- a/packages/odyssey-postcss-scss/package.json
+++ b/packages/odyssey-postcss-scss/package.json
@@ -6,14 +6,17 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "prepare": "tsc"
+    "prepare": "tsc",
+    "test": "jest"
   },
   "dependencies": {
     "sass": "^1.42.1"
   },
   "devDependencies": {
     "@okta/odyssey-typescript": "^0.8.4",
-    "@types/sass": "^1.16.1"
+    "@types/sass": "^1.16.1",
+    "jest": "^26.6.3",
+    "postcss": "^8.3.6"
   },
   "peerDependencies": {
     "postcss": "^8.3.6"

--- a/packages/odyssey-postcss-scss/src/plugin.test.js
+++ b/packages/odyssey-postcss-scss/src/plugin.test.js
@@ -1,0 +1,30 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+const postcss = require("postcss");
+const { default: plugin } = require("../dist");
+
+async function run(input, output, importData = "") {
+  const result = await postcss([plugin({ importData })]).process(input, {
+    from: undefined,
+  });
+  expect(result.css).toEqual(output);
+  expect(result.warnings()).toHaveLength(0);
+}
+
+it("transforms scss", async () => {
+  await run("$color: red; a { color: $color }", "a {\n  color: red;\n}");
+});
+
+it("transforms scss with importData", async () => {
+  await run("a { color: $color }", "a {\n  color: red;\n}", "$color: red;");
+});

--- a/packages/odyssey-postcss-theme/src/plugin.ts
+++ b/packages/odyssey-postcss-theme/src/plugin.ts
@@ -16,12 +16,13 @@ const customPropRegex = /var\(--([A-z][\w-]*)\)/g;
 
 const plugin: PluginCreator<never> = () => ({
   postcssPlugin: "odyssey-postcss-theme",
-  Declaration: (decl) => {
-    const replaced = decl.value.replace(
-      customPropRegex,
-      (_, capture) => `\$\{theme.${capture}\}`
-    );
-    decl.value = replaced;
+  OnceExit(root) {
+    root.walkDecls((decl) => {
+      decl.value = decl.value.replace(
+        customPropRegex,
+        (_, capture) => `\$\{theme.${capture}\}`
+      );
+    });
   },
 });
 

--- a/packages/odyssey-react/src/components/Status/Status.module.scss
+++ b/packages/odyssey-react/src/components/Status/Status.module.scss
@@ -21,7 +21,9 @@ $status-border-radius: 1em;
 
 .value {
   position: relative;
-  padding-inline-start: $status-indicator-size + $spacing-xs-em;
+  padding-inline-start: calc(
+    #{$status-indicator-size} + var(--SpaceRelativeXs)
+  );
   background-color: transparent;
 
   &::before {

--- a/packages/odyssey-transform-styles-postcss-preset/package.json
+++ b/packages/odyssey-transform-styles-postcss-preset/package.json
@@ -6,7 +6,8 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "prepare": "tsc"
+    "prepare": "tsc",
+    "test": "jest"
   },
   "dependencies": {
     "@okta/odyssey-postcss-theme": "^0.0.0",
@@ -18,6 +19,7 @@
   "devDependencies": {
     "@okta/odyssey-typescript": "^0.8.4",
     "@types/cssnano": "^4.0.1",
+    "jest": "^26.6.3",
     "postcss": "^8.3.6"
   },
   "peerDependencies": {

--- a/packages/odyssey-transform-styles-postcss-preset/src/plugin.test.js
+++ b/packages/odyssey-transform-styles-postcss-preset/src/plugin.test.js
@@ -1,0 +1,43 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+const postcss = require("postcss");
+const { default: plugin } = require("../dist");
+
+async function run(
+  input,
+  output,
+  opts = { modules: { getJSON: Function.prototype } }
+) {
+  const result = await postcss([plugin(opts)]).process(input, {
+    from: undefined,
+  });
+  expect(result.css).toEqual(output);
+  expect(result.warnings()).toHaveLength(0);
+}
+
+it("minimizes non meaningful whitespace", async () => {
+  await run("a {\n    margin: 1px;\n}", "a{margin:1px}");
+});
+
+describe("calc", () => {
+  it("transforms css custom properties to theme expressions", async () => {
+    await run(
+      "a { margin: calc(1px + var(--space)); }",
+      "a{margin:calc(1px + ${theme.space})}"
+    );
+  });
+
+  it("reduces expressions when possible", async () => {
+    await run("a { margin: calc(1px + 1px); }", "a{margin:2px}");
+  });
+});


### PR DESCRIPTION
This PR does the following:

* Allow `calc()` expressions to be used with custom properties in our build toolchain
  * [OKTA-455370](https://oktainc.atlassian.net/browse/OKTA-455370)
* Improve unit test coverage for build tooling packages