### PR TITLE
OKTA-473739: odyssey-react checkbox a11y fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "engines": {
     "yarn": "^1.15.2",
-    "node": ">=16.14.0"
+    "node": ">=14.17.0"
   },
   "scripts": {
     "start": "lerna run start --parallel",

--- a/packages/odyssey-react/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/odyssey-react/src/components/Checkbox/Checkbox.test.tsx
@@ -54,7 +54,20 @@ describe("Checkbox", () => {
     );
 
     expect(getByRole(checkbox)).toHaveAttribute("id", "foo");
-    expect(getByText(label)).toHaveAttribute("for", "foo");
+    expect(getByText(label).closest("label")).toHaveAttribute("for", "foo");
+  });
+
+  it("renders input elem with aria-labelledby attr referencing label text", () => {
+    const { container } = render(
+      <Checkbox label={label} name={name} value={value} />
+    );
+
+    const inputElem = container.querySelector("input");
+    const ariaLabelledById = inputElem?.getAttribute("aria-labelledby");
+    const labelledByIdElem = container.querySelector(
+      `[id="${ariaLabelledById}"]`
+    );
+    expect(labelledByIdElem).toBeInTheDocument();
   });
 
   it("renders a generated id associating the input and label", () => {

--- a/packages/odyssey-react/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/odyssey-react/src/components/Checkbox/Checkbox.test.tsx
@@ -49,12 +49,13 @@ describe("Checkbox", () => {
   });
 
   it("renders a provided id associating the input and label", () => {
-    const { getByRole, getByText } = render(
+    const { container } = render(
       <Checkbox label={label} name={name} value={value} id="foo" />
     );
-
-    expect(getByRole(checkbox)).toHaveAttribute("id", "foo");
-    expect(getByText(label).closest("label")).toHaveAttribute("for", "foo");
+    const inputElem = container.querySelector("input");
+    const labelElem = container.querySelector("label");
+    expect(inputElem).toHaveAttribute("id", "foo");
+    expect(labelElem).toHaveAttribute("for", "foo");
   });
 
   it("renders input elem with aria-labelledby attr referencing label text", () => {
@@ -71,11 +72,17 @@ describe("Checkbox", () => {
   });
 
   it("renders a generated id associating the input and label", () => {
-    render(<Checkbox label={label} name={name} value={value} />);
+    const { container } = render(
+      <Checkbox label={label} name={name} value={value} />
+    );
 
-    const result = screen.getByLabelText(label);
-    expect(result).toBeInstanceOf(HTMLInputElement);
-    expect(result).toHaveAttribute("name", name);
+    const inputElem = container.querySelector("input");
+    const labelElem = container.querySelector("label");
+    const inputElemId = inputElem?.getAttribute("id");
+    const labelElemForAttrValue = labelElem?.getAttribute("for");
+    expect(inputElem).toBeInstanceOf(HTMLInputElement);
+    expect(labelElem).toBeInstanceOf(HTMLLabelElement);
+    expect(labelElemForAttrValue).toEqual(inputElemId);
   });
 
   it.each([["disabled"], ["checked"], ["required"]])(

--- a/packages/odyssey-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/odyssey-react/src/components/Checkbox/Checkbox.tsx
@@ -15,7 +15,7 @@ import type { ComponentPropsWithRef, ChangeEvent } from "react";
 import { withTheme } from "@okta/odyssey-react-theme";
 import { Box } from "../Box";
 import { CheckIcon, SubtractIcon } from "../Icon";
-import { useCx, useOid, useOmit } from "../../utils";
+import { useOid, useOmit } from "../../utils";
 import { Field } from "../Field";
 import type { CommonFieldProps } from "../Field/types";
 import { theme } from "./Checkbox.theme";
@@ -70,6 +70,7 @@ export const Checkbox = withTheme(
     } = props;
 
     const oid = useOid(id);
+    const ariaLabelledById = useOid();
     const omitProps = useOmit(rest);
 
     const handleChange = useCallback(
@@ -93,17 +94,13 @@ export const Checkbox = withTheme(
       internalRef.current.indeterminate = indeterminate;
     }, [indeterminate, internalRef]);
 
-    const ariaDescribedBy = useCx(
-      typeof error !== "undefined" && `${oid}-error`
-    );
-
     return (
       <Box position="relative">
         <input
           {...omitProps}
           className={styles.checkbox}
           id={oid}
-          aria-describedby={ariaDescribedBy}
+          aria-labelledby={ariaLabelledById}
           onChange={handleChange}
           ref={internalRef}
           required={required}
@@ -115,8 +112,7 @@ export const Checkbox = withTheme(
               {indeterminate ? <SubtractIcon /> : <CheckIcon />}
             </span>
           </span>
-
-          {label}
+          <span id={ariaLabelledById}>{label}</span>
         </label>
         {error && <Field.Error id={oid}>{error}</Field.Error>}
       </Box>


### PR DESCRIPTION
### Description

Add an `aria-labelledby` attribute to the checkbox input field that maps to the checkbox label text.

See https://oktainc.atlassian.net/browse/OKTA-473739 (Okta employees only)
