### PR TITLE
chore(odyssey-storybook): fixes + cleanup

### DIFF
--- a/packages/odyssey-storybook/applitools.config.js
+++ b/packages/odyssey-storybook/applitools.config.js
@@ -18,6 +18,7 @@ module.exports = {
   // github integration.
   exitcode: false,
 
+  matchLevel: "Strict",
   showStorybookOutput: true,
   testConcurrency: 10,
   browser: [
@@ -30,5 +31,8 @@ module.exports = {
     level: "AA",
     guidelinesVersion: "WCAG_2_1",
   },
-  matchLevel: "Strict",
+  include({ name }) {
+    if (name === "Toast.Provider") return false;
+    return true;
+  },
 };

--- a/packages/odyssey-storybook/src/components/FieldGroup/FieldGroup.stories.tsx
+++ b/packages/odyssey-storybook/src/components/FieldGroup/FieldGroup.stories.tsx
@@ -44,7 +44,7 @@ const Template: Story<FieldGroupProps> = ({ legend, desc }) => (
   <FieldGroup legend={legend} desc={desc}>
     <FieldGroup.Error>
       <Infobox
-        title="Route impossible"
+        heading="Route impossible"
         variant="danger"
         content="this is an error"
       />

--- a/packages/odyssey-storybook/src/components/Text/TextStyles.stories.tsx
+++ b/packages/odyssey-storybook/src/components/Text/TextStyles.stories.tsx
@@ -183,10 +183,10 @@ LineHeightNormal.args = {
   lineHeight: "normal",
 };
 
-export const LineHeightTitle = TemplateWithContainer.bind({});
-LineHeightTitle.storyName = "Line height: Title";
-LineHeightTitle.args = {
-  children: "Title text LineHeight style",
+export const LineHeightHeading = TemplateWithContainer.bind({});
+LineHeightHeading.storyName = "Line height: Heading";
+LineHeightHeading.args = {
+  children: "Heading text LineHeight style",
   lineHeight: "heading",
 };
 


### PR DESCRIPTION
### Description

* [chore(odyssey-storybook): fix heading for Infobox in FieldGroup story](https://github.com/okta/odyssey/commit/c06b870beee0778601e223e23207820d48175835)

* [chore(odyssey-storybook): rename title to heading for Text story](https://github.com/okta/odyssey/commit/aa7d5e0844acded23b1c71d3ca5ba24f924bfc2c)

* [chore(odyssey-storybook): exclude Toast.Provider story from VRT](https://github.com/okta/odyssey/commit/cbd56c2ea6c79eca8d6137c51269ee938554aa07)
