### PR TITLE
build: add no-extraneous-dependencies rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,4 +10,5 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+// eslint-disable-next-line import/no-extraneous-dependencies
 module.exports = require("@okta/odyssey-eslint");

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -10,4 +10,5 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+// eslint-disable-next-line import/no-extraneous-dependencies
 module.exports = require("@okta/odyssey-commitlint");

--- a/packages/odyssey-eslint/package.json
+++ b/packages/odyssey-eslint/package.json
@@ -11,7 +11,7 @@
     "eslint": "^7.27.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-header": "^3.1.1",
-    "eslint-plugin-import": "^2.25.2",
+    "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react-hooks": "^4.2.0"
   }

--- a/packages/odyssey-eslint/src/index.js
+++ b/packages/odyssey-eslint/src/index.js
@@ -24,13 +24,25 @@ module.exports = {
     sourceType: "module",
   },
   ignorePatterns: ["node_modules", "dist"],
-  plugins: ["header"],
+  plugins: ["header", "import"],
   rules: {
     "header/header": [
       "error",
       "block",
       ["!", { pattern, template }, ...header.split("\n")],
       2,
+    ],
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        devDependencies: [
+          "**/*.stories.*",
+          "**/*.docgen.*",
+          "**/jest.setup.js",
+          "**/*.test.*",
+          "**/scripts/*",
+        ],
+      },
     ],
   },
   overrides: [

--- a/packages/odyssey-react-theme/package.json
+++ b/packages/odyssey-react-theme/package.json
@@ -16,7 +16,7 @@
     "hoist-non-react-statics": "^3.3.2"
   },
   "devDependencies": {
-    "@babel/cli": "*",
+    "@babel/cli": "^7.14.8",
     "@okta/browserslist-config-odyssey": "^0.8.4",
     "@okta/odyssey-babel-preset": "^0.8.4",
     "@okta/odyssey-eslint": "^0.8.4",
@@ -29,7 +29,8 @@
     "babel-jest": "^26.6.3",
     "jest": "^26.6.3",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "regenerator-runtime": "^0.13.7"
   },
   "peerDependencies": {
     "react": ">=16 <18",

--- a/packages/odyssey-react/package.json
+++ b/packages/odyssey-react/package.json
@@ -16,7 +16,7 @@
     "choices.js": "^9.0.1"
   },
   "devDependencies": {
-    "@babel/cli": "*",
+    "@babel/cli": "^7.14.8",
     "@okta/browserslist-config-odyssey": "^0.8.4",
     "@okta/odyssey-babel-preset": "^0.8.4",
     "@okta/odyssey-eslint": "^0.8.4",
@@ -34,10 +34,15 @@
     "@types/react": "^17.0.30",
     "@types/react-dom": "^17.0.5",
     "babel-jest": "^26.6.3",
+    "chokidar": "^3.4.0",
     "jest": "^26.6.3",
     "jest-axe": "^5.0.1",
+    "postcss": "^8.3.6",
+    "postcss-load-config": "^3.1.0",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "regenerator-runtime": "^0.13.7",
+    "sass": "^1.42.1"
   },
   "peerDependencies": {
     "react": ">=16 <18",

--- a/packages/odyssey-storybook/package.json
+++ b/packages/odyssey-storybook/package.json
@@ -13,6 +13,7 @@
     "@applitools/eyes-storybook": "^3.24.0",
     "@okta/odyssey-design-tokens": "^0.8.4",
     "@okta/odyssey-react": "^0.8.4",
+    "@okta/odyssey-react-theme": "^0.0.0",
     "@okta/odyssey-typescript": "^0.8.4",
     "@pxblue/storybook-rtl-addon": "^1.0.1",
     "@storybook/addon-a11y": "^6.3.7",
@@ -21,10 +22,13 @@
     "@storybook/addon-links": "^6.3.7",
     "@storybook/addon-postcss": "^2.0.0",
     "@storybook/addons": "^6.3.12",
+    "@storybook/client-api": "^6.3.7",
     "@storybook/react": "^6.3.7",
     "@storybook/theming": "^6.3.12",
     "@types/mdx": "^2.0.1",
-    "@types/react": "^17.0.30"
+    "@types/react": "^17.0.30",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "scripts": {
     "start": "start-storybook --quiet --port 6006",

--- a/packages/odyssey-transform-styles-babel-plugin/package.json
+++ b/packages/odyssey-transform-styles-babel-plugin/package.json
@@ -10,7 +10,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@babel/types": "^7.15.6",
+    "@babel/types": "^7.14.5",
+    "@babel/template": "^7.12.13",
     "postcss-load-config": "^3.1.0"
   },
   "devDependencies": {

--- a/packages/odyssey-transform-styles-babel-plugin/src/transformStyles.ts
+++ b/packages/odyssey-transform-styles-babel-plugin/src/transformStyles.ts
@@ -11,11 +11,6 @@
  */
 
 import type * as Babel from "@babel/core";
-import type {
-  VariableDeclaration,
-  ObjectExpression,
-  NewExpression,
-} from "@babel/traverse/node_modules/@babel/types";
 import type { File } from "./compile";
 import { resolve, dirname } from "path";
 import compileFactory from "./compileFactory";
@@ -67,7 +62,7 @@ export default function transformStyles({
           path.replaceWith(
             identityObjectProxyVariableDeclaration({
               name: specifier.local.name,
-            }) as VariableDeclaration
+            })
           );
 
           return;
@@ -85,7 +80,7 @@ export default function transformStyles({
           variableDeclaration({
             name: specifier.local.name,
             ...file,
-          }) as VariableDeclaration
+          })
         );
       },
 
