### PR TITLE
feat(odyssey-react): update Banner styles and make Banner IE11-friendly

### DIFF
--- a/packages/odyssey-ie-11-sandbox/src/App.tsx
+++ b/packages/odyssey-ie-11-sandbox/src/App.tsx
@@ -52,7 +52,7 @@ export default function App(): JSX.Element {
         descriptor="Banner"
         label="Status Label"
         labelHidden
-        variant="danger"
+        variant="success"
       />
       <ErrorBoundary>
         <Banner

--- a/packages/odyssey-react/src/components/Banner/Banner.module.scss
+++ b/packages/odyssey-react/src/components/Banner/Banner.module.scss
@@ -11,11 +11,8 @@
  */
 
 .root {
-  display: grid;
+  display: flex;
   position: relative;
-  grid-template-areas: "icon heading content actions";
-  grid-template-columns: repeat(4, minmax(min-content, max-content));
-  grid-template-rows: 1fr;
   align-items: center;
   justify-content: center;
   width: 100%;
@@ -24,19 +21,17 @@
 }
 
 .icon {
-  grid-area: icon;
+  width: var(--IconSize);
   margin-inline-end: var(--IconMarginInlineEnd);
   font-size: var(--IconSize);
   line-height: 1;
 }
 
 .heading {
-  grid-area: heading;
   margin-inline-end: var(--HeadingMarginInlineEnd);
 }
 
 .content {
-  grid-area: content;
   max-width: 100%;
   margin-block-end: 0;
   margin-inline-end: var(--ContentMarginInlineEnd);
@@ -44,7 +39,6 @@
 
 .actions {
   display: flex;
-  grid-area: actions;
   justify-content: end;
 }
 
@@ -68,39 +62,51 @@
 
 .infoVariant {
   background-color: var(--InfoBackgroundColor);
-}
 
-.successVariant {
-  background-color: var(--SuccessBackgroundColor);
+  .icon {
+    color: var(--InfoIconColor);
+  }
 }
 
 .cautionVariant {
   background-color: var(--CautionBackgroundColor);
+
+  .icon {
+    color: var(--CautionIconColor);
+  }
 }
 
 .dangerVariant {
   background-color: var(--DangerBackgroundColor);
+
+  .icon {
+    color: var(--DangerIconColor);
+  }
 }
 
-@media screen and (max-width: (calc(var(--MaxLineLength) * 1.5))) {
+@media screen and (max-width: (calc(33rem * 1.5))) {
   .root {
-    grid-template-areas: initial;
-    grid-template-columns: repeat(2, minmax(min-content, max-content));
-    grid-template-rows: unset;
-    justify-content: start;
-    justify-items: start;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-start;
+    padding-inline: calc(
+      var(--IconSize) + var(--IconMarginInlineEnd) + var(--PaddingInline)
+    );
   }
 
-  .icon,
-  .heading,
-  .content,
-  .actions {
-    grid-area: initial;
+  .icon {
+    position: absolute;
+    inset-block-start: var(--IconInsetBlockStart);
+    inset-inline-start: var(--IconInsetInlineStart);
   }
 
-  .heading,
-  .content,
-  .actions {
-    grid-column: 2;
+  .heading {
+    margin-block-end: var(--HeadingMobileMarginBlockEnd);
+    margin-inline-end: 0;
+  }
+
+  .content {
+    margin-block-end: var(--ContentMobileMarginBlockEnd);
+    margin-inline-end: 0;
   }
 }

--- a/packages/odyssey-react/src/components/Banner/Banner.theme.ts
+++ b/packages/odyssey-react/src/components/Banner/Banner.theme.ts
@@ -19,12 +19,16 @@ export const theme: ThemeReducer = (theme) => ({
   PaddingBlock: theme.SpaceScale3,
   PaddingInline: theme.SpaceScale3,
 
+  IconInsetBlockStart: theme.SpaceScale3,
+  IconInsetInlineStart: theme.SpaceScale3,
   IconMarginInlineEnd: theme.SpaceScale3,
   IconSize: theme.FontSizeHeading5,
 
   HeadingMarginInlineEnd: theme.SpaceScale0,
+  HeadingMobileMarginBlockEnd: theme.SpaceScale0,
 
   ContentMarginInlineEnd: theme.SpaceScale3,
+  ContentMobileMarginBlockEnd: theme.SpaceScale0,
 
   DismissButtonInsetInlineEnd: theme.SpaceScale3,
   DismissButtonMarginInlineStart: theme.SpaceScale3,
@@ -33,8 +37,12 @@ export const theme: ThemeReducer = (theme) => ({
   DismissablePaddingInlineEnd: theme.SpaceScale6,
   DismissablePaddingInlineStart: theme.SpaceScale3,
 
-  CautionBackgroundColor: theme.ColorCautionLight,
-  DangerBackgroundColor: theme.ColorDangerLight,
-  InfoBackgroundColor: theme.ColorPrimaryLight,
-  SuccessBackgroundColor: theme.ColorSuccessLight,
+  CautionBackgroundColor: theme.ColorBackgroundCautionLight,
+  CautionIconColor: theme.ColorCautionDark,
+
+  DangerBackgroundColor: theme.ColorBackgroundDangerLight,
+  DangerIconColor: theme.ColorDangerBase,
+
+  InfoBackgroundColor: theme.ColorBackgroundPrimaryLight,
+  InfoIconColor: theme.ColorPrimaryBase,
 });


### PR DESCRIPTION
### Description

This PR makes Banner IE11-friendly and updates our styles to match the most recent design.

Some theme variables are removed; however, the React API does not allow the Success variant, so these were extraneous.

#### Screenshots

##### IE 11

<img width="921" alt="Screen Shot 2022-03-10 at 2 01 15 PM" src="https://user-images.githubusercontent.com/36284167/157762587-93363810-c488-480a-9cf4-ee883a4e9095.png">
<img width="309" alt="Screen Shot 2022-03-10 at 2 01 10 PM" src="https://user-images.githubusercontent.com/36284167/157762590-b7626c78-c84c-4aef-af5e-52b4134fc214.png">

##### FF

<img width="1695" alt="Screen Shot 2022-03-10 at 2 05 47 PM" src="https://user-images.githubusercontent.com/36284167/157762662-d07397c3-127e-4e41-91ee-4fcb3ac2233c.png">
<img width="439" alt="Screen Shot 2022-03-10 at 2 05 40 PM" src="https://user-images.githubusercontent.com/36284167/157762665-4c526caa-fb67-4395-b9f3-4de3ee924ca3.png">

