### PR TITLE
fix(odyssey-react): conditionally display aria-describedby attribute in TextInput component

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry="https://registry.yarnpkg.com"
+strict-ssl=false

--- a/packages/odyssey-react/src/components/TextInput/TextInput.test.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.test.tsx
@@ -45,6 +45,24 @@ describe("TextInput", () => {
     expect(screen.getByRole(textBox, { name: label })).toBeVisible();
   });
 
+  it("renders an aria-describedby attribute when an error is present", () => {
+    const error = "oops";
+    render(<TextInput label={label} error={error} />);
+
+    const errorEl = screen.getByText(error);
+    expect(screen.getByRole(textBox, { name: label })).toHaveAttribute(
+      "aria-describedby",
+      errorEl.id
+    );
+  });
+
+  it("does not render an aria-describedby attribute when no error is present", () => {
+    render(<TextInput label={label} />);
+    expect(screen.getByRole(textBox, { name: label })).not.toHaveAttribute(
+      "aria-describedby"
+    );
+  });
+
   it("renders a provided name for the input", () => {
     render(<TextInput label={label} name="bar" />);
 

--- a/packages/odyssey-react/src/components/TextInput/TextInput.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.tsx
@@ -18,7 +18,7 @@ import type {
 } from "react";
 import { withTheme } from "@okta/odyssey-react-theme";
 import { useOid, useOmit, useCx } from "../../utils";
-import { SearchIcon } from "../Icon/Search";
+import { SearchIcon } from "../Icon";
 import { Field } from "../Field";
 import type { CommonFieldProps } from "../Field/types";
 import { theme } from "./TextInput.theme";
@@ -133,13 +133,20 @@ export const TextInput = withTheme(
 
     const ariaDescribedBy = useCx(
       hint && `${oid}-hint`,
-      typeof error !== "undefined" && `${oid}-error`
+      !!error && `${oid}-error`
     );
+
+    const ariaProps =
+      hint || error
+        ? {
+            "aria-describedby": ariaDescribedBy,
+          }
+        : {};
 
     const input = (
       <input
         {...omitProps}
-        aria-describedby={ariaDescribedBy}
+        {...ariaProps}
         className={styles.root}
         disabled={disabled}
         id={oid}


### PR DESCRIPTION
### Description

Conditionally display the aria-describedby attribute in the text input field (`TextInput` component), only adding the attribute when a hint or an error is present.

See https://oktainc.atlassian.net/browse/OKTA-473744 (Okta employees only)
