### PR TITLE
fix: improve class name hashing

### DIFF
--- a/packages/odyssey-transform-styles-babel-plugin/src/__tests__/__snapshots__/importVisitor.test.js.snap
+++ b/packages/odyssey-transform-styles-babel-plugin/src/__tests__/__snapshots__/importVisitor.test.js.snap
@@ -2,11 +2,11 @@
 
 exports[`transformStyles import visitor transforms styles as expected 1`] = `
 Object {
-  "__digest": "fdf87d",
+  "__digest": "0776a6",
   "__template": [Function],
-  "autoprefixed": "ods-322606",
-  "root": "ods-c0f206",
+  "autoprefixed": "ods-58h7mt",
+  "root": "ods-3l3bKz",
 }
 `;
 
-exports[`transformStyles import visitor transforms styles template function return value as expected 1`] = `".ods-c0f206:dir(ltr){margin-left:0}.ods-c0f206:dir(rtl){margin-right:0}.ods-c0f206:dir(ltr){margin-right:.375rem}.ods-c0f206:dir(rtl){margin-left:.375rem}.ods-c0f206{background:#ebebed;color:#1d1d21;display:inline-block;margin-bottom:.375rem;margin-top:0;padding:0 .375em}.ods-322606{::-moz-placeholder{color:#bada55}:-ms-input-placeholder{color:#bada55}::placeholder{color:#bada55}}"`;
+exports[`transformStyles import visitor transforms styles template function return value as expected 1`] = `".ods-3l3bKz:dir(ltr){margin-left:0}.ods-3l3bKz:dir(rtl){margin-right:0}.ods-3l3bKz:dir(ltr){margin-right:.375rem}.ods-3l3bKz:dir(rtl){margin-left:.375rem}.ods-3l3bKz{background:#ebebed;color:#1d1d21;display:inline-block;margin-bottom:.375rem;margin-top:0;padding:0 .375em}.ods-58h7mt{::-moz-placeholder{color:#bada55}:-ms-input-placeholder{color:#bada55}::placeholder{color:#bada55}}"`;

--- a/packages/odyssey-transform-styles-babel-plugin/src/__tests__/__snapshots__/requireVisitor.test.js.snap
+++ b/packages/odyssey-transform-styles-babel-plugin/src/__tests__/__snapshots__/requireVisitor.test.js.snap
@@ -2,11 +2,11 @@
 
 exports[`transformStyles require visitor transforms styles as expected 1`] = `
 Object {
-  "__digest": "fdf87d",
+  "__digest": "0776a6",
   "__template": [Function],
-  "autoprefixed": "ods-322606",
-  "root": "ods-c0f206",
+  "autoprefixed": "ods-58h7mt",
+  "root": "ods-3l3bKz",
 }
 `;
 
-exports[`transformStyles require visitor transforms styles template function return value as expected 1`] = `".ods-c0f206:dir(ltr){margin-left:0}.ods-c0f206:dir(rtl){margin-right:0}.ods-c0f206:dir(ltr){margin-right:.375rem}.ods-c0f206:dir(rtl){margin-left:.375rem}.ods-c0f206{background:#ebebed;color:#1d1d21;display:inline-block;margin-bottom:.375rem;margin-top:0;padding:0 .375em}.ods-322606{::-moz-placeholder{color:#bada55}:-ms-input-placeholder{color:#bada55}::placeholder{color:#bada55}}"`;
+exports[`transformStyles require visitor transforms styles template function return value as expected 1`] = `".ods-3l3bKz:dir(ltr){margin-left:0}.ods-3l3bKz:dir(rtl){margin-right:0}.ods-3l3bKz:dir(ltr){margin-right:.375rem}.ods-3l3bKz:dir(rtl){margin-left:.375rem}.ods-3l3bKz{background:#ebebed;color:#1d1d21;display:inline-block;margin-bottom:.375rem;margin-top:0;padding:0 .375em}.ods-58h7mt{::-moz-placeholder{color:#bada55}:-ms-input-placeholder{color:#bada55}::placeholder{color:#bada55}}"`;

--- a/packages/odyssey-transform-styles-postcss-preset/package.json
+++ b/packages/odyssey-transform-styles-postcss-preset/package.json
@@ -13,6 +13,7 @@
     "@okta/odyssey-postcss-theme": "^0.9.1",
     "autoprefixer": "^10.3.4",
     "cssnano": "^5.0.8",
+    "loader-utils": "1.4.0",
     "postcss-logical": "^5.0.0",
     "postcss-modules": "^4.2.2"
   },

--- a/packages/odyssey-transform-styles-postcss-preset/src/plugin.ts
+++ b/packages/odyssey-transform-styles-postcss-preset/src/plugin.ts
@@ -14,6 +14,7 @@ import type { PluginCreator } from "postcss";
 import type { CssNanoOptions } from "cssnano";
 import type { Options as AutoPrefixerOptions } from "autoprefixer";
 import type PostcssModulesPlugin from "postcss-modules";
+import { interpolateName } from "loader-utils";
 import postcss from "postcss";
 import postcssModules from "postcss-modules";
 import postcssLogical from "postcss-logical";
@@ -38,7 +39,13 @@ const plugin: PluginCreator<PluginOptions> = (optsArgs = {}) => {
       ...optsArgs.logical,
     },
     modules: {
-      generateScopedName: "ods-[hash:hex:6]",
+      generateScopedName(name, cssPath, css) {
+        return interpolateName(
+          { resourcePath: cssPath },
+          "ods-[hash:base62:6]",
+          { content: name + css, context: process.cwd() }
+        );
+      },
       ...optsArgs.modules,
     },
     cssnano: {

--- a/packages/odyssey-transform-styles-postcss-preset/src/types.d.ts
+++ b/packages/odyssey-transform-styles-postcss-preset/src/types.d.ts
@@ -22,3 +22,16 @@ declare module "postcss-logical" {
 
   export { LogicalOptions, postcssLogical as default };
 }
+
+declare module "loader-utils" {
+  type Context = { resourcePath: string };
+  type Options = { content: string; context: string };
+
+  function interpolateName(
+    loaderContext: Context,
+    name: string,
+    options: Options
+  ): string;
+
+  export { interpolateName };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12467,6 +12467,15 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
+loader-utils@1.4.0, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
+  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^1.0.1"
+
 loader-utils@2.0.0, loader-utils@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0"
@@ -12475,15 +12484,6 @@ loader-utils@2.0.0, loader-utils@^2.0.0:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^2.1.2"
-
-loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
-  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^3.0.0"
-    json5 "^1.0.1"
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

This PR changes how our build generates class names. Previously hashing was done with the contents of the filename and class name which lead to bugs across versions of Odyssey deployed within the same browser frame. We now hash based on the contents of the style module and use a base62 encoding to further reduce any accidental collisions by two orders of magnitude or so.
