### PR TITLE
Infobox: IE11-Friendly + Style Update

### DIFF
--- a/packages/odyssey-ie-11-sandbox/src/App.tsx
+++ b/packages/odyssey-ie-11-sandbox/src/App.tsx
@@ -222,7 +222,7 @@ export default function App(): JSX.Element {
         descriptor="Infobox"
         label="Status Label"
         labelHidden
-        variant="neutral"
+        variant="success"
       />
       <Infobox
         actions={

--- a/packages/odyssey-react/src/components/Infobox/Infobox.module.scss
+++ b/packages/odyssey-react/src/components/Infobox/Infobox.module.scss
@@ -13,16 +13,14 @@
 .root {
   @include border-radius(var(--BorderRadius));
 
-  display: grid;
-  grid-template-areas:
-    "icon content"
-    ". actions";
-  grid-template-columns: max-content 1fr;
-  width: 100%;
+  position: relative;
   max-width: calc(var(--MaxLineLength) + calc(var(--PaddingInline) * 2));
   padding-block: var(--PaddingBlock);
-  padding-inline: var(--PaddingInline);
-  column-gap: var(--ColumnGap);
+  padding-inline: calc(
+    var(--IconSize) + var(--IconMargin) + var(--PaddingInline)
+  );
+  border-width: var(--BorderWidth);
+  border-style: var(--BorderStyle);
 
   &:not(:last-child) {
     margin-block-end: var(--MarginBlockEnd);
@@ -30,16 +28,25 @@
 }
 
 .icon {
-  grid-area: icon;
-  align-self: start;
+  position: absolute;
+  inset-block-start: var(--IconInsetBlockStart);
+  inset-inline-start: var(--IconInsetInlineStart);
+  width: var(--IconSize);
   font-size: var(--IconSize);
-  line-height: var(--IconLineHeight);
-  justify-self: start;
+  line-height: 1;
+}
+
+.heading {
+  margin-block-start: 0;
+  margin-block-end: var(--HeadingMarginBlock);
+  margin-inline: var(--HeadingMarginInline);
+  color: var(--HeadingTextColor);
+  font-size: var(--HeadingFontSize);
+  font-weight: var(--HeadingFontWeight);
+  line-height: var(--HeadingLineHeight);
 }
 
 .content {
-  grid-area: content;
-
   &:not(:last-child) {
     margin-block-end: var(--ContentMarginBlockEnd);
   }
@@ -47,24 +54,42 @@
 
 .actions {
   display: flex;
-  grid-area: actions;
-  justify-content: start;
 }
 
 /* Variants */
 
 .infoVariant {
+  border-color: var(--InfoBorderColor);
   background-color: var(--InfoBackgroundColor);
+
+  .icon {
+    color: var(--InfoIconColor);
+  }
 }
 
 .successVariant {
+  border-color: var(--SuccessBorderColor);
   background-color: var(--SuccessBackgroundColor);
+
+  .icon {
+    color: var(--SuccessIconColor);
+  }
 }
 
 .cautionVariant {
+  border-color: var(--CautionBorderColor);
   background-color: var(--CautionBackgroundColor);
+
+  .icon {
+    color: var(--CautionIconColor);
+  }
 }
 
 .dangerVariant {
+  border-color: var(--DangerBorderColor);
   background-color: var(--DangerBackgroundColor);
+
+  .icon {
+    color: var(--DangerIconColor);
+  }
 }

--- a/packages/odyssey-react/src/components/Infobox/Infobox.theme.ts
+++ b/packages/odyssey-react/src/components/Infobox/Infobox.theme.ts
@@ -14,22 +14,41 @@ import type { ThemeReducer } from "@okta/odyssey-react-theme";
 
 export const theme: ThemeReducer = (theme) => ({
   // Root
+  BorderRadius: theme.BorderRadiusBase,
+  BorderStyle: theme.BorderStyleBase,
+  BorderWidth: theme.BorderWidthBase,
+  ColumnGap: theme.SpaceScale2,
+  MarginBlockEnd: theme.SpaceScale3,
   // eslint-disable-next-line @okta/odyssey/no-invalid-theme-properties
   MaxLineLength: theme.FontLineLengthMax,
   PaddingBlock: theme.SpaceScale3,
   PaddingInline: theme.SpaceScale3,
-  MarginBlockEnd: theme.SpaceScale3,
-  BorderRadius: theme.BorderRadiusBase,
-  ColumnGap: theme.SpaceScale2,
 
-  IconSize: theme.FontSizeHeading5,
-  IconLineHeight: theme.FontLineHeightHeading5,
+  IconInsetBlockStart: theme.SpaceScale3,
+  IconInsetInlineStart: theme.SpaceScale3,
+  IconMargin: theme.SpaceScale3,
+  IconSize: theme.FontSizeHeading4,
+
+  HeadingFontSize: theme.FontSizeHeading6,
+  HeadingFontWeight: theme.FontWeightBold,
+  HeadingLineHeight: theme.FontLineHeightHeading6,
+  HeadingMarginBlock: theme.SpaceScale0,
+  HeadingMarginInline: 0,
+  HeadingTextColor: theme.ColorTextBody,
 
   ContentMarginBlockEnd: theme.SpaceScale2,
 
   // Variants
   CautionBackgroundColor: theme.ColorBackgroundCautionLight,
+  CautionBorderColor: theme.ColorBackgroundCautionBase,
+  CautionIconColor: theme.ColorCautionDark,
   DangerBackgroundColor: theme.ColorBackgroundDangerLight,
+  DangerBorderColor: theme.ColorBackgroundDangerBase,
+  DangerIconColor: theme.ColorDangerBase,
   InfoBackgroundColor: theme.ColorBackgroundPrimaryLight,
+  InfoBorderColor: theme.ColorBackgroundPrimaryBase,
+  InfoIconColor: theme.ColorPrimaryBase,
   SuccessBackgroundColor: theme.ColorBackgroundSuccessLight,
+  SuccessBorderColor: theme.ColorBackgroundSuccessBase,
+  SuccessIconColor: theme.ColorSuccessBase,
 });

--- a/packages/odyssey-react/src/components/Infobox/Infobox.tsx
+++ b/packages/odyssey-react/src/components/Infobox/Infobox.tsx
@@ -15,7 +15,6 @@ import type { ComponentPropsWithRef, ReactNode } from "react";
 import { withTheme } from "@okta/odyssey-react-theme";
 import { useCx, useOmit } from "../../utils";
 import { Box } from "../Box";
-import { Heading } from "../Heading";
 import { Text } from "../Text";
 import {
   AlertCircleFilledIcon,
@@ -99,7 +98,7 @@ export const Infobox = withTheme(
         <span className={styles.icon}>{icon[variant]}</span>
 
         <section className={styles.content}>
-          {heading && <Heading visualLevel="6" children={heading} />}
+          {heading && <h1 className={styles.heading}>{heading}</h1>}
           {content && <Text>{content}</Text>}
         </section>
 

--- a/packages/odyssey-storybook/src/components/Infobox/Infobox.stories.tsx
+++ b/packages/odyssey-storybook/src/components/Infobox/Infobox.stories.tsx
@@ -74,6 +74,4 @@ Success.args = {
   variant: "success",
 };
 
-export const HeadingOnly = (): ReactElement => <Infobox heading="Heading" />;
-
 export const ContentOnly = (): ReactElement => <Infobox content={content} />;


### PR DESCRIPTION
### Description

This PR makes Banner IE11-friendly and updates our styles to match the most recent design. Changes to the component itself reflect pattern-matching with the related Toast and Banner components.

### Screenshots

#### FF

<img width="498" alt="Screen Shot 2022-03-11 at 11 10 59 AM" src="https://user-images.githubusercontent.com/36284167/157936173-7aed1397-7337-43d1-8ba7-572ec5321153.png">
<img width="498" alt="Screen Shot 2022-03-11 at 11 09 25 AM" src="https://user-images.githubusercontent.com/36284167/157936174-aa9d13f3-2808-4b96-a8fa-1719210c132f.png">

#### IE11

<img width="435" alt="Screen Shot 2022-03-11 at 11 09 18 AM" src="https://user-images.githubusercontent.com/36284167/157936200-0003c659-a67e-433d-95ea-673f00160239.png">
