### PR TITLE
POC to get get dynamic options update with Select component

### DIFF
--- a/packages/odyssey-react/src/components/Select/Select.test.tsx
+++ b/packages/odyssey-react/src/components/Select/Select.test.tsx
@@ -21,11 +21,20 @@ const label = "Select speed";
 const name = "speed";
 const warpValue = "Warp speed";
 
-const tree = (props: Record<string, unknown> = {}) => (
-  <Select {...props} label={label} name={name}>
+const DEFAULT_OPTIONS = (
+  <>
     <Select.Option children="Lightspeed" />
     <Select.Option children="Warp speed" />
     <Select.Option children="Ludicrous speed" />
+  </>
+);
+
+const tree = (
+  props: Record<string, unknown> = {},
+  children = DEFAULT_OPTIONS
+) => (
+  <Select {...props} label={label} name={name}>
+    {children}
   </Select>
 );
 
@@ -124,6 +133,30 @@ describe("Select", () => {
       expect.objectContaining({ type: "change" }),
       warpValue
     );
+  });
+
+  it("correctly renders new children when updated dynamically", () => {
+    const { rerender } = render(tree());
+
+    // Make sure initial tree has 3 items
+    let listbox = screen.getAllByRole(listboxRole).pop() as HTMLDivElement;
+    let options = within(listbox).getAllByRole(optionRole);
+    expect(options.length).toBe(3);
+
+    rerender(
+      tree(
+        {},
+        <>
+          <Select.Option children="Lightspeed" />
+          <Select.Option children="Warp speed" />
+        </>
+      )
+    );
+
+    // Make sure tree has 2 items after being dynamically updated
+    listbox = screen.getAllByRole(listboxRole).pop() as HTMLDivElement;
+    options = within(listbox).getAllByRole(optionRole);
+    expect(options.length).toBe(2);
   });
 
   it("restricts multiple and noChoicesText via types", () => {

--- a/packages/odyssey-react/src/components/Select/Select.tsx
+++ b/packages/odyssey-react/src/components/Select/Select.tsx
@@ -118,7 +118,14 @@ export const Select = withTheme(
 
       const oid = useOid(id);
 
-      useChoices({ id: oid, value, loadingText, noResultsText, noChoicesText });
+      useChoices({
+        id: oid,
+        children,
+        value,
+        loadingText,
+        noResultsText,
+        noChoicesText,
+      });
 
       const handleChange = useCallback(
         (event: ChangeEvent<HTMLSelectElement>) => {

--- a/packages/odyssey-react/src/components/Select/SelectOption.tsx
+++ b/packages/odyssey-react/src/components/Select/SelectOption.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import React, { forwardRef } from "react";
+import React, { forwardRef, ReactText } from "react";
 import type { ComponentPropsWithRef } from "react";
 import { useOmit } from "../../utils";
 import { Box } from "../Box";
@@ -21,9 +21,9 @@ export interface SelectOptionProps
     "style" | "className" | "selected" | "color"
   > {
   /**
-   * The underlying option element value attribute.
+   * The option's value
    */
-  value?: string;
+  children: ReactText;
 }
 
 /**

--- a/packages/odyssey-storybook/src/components/Select/Select.stories.tsx
+++ b/packages/odyssey-storybook/src/components/Select/Select.stories.tsx
@@ -10,10 +10,10 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import React from "react";
+import React, { useState } from "react";
 import type { Story } from "@storybook/react";
 import type { ReactElement } from "react";
-import { Select, SelectProps } from "@okta/odyssey-react";
+import { Button, Select, SelectProps } from "@okta/odyssey-react";
 import { Select as Source } from "../../../../odyssey-react/src";
 
 import SelectMdx from "./Select.mdx";
@@ -57,9 +57,11 @@ export default {
 
 const Template: Story<SelectProps> = (args) => (
   <Select {...args}>
-    {options.map((option) => (
-      <Select.Option key={option} children={option} value={option} />
-    ))}
+    <>
+      {options.map((option) => (
+        <Select.Option key={option} children={option} value={option} />
+      ))}
+    </>
   </Select>
 );
 
@@ -100,3 +102,34 @@ export const Group = (args: SelectProps): ReactElement => (
     </Select.OptionGroup>
   </Select>
 );
+
+export const Dynamic = (): ReactElement => {
+  const [options, setOptions] = useState([
+    {
+      value: "Option 1",
+    },
+  ]);
+
+  const addOption = () => {
+    const newOptions = [
+      ...options,
+      {
+        value: `Option ${options.length + 1}`,
+      },
+    ];
+    setOptions(newOptions);
+  };
+
+  return (
+    <div className="App">
+      <Button onClick={addOption}>Add option</Button>
+      <form>
+        <Select label="menu" name="test">
+          {options.map((option) => (
+            <Select.Option key={option.value}>{option.value}</Select.Option>
+          )) || []}
+        </Select>
+      </form>
+    </div>
+  );
+};


### PR DESCRIPTION
Spent a couple of hours digging into the inner workings of `choicesjs`. This is an attempt to have working dynamic options driven by the underlying select but this feels totally flaky to me.

(The test I added won't pass because `choicesjs` removes an element that `react` then also attempts to remove)

As mentioned in the ticket, moving to a prop driven component instead of children would be more in line with what the library expects and can handle.