### PR TITLE
feat(odyssey-storybook): add build to prepublishOnly

### DIFF
--- a/packages/odyssey-storybook/package.json
+++ b/packages/odyssey-storybook/package.json
@@ -34,6 +34,7 @@
     "start": "start-storybook --quiet --port 6006",
     "build": "build-storybook --quiet --output-dir dist",
     "typecheck": "tsc",
+    "prepublishOnly": "yarn run build",
     "prepack": "node ./scripts/prepack.js"
   }
 }


### PR DESCRIPTION
This PR adds a `prepublishOnly` build step for our storybook deployment