@@ -118,7 +113,7 @@ export default function transformStyles({
         }
 
         if (opts.identityObjectProxy) {
-          path.replaceWith(identityObjectProxy() as NewExpression);
+          path.replaceWith(identityObjectProxy());
 
           return;
         }
@@ -131,7 +126,7 @@ export default function transformStyles({
           fileMap.set(filePath, file);
         }
 
-        path.replaceWith(tokenObjectExpression(file) as ObjectExpression);
+        path.replaceWith(tokenObjectExpression(file));
       },
     },
   };

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -10,4 +10,5 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+// eslint-disable-next-line import/no-extraneous-dependencies
 module.exports = require("@okta/odyssey-stylelint");

--- a/yarn.lock
+++ b/yarn.lock
@@ -9200,7 +9200,7 @@ eslint-import-resolver-node@^0.3.6:
     debug "^3.2.7"
     resolve "^1.20.0"
 
-eslint-module-utils@^2.7.0:
+eslint-module-utils@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.1.tgz#b435001c9f8dd4ab7f6d0efcae4b9696d4c24b7c"
   integrity sha512-fjoetBXQZq2tSTWZ9yWVl2KuFrTZZH3V+9iD1V1RfpDgxzJR+mPd/KZmMiA8gbPqdBzpNiEHOuT7IYEWxrH0zQ==
@@ -9214,19 +9214,19 @@ eslint-plugin-header@^3.1.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz#6ce512432d57675265fac47292b50d1eff11acd6"
   integrity sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==
 
-eslint-plugin-import@^2.25.2:
-  version "2.25.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.25.2.tgz#b3b9160efddb702fc1636659e71ba1d10adbe9e9"
-  integrity sha512-qCwQr9TYfoBHOFcVGKY9C9unq05uOxxdklmBXLVvcwo68y5Hta6/GzCZEMx2zQiu0woKNEER0LE7ZgaOfBU14g==
+eslint-plugin-import@^2.25.3:
+  version "2.25.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.25.3.tgz#a554b5f66e08fb4f6dc99221866e57cfff824766"
+  integrity sha512-RzAVbby+72IB3iOEL8clzPLzL3wpDrlwjsTBAQXgyp5SeTqqY+0bFubwuo+y/HLhNZcXV4XqTBO4LGsfyHIDXg==
   dependencies:
     array-includes "^3.1.4"
     array.prototype.flat "^1.2.5"
     debug "^2.6.9"
     doctrine "^2.1.0"
     eslint-import-resolver-node "^0.3.6"
-    eslint-module-utils "^2.7.0"
+    eslint-module-utils "^2.7.1"
     has "^1.0.3"
-    is-core-module "^2.7.0"
+    is-core-module "^2.8.0"
     is-glob "^4.0.3"
     minimatch "^3.0.4"
     object.values "^1.1.5"
@@ -11216,7 +11216,7 @@ is-core-module@^2.2.0:
   dependencies:
     has "^1.0.3"
 
-is-core-module@^2.7.0:
+is-core-module@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.0.tgz#0321336c3d0925e497fd97f5d95cb114a5ccd548"
   integrity sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -305,7 +305,7 @@
     postcss-value-parser "4.1.0"
     throat "5.0.0"
 
-"@babel/cli@*", "@babel/cli@^7.14.8":
+"@babel/cli@^7.14.8":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.14.8.tgz#fac73c0e2328a8af9fd3560c06b096bfa3730933"
   integrity sha512-lcy6Lymft9Rpfqmrqdd4oTDdUx9ZwaAhAfywVrHG4771Pa6PPT0danJ1kDHBXYqh4HHSmIdA+nlmfxfxSDPtBg==
@@ -2571,14 +2571,6 @@
     "@babel/helper-validator-identifier" "^7.14.5"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.15.6":
-  version "7.15.6"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.15.6.tgz#99abdc48218b2881c058dd0a7ab05b99c9be758f"
-  integrity sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.14.9"
-    to-fast-properties "^2.0.0"
-
 "@base2/pretty-print-object@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.0.tgz#860ce718b0b73f4009e153541faff2cb6b85d047"
@@ -4460,7 +4452,7 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/client-api@6.3.7":
+"@storybook/client-api@6.3.7", "@storybook/client-api@^6.3.7":
   version "6.3.7"
   resolved "https://registry.yarnpkg.com/@storybook/client-api/-/client-api-6.3.7.tgz#cb1dca05467d777bd09aadbbdd1dd22ca537ce14"
   integrity sha512-8wOH19cMIwIIYhZy5O5Wl8JT1QOL5kNuamp9GPmg5ff4DtnG+/uUslskRvsnKyjPvl+WbIlZtBVWBiawVdd/yQ==


### PR DESCRIPTION
This PR does the following:

* Add static analysis to ensure consumed dependencies are listed correctly in the corresponding package.json
   * [rule documentation](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md) 
   * Within a monorepo, publishing packages that are broken at install time due to missing dependencies is an easy trap to stumble into. This is because at develop time, dependencies are often available to the node module resolution algorithm transitively, or even via sibling packages. The assumed version (or any version) may not be present at install time. Being explicit about our dependency graph will help us maintain quality as we scale.
* Update violations via adding dependencies to package.json files, or escaping in the case of monorepo plumbing
* Remove need for type assertion by using the hoisted copy of `@babel/types` within `@okta/odyssey-transform-styles-babel-plugin`
