### PR TITLE
add maxLength attribute to input and text area

### DIFF
--- a/packages/odyssey-react/src/components/TextArea/TextArea.test.tsx
+++ b/packages/odyssey-react/src/components/TextArea/TextArea.test.tsx
@@ -44,6 +44,12 @@ describe("TextArea", () => {
     expect(screen.getByRole(textBox, { name: label })).toBeVisible();
   });
 
+  it("renders a max length for the text area", () => {
+    render(<TextArea label={label} name="bar" maxLength={5} />);
+
+    expect(screen.getByRole(textBox)).toHaveAttribute("maxLength", "5");
+  });
+
   it("renders a provided name for the input", () => {
     render(<TextArea label={label} name="bar" />);
 

--- a/packages/odyssey-react/src/components/TextArea/TextArea.tsx
+++ b/packages/odyssey-react/src/components/TextArea/TextArea.tsx
@@ -62,6 +62,11 @@ export interface TextAreaProps
   value?: string;
 
   /**
+   * The underlying textarea element max length attribute
+   */
+  maxLength?: number;
+
+  /**
    * The initial textarea element value for uncontrolled components
    */
   defaultValue?: string;
@@ -97,6 +102,7 @@ export const TextArea = withTheme(
     const {
       defaultValue,
       disabled = false,
+      maxLength,
       id,
       name,
       onBlur,
@@ -142,6 +148,7 @@ export const TextArea = withTheme(
           aria-describedby={ariaDescribedBy}
           className={styles.root}
           disabled={disabled}
+          maxLength={maxLength}
           id={oid}
           name={name}
           onChange={handleChange}

--- a/packages/odyssey-react/src/components/TextInput/TextInput.test.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.test.tsx
@@ -51,6 +51,12 @@ describe("TextInput", () => {
     expect(screen.getByRole(textBox)).toHaveAttribute("name", "bar");
   });
 
+  it("renders a max length for the input", () => {
+    render(<TextInput label={label} name="bar" maxLength={5} />);
+
+    expect(screen.getByRole(textBox)).toHaveAttribute("maxLength", "5");
+  });
+
   it("renders the optionalLabel when input is not required", () => {
     const optionalLabel = "Optional";
 

--- a/packages/odyssey-react/src/components/TextInput/TextInput.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.tsx
@@ -69,6 +69,11 @@ export interface TextInputProps
   value?: string;
 
   /**
+   * The underlying input element max length attribute
+   */
+   maxLength?: number;
+
+  /**
    * The initial input element value for uncontrolled components
    */
   defaultValue?: string;
@@ -104,6 +109,7 @@ export const TextInput = withTheme(
     const {
       defaultValue,
       disabled = false,
+      maxLength,
       id,
       name,
       onBlur,
@@ -142,6 +148,7 @@ export const TextInput = withTheme(
         aria-describedby={ariaDescribedBy}
         className={styles.root}
         disabled={disabled}
+        maxLength={maxLength}
         id={oid}
         name={name}
         onChange={handleChange}


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

adding prop `maxLength` to `TextInput` and `TextArea` to limit user input from frontend.
