### PR TITLE
fix(odyssey-react): conditionally display aria-describedby attribute to avoid a11y warnings in Checkbox component

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry="https://registry.yarnpkg.com"
+strict-ssl=false

--- a/packages/odyssey-react/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/odyssey-react/src/components/Checkbox/Checkbox.test.tsx
@@ -65,6 +65,24 @@ describe("Checkbox", () => {
     expect(result).toHaveAttribute("name", name);
   });
 
+  it("renders an aria-describedby attribute when an error is present", () => {
+    const error = "oops";
+    render(<Checkbox label={label} name={name} value={value} error="oops" />);
+
+    const errorEl = screen.getByText(error);
+    expect(screen.getByRole(checkbox, { name: label })).toHaveAttribute(
+      "aria-describedby",
+      errorEl.id
+    );
+  });
+
+  it("does not render an aria-describedby attribute when no error is present", () => {
+    render(<Checkbox label={label} name={name} value={value} />);
+    expect(screen.getByRole(checkbox, { name: label })).not.toHaveAttribute(
+      "aria-describedby"
+    );
+  });
+
   it.each([["disabled"], ["checked"], ["required"]])(
     "renders %s attribute",
     (attr: string) => {

--- a/packages/odyssey-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/odyssey-react/src/components/Checkbox/Checkbox.tsx
@@ -93,17 +93,16 @@ export const Checkbox = withTheme(
       internalRef.current.indeterminate = indeterminate;
     }, [indeterminate, internalRef]);
 
-    const ariaDescribedBy = useCx(
-      typeof error !== "undefined" && `${oid}-error`
-    );
+    const ariaDescribedBy = useCx(!!error && `${oid}-error`);
+    const ariaProps = error ? { "aria-describedby": ariaDescribedBy } : {};
 
     return (
       <Box position="relative">
         <input
           {...omitProps}
+          {...ariaProps}
           className={styles.checkbox}
           id={oid}
-          aria-describedby={ariaDescribedBy}
           onChange={handleChange}
           ref={internalRef}
           required={required}

--- a/packages/odyssey-react/src/components/Icon/SvgIcon.tsx
+++ b/packages/odyssey-react/src/components/Icon/SvgIcon.tsx
@@ -44,13 +44,18 @@ export const SvgIcon = withTheme(
     ({ title, children, ...rest }, ref) => {
       const oid = useOid();
       const omitProps = useOmit(rest);
+      const ariaProps = !!title
+        ? {
+            "aria-labelledby": oid,
+          }
+        : {};
 
       return Children.only(
         cloneElement(
           children,
           {
             ...omitProps,
-            "aria-labelledby": oid,
+            ...ariaProps,
             className: styles.root,
             ref: ref,
             role: title ? "img" : "presentation",


### PR DESCRIPTION
### Description

Conditionally display the `aria-describedby` attribute to the checkbox input field, only adding the attribute when an error is present.

See https://oktainc.atlassian.net/browse/OKTA-473739 (Okta employees only)