### PR TITLE
🔥 Removed unnecessary ternary

### DIFF
--- a/packages/odyssey-react/src/components/TextInput/TextInput.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.tsx
@@ -176,7 +176,7 @@ export const TextInput: FunctionComponent<TextInputProps> = withTheme(
       hint={hint}
       inputId={oid}
       label={label}
-      labelHidden={type === "search" ? true : false}
+      labelHidden={type === "search"}
       optionalLabel={optionalLabel}
       required={required}
     >


### PR DESCRIPTION
I removed an unnecessary ternary from `TextInput`.