### PR TITLE
Description List: IE11-friendly

### DIFF
--- a/packages/odyssey-ie-11-sandbox/src/App.tsx
+++ b/packages/odyssey-ie-11-sandbox/src/App.tsx
@@ -249,7 +249,7 @@ export default function App(): JSX.Element {
         descriptor="List"
         label="Status Label"
         labelHidden
-        variant="danger"
+        variant="success"
       />
       <ErrorBoundary>
         <List listType="unordered">

--- a/packages/odyssey-react/src/components/List/List.module.scss
+++ b/packages/odyssey-react/src/components/List/List.module.scss
@@ -65,7 +65,7 @@
   margin-inline-start: 0;
   padding-inline-start: var(--DescriptionColumnGap);
 
-  &+& {
+  & + & {
     margin-inline-start: 25%;
   }
 

--- a/packages/odyssey-react/src/components/List/List.module.scss
+++ b/packages/odyssey-react/src/components/List/List.module.scss
@@ -44,11 +44,10 @@
 }
 
 .description {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(min-content, max-content));
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
   padding-inline: 0;
-  column-gap: var(--DescriptionColumnGap);
-  row-gap: var(--DescriptionRowGap);
 
   &:last-child {
     margin-block-end: 0;
@@ -56,12 +55,23 @@
 }
 
 .term {
-  grid-column: 1/1;
+  flex: 0 0 25%;
 }
 
 .details {
+  flex: 75% 0 0;
+  max-width: 75%;
+  margin-block-end: var(--DescriptionRowGap);
   margin-inline-start: 0;
-  grid-column: 2/2;
+  padding-inline-start: var(--DescriptionColumnGap);
+
+  &+& {
+    margin-inline-start: 25%;
+  }
+
+  &:last-child {
+    margin-block-end: 0;
+  }
 }
 
 .unstyled {


### PR DESCRIPTION
### Description

This updates `dl` to be IE11-friendly.

### Screenshots

#### IE

<img width="182" alt="Screen Shot 2022-03-11 at 12 15 40 PM" src="https://user-images.githubusercontent.com/36284167/157954566-f6ac7775-4e19-4fc3-b2a4-6649ea0fbbab.png">

#### FF

<img width="222" alt="Screen Shot 2022-03-11 at 12 15 45 PM" src="https://user-images.githubusercontent.com/36284167/157954590-11bb2982-e8d1-4da0-8063-b30f85d4c0b5.png">
