### PR TITLE
Infobox content gap bugfix

### DIFF
--- a/packages/odyssey-react/src/components/Infobox/Infobox.module.scss
+++ b/packages/odyssey-react/src/components/Infobox/Infobox.module.scss
@@ -15,8 +15,7 @@
 
   display: grid;
   grid-template-areas:
-    "icon heading"
-    ". content"
+    "icon content"
     ". actions";
   grid-template-columns: max-content 1fr;
   width: 100%;
@@ -36,10 +35,6 @@
   font-size: var(--IconSize);
   line-height: var(--IconLineHeight);
   justify-self: start;
-}
-
-.heading {
-  grid-area: heading;
 }
 
 .content {

--- a/packages/odyssey-react/src/components/Infobox/Infobox.tsx
+++ b/packages/odyssey-react/src/components/Infobox/Infobox.tsx
@@ -92,16 +92,12 @@ export const Infobox = withTheme(
         role="status"
       >
         <span className={styles.icon}>{icon[variant]}</span>
-        {heading && (
-          <div className={styles.heading}>
-            <Heading visualLevel="6" children={heading} />
-          </div>
-        )}
-        {content && (
-          <section className={styles.content}>
-            <Text>{content}</Text>
-          </section>
-        )}
+
+        <section className={styles.content}>
+          {heading && <Heading visualLevel="6" children={heading} />}
+          {content && <Text>{content}</Text>}
+        </section>
+
         {actions && (
           <section className={styles.actions}>
             <Text>{actions}</Text>

--- a/packages/odyssey-storybook/src/components/Infobox/Infobox.stories.tsx
+++ b/packages/odyssey-storybook/src/components/Infobox/Infobox.stories.tsx
@@ -11,6 +11,7 @@
  */
 
 import React from "react";
+import type { ReactElement } from "react";
 import { Story } from "@storybook/react";
 import { Infobox, InfoboxProps, Link } from "@okta/odyssey-react";
 import { Infobox as Source } from "../../../../odyssey-react/src";
@@ -72,3 +73,7 @@ export const Success = Template.bind({});
 Success.args = {
   variant: "success",
 };
+
+export const HeadingOnly = (): ReactElement => <Infobox heading="Heading" />;
+
+export const ContentOnly = (): ReactElement => <Infobox content={content} />;


### PR DESCRIPTION
This change allows for content to be displayed without a heading and not have any gap between the content and the top of the Infobox.

![image](https://user-images.githubusercontent.com/87656589/152422174-2d89536a-1151-473a-8c96-8c108e90befc.png)
