### PR TITLE
feat(browserslist-config-odyssey): expose development and test configs

### DIFF
--- a/packages/browserslist-config-odyssey/index.ts
+++ b/packages/browserslist-config-odyssey/index.ts
@@ -31,6 +31,8 @@ const config = {
   ie11,
   modern,
   production: all,
+  development: modern,
+  test: modern,
 };
 
 module.exports = config;


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

This PR exposes two new browserslist configs that can be activated without any explicit config via conventional `NODE_ENV` values of `development` and `test`. Under this approach, a standard `create-react-app` workflow will compile successfully. Using the configuration as it stood before (defaulting to `production`/`all`) create-react-app could not start the development server.

This change **could** lead to broken builds in test or development environments for downstream teams who previously cared about exercising ie11 in those environments. To work around this they'll now need to set an explicit `BROWSERSLIST_ENV` value to `all` or `production`
