### PR TITLE
refactor(odyssey-react): extends max-width for Banner content

### DIFF
--- a/packages/odyssey-react/src/components/Banner/Banner.module.scss
+++ b/packages/odyssey-react/src/components/Banner/Banner.module.scss
@@ -32,8 +32,8 @@
 }
 
 .content {
-  max-width: 100%;
-  margin-block-end: 0;
+  max-width: calc(var(--MaxLineLength) * 2);
+  margin-block: 0;
   margin-inline-end: var(--ContentMarginInlineEnd);
 }
 

--- a/packages/odyssey-react/src/components/Banner/Banner.theme.ts
+++ b/packages/odyssey-react/src/components/Banner/Banner.theme.ts
@@ -24,7 +24,7 @@ export const theme: ThemeReducer = (theme) => ({
   IconMarginInlineEnd: theme.SpaceScale3,
   IconSize: theme.FontSizeHeading5,
 
-  HeadingMarginInlineEnd: theme.SpaceScale0,
+  HeadingMarginInlineEnd: theme.SpaceScale1,
   HeadingMobileMarginBlockEnd: theme.SpaceScale0,
 
   ContentMarginInlineEnd: theme.SpaceScale3,

--- a/packages/odyssey-react/src/components/Banner/Banner.tsx
+++ b/packages/odyssey-react/src/components/Banner/Banner.tsx
@@ -17,7 +17,6 @@ import { useCx, useOmit } from "../../utils";
 import { Box } from "../Box";
 import { Heading } from "../Heading";
 import { Button } from "../Button";
-import { Text } from "../Text";
 import type { ButtonProps } from "../Button";
 import {
   AlertTriangleFilledIcon,
@@ -114,16 +113,8 @@ export const Banner = withTheme(
             <Heading visualLevel="6" noEndMargin children={heading} />
           </div>
         )}
-        {content && (
-          <span className={styles.content}>
-            <Text as="p" children={content} />
-          </span>
-        )}
-        {children && (
-          <section className={styles.actions}>
-            <Text>{children}</Text>
-          </section>
-        )}
+        {content && <p className={styles.content}>{content}</p>}
+        {children && <section className={styles.actions}>{children}</section>}
         {onDismiss && (
           <span className={styles.dismissButton}>
             <Button


### PR DESCRIPTION
### Description

Extends the `max-width` for Banner to `MaxLineLength * 2`. For now, this is not accessible via a unique theme variable, as we do not want folks re-theming their Banner layout.