### PR TITLE
Update Link variant names

### DIFF
--- a/packages/odyssey-react/src/components/Link/Link.module.scss
+++ b/packages/odyssey-react/src/components/Link/Link.module.scss
@@ -45,15 +45,15 @@
 
 /* Variant */
 
-.secondaryVariant {
-  color: var(--SecondaryTextColor);
+.monochromeVariant {
+  color: var(--MonochromeTextColor);
   text-decoration: underline;
 
   &:hover {
-    color: var(--SecondaryTextColor);
+    color: var(--MonochromeTextColor);
   }
 
   &:visited {
-    color: var(--SecondaryTextColor);
+    color: var(--MonochromeTextColor);
   }
 }

--- a/packages/odyssey-react/src/components/Link/Link.test.tsx
+++ b/packages/odyssey-react/src/components/Link/Link.test.tsx
@@ -110,7 +110,7 @@ describe("Link", () => {
   a11yCheck(() => render(<Link href={href}>{children}</Link>));
   a11yCheck(() =>
     render(
-      <Link href={href} variant="secondary">
+      <Link href={href} variant="monochrome">
         {children}
       </Link>
     )

--- a/packages/odyssey-react/src/components/Link/Link.theme.ts
+++ b/packages/odyssey-react/src/components/Link/Link.theme.ts
@@ -15,11 +15,11 @@ import type { ThemeReducer } from "@okta/odyssey-react-theme";
 export const theme: ThemeReducer = (theme) => ({
   BorderRadius: theme.BorderRadiusBase,
 
-  // Primary Variant
+  // Default Variant
   TextColor: theme.ColorTextPrimary,
 
-  // Secondary Variant
-  SecondaryTextColor: theme.ColorTextBody,
+  // Monochrome Variant
+  MonochromeTextColor: theme.ColorTextBody,
 
   // Focus
   FocusOutlineColor: theme.FocusOutlineColorPrimary,

--- a/packages/odyssey-react/src/components/Link/Link.tsx
+++ b/packages/odyssey-react/src/components/Link/Link.tsx
@@ -31,9 +31,9 @@ export interface LinkProps
 
   /**
    * The visual variant to be displayed to the user.
-   * @default primary
+   * @default default
    */
-  variant?: "primary" | "secondary";
+  variant?: "default" | "monochrome";
 
   /**
    * The human readable/perceivable value shown to the user
@@ -54,7 +54,7 @@ export const Link = withTheme(
   styles
 )(
   forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
-    const { children, variant = "primary", icon, ...rest } = props;
+    const { children, variant = "default", icon, ...rest } = props;
     const classNames = useCx(styles.root, styles[`${variant}Variant`]);
     const omitProps = useOmit(rest);
     const external = rest.target === `_blank`;

--- a/packages/odyssey-storybook/src/components/Banner/Banner.stories.tsx
+++ b/packages/odyssey-storybook/src/components/Banner/Banner.stories.tsx
@@ -68,7 +68,7 @@ const Template: Story<BannerProps> = (props) => {
 
   return (
     <Banner {...props} {...dismissProps}>
-      <Link variant="secondary" href="https://www.okta.com">
+      <Link variant="monochrome" href="https://www.okta.com">
         Action Link
       </Link>
     </Banner>

--- a/packages/odyssey-storybook/src/components/Infobox/Infobox.stories.tsx
+++ b/packages/odyssey-storybook/src/components/Infobox/Infobox.stories.tsx
@@ -40,7 +40,7 @@ export default {
 const content =
   "An infobox is a type of alert that provides feedback in response to a user action or system activity.";
 const actions = (
-  <Link href="https://ww.okta.com" variant="secondary">
+  <Link href="https://ww.okta.com" variant="monochrome">
     Link to associated action
   </Link>
 );

--- a/packages/odyssey-storybook/src/components/Link/Link.stories.tsx
+++ b/packages/odyssey-storybook/src/components/Link/Link.stories.tsx
@@ -56,17 +56,17 @@ Default.args = {
   children: "Anchor link",
 };
 
-export const Secondary = Template.bind({});
-Secondary.args = {
+export const Monochrome = Template.bind({});
+Monochrome.args = {
   href: "#anchor",
-  variant: "secondary",
-  children: "Secondary link",
+  variant: "monochrome",
+  children: "Monochrome link",
 };
 
 export const WithIcon = Template.bind({});
 WithIcon.args = {
   href: "#anchor",
-  children: "Secondary link",
+  children: "Monochrome link",
   icon: <InformationCircleFilledIcon />,
 };
 


### PR DESCRIPTION
### Description

Updates Link variant names: "primary" is now "default"; "secondary" is now "monochrome".