### PR TITLE
enable theming for Link

### DIFF
--- a/packages/odyssey-react/src/components/Link/Link.module.scss
+++ b/packages/odyssey-react/src/components/Link/Link.module.scss
@@ -11,40 +11,40 @@
  */
 
 .root {
-  color: cv("blue", "500");
+  color: var(--ColorTextPrimary);
   text-decoration: none;
 
   &:hover {
-    color: cv("blue", "500");
+    color: var(--ColorTextPrimary);
     text-decoration: underline;
   }
 
   &:visited {
-    color: cv("blue", "500");
+    color: var(--ColorTextPrimary);
   }
 }
 
 .indicator {
   display: inline-block;
-  margin-inline-start: 0.2em;
+  margin-inline-start: var(--SpaceRelativeXs);
 }
 
 .icon {
   display: inline-block;
-  margin-inline-end: 0.2em;
+  margin-inline-end: var(--SpaceRelativeXs);
 }
 
 /* Variant */
 
 .secondaryVariant {
-  color: $text-body;
+  color: var(--ColorTextBody);
   text-decoration: underline;
 
   &:hover {
-    color: $text-body;
+    color: var(--ColorTextBody);
   }
 
   &:visited {
-    color: $text-body;
+    color: var(--ColorTextBody);
   }
 }

--- a/packages/odyssey-react/src/components/Link/Link.theme.ts
+++ b/packages/odyssey-react/src/components/Link/Link.theme.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import type { ThemeReducer } from "@okta/odyssey-react-theme";
+
+export const theme: ThemeReducer = (theme) => ({
+  // Primary Variant
+  ColorTextPrimary: theme.ColorTextPrimary,
+
+  // Secondary Variant
+  ColorTextBody: theme.ColorTextBody,
+
+  // Space
+  SpaceRelativeXs: theme.SpaceRelativeXs,
+});

--- a/packages/odyssey-react/src/components/Link/Link.tsx
+++ b/packages/odyssey-react/src/components/Link/Link.tsx
@@ -17,6 +17,7 @@ import { ExternalIcon } from "../Icon";
 import { useCx, useOmit } from "../../utils";
 import { Box } from "../Box";
 import styles from "./Link.module.scss";
+import { theme } from "./Link.theme";
 
 export interface LinkProps
   extends Omit<
@@ -49,7 +50,7 @@ export interface LinkProps
  * Links are navigation elements displayed as text. Use a Link to bring a user to another page or start a download.
  */
 export const Link = withTheme(
-  () => ({}),
+  theme,
   styles
 )(
   forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {


### PR DESCRIPTION
@josesolano-okta, FYI I've updated the spacing units for Icons/Indicators from `0.2em` to our standard xs spacing of `0.375em`

https://81a7b1b.ods.dev/?path=/story/components-link--default