### PR TITLE
docs: add philosophy writeup

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Please read [the full text](/CODE_OF_CONDUCT.md) so that you can understand what
 
 - Code should be easy to reason about
 - Code should be easy to delete
-- Avoid abstracting too early
+- Avoid early abstractions
 - Avoid thinking too far into the future
 - Complexity should be introduced when it is inevitable
 

--- a/packages/odyssey-storybook/src/contributing/GettingStarted.stories.mdx
+++ b/packages/odyssey-storybook/src/contributing/GettingStarted.stories.mdx
@@ -1,10 +1,14 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Contributing/Getting Started" />
+
 # Contributing
 
 ## Code of Conduct
 
 Odyssey has adopted the [Contributor Covenant](https://www.contributor-covenant.org/) as its Code of Conduct, and we expect project participants to adhere to it.
 
-Please read [the full text](/CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
+Please read [the full text](https://github.com/okta/odyssey/blob/ceb6623be45782ce22693cf761b833cc5ca77dec/CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
 
 ## Heuristics
 
@@ -50,7 +54,7 @@ A good PR is small, focuses on a single feature or improvement, and clearly comm
 
 ```sh
 git clone https://github.com/<your username>/odyssey.git
-cd primitives
+cd odyssey
 git remote add upstream https://github.com/okta/odyssey.git
 ```
 
@@ -97,7 +101,7 @@ The repo is managed with Yarn Workspaces.
 
 ### Development
 
-```bash
+```sh
 # install dependencies
 yarn install
 

--- a/packages/odyssey-storybook/src/guidelines/Philosophy.stories.mdx
+++ b/packages/odyssey-storybook/src/guidelines/Philosophy.stories.mdx
@@ -1,0 +1,72 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Guidelines/Philosophy" />
+
+# Philosophy and Guiding Principles
+
+## Vision
+
+Become the standard Okta UI framework powering teams and customers to create more consistent, efficient, usable and accessible experiences.
+
+## Principles at a glance
+
+1. Modular
+2. Minimal
+3. Accessible
+4. Functional
+
+---
+
+## Principles
+
+### Modular
+
+- Components can be used in isolation without any required setup or surrounding context in the browser at run time.
+- Components ship with embedded, low specificity styles that will not affect other UI on the page incorrectly.
+- Components are designed with an open API that provides consumers with direct access to the underlying DOM node via forwarded refs.
+- Just as DOM nodes are composable, so are DOM event handlers; consumers should be able to pass their own event handlers directly to a component and stop internal handlers from firing.
+- Components are built using composition of low level components which can also be leverged by consumers for their own higher order components.
+
+### Minimal
+
+- Most Components ship with zero third party dependencies beyond React itself.
+- Components are published in an ESM format to allow for optimizied bundling and polyfilling by consumers.
+
+### Accessible
+
+- Components adhere to WCAG 2.2 AA success criteria and WAI-ARIA guidelines.
+- Developers should know about accessibility but shouldn't have to spend too much time implementing accessible patterns.
+- Most behavior and markup related to accessibility should be abstracted, and bits that can't should be simplified where possible.
+- Individual components are tested to ensure accessibility, but where app context is required the component library should provide useful guidance to support building fully accessible applications.
+
+### Functional
+
+- Components are feature-rich, with support for keyboard interaction, responsive layouts, multiple variants and more.
+- Low level components expose utility styling APIs to help with building UI without writing or maintaining any CSS by hand.
+- Components are built to be themed; no need to override opinionated styles using error prone cascade approaches that are tightly coupled to internal DOM structure.
+
+## Other considerations
+
+### Internationalization
+
+- Components support injecting internationalized user facing strings and make behavioral and layout adjustments for right-to-left languages.
+
+### Stateful components can be controlled or uncontrolled
+
+- Similar to form field JSX elements in React, all components with internal state can either be uncontrolled (internally managed) or controlled (managed by the consumer).
+
+### Developer experience
+
+- Component APIs are designed to be consistent, resiliant, unambiguous, simple, and tiny.
+- Component APIs favor a declarative approach when possible.
+- Components ship with supporting type annotations for props and static members for compound components.
+
+### Misc
+
+- Code should be easy to reason about
+- Code should be easy to delete
+- Avoid early abstractions
+- Avoid thinking too far into the future
+- Complexity should be introduced when it is inevitable
+- Keep file structure flat so logic is easier to follow.
+- Don't repeat yourself _too much_ but don't be afraid to repeat yourself if an implementation detail hasn't been thoroughly vetted.


### PR DESCRIPTION
### Description

This PR adds a new `Philosophy.stories.mdx` writeup under the doc site `Guidelines` to better describe some of the design influences for the the project that can help guide new contributors as well!

Additionally, it renders our contributing writeup on the doc site as well under the `Contribution` section
