### PR TITLE
Fix: Table sort indication overlaps label with multiple icons for unsorted

### DIFF
--- a/packages/odyssey-react/src/components/Table/TableSortButton.module.scss
+++ b/packages/odyssey-react/src/components/Table/TableSortButton.module.scss
@@ -16,7 +16,9 @@
   width: 100%;
   padding-block: 0;
   padding-inline-start: 0;
-  padding-inline-end: calc(2em + var(--PaddingInlineEnd));
+  padding-inline-end: calc(
+    (2 * var(--SortIndicatorFontSize)) + var(--PaddingInlineEnd)
+  );
   border: 0;
   background: none;
   font-family: inherit;

--- a/packages/odyssey-react/src/components/Table/TableSortButton.module.scss
+++ b/packages/odyssey-react/src/components/Table/TableSortButton.module.scss
@@ -16,7 +16,7 @@
   width: 100%;
   padding-block: 0;
   padding-inline-start: 0;
-  padding-inline-end: calc(1em + var(--PaddingInlineEnd));
+  padding-inline-end: calc(2em + var(--PaddingInlineEnd));
   border: 0;
   background: none;
   font-family: inherit;


### PR DESCRIPTION
### Description

Updates our styles to account for there now being two icons in the Sort button; now uses `--SortIndicatorFontSize` rather than a magic `em` to set the width.

<img width="417" alt="Screen Shot 2022-03-28 at 9 48 33 AM" src="https://user-images.githubusercontent.com/36284167/160447575-c779b2b8-824b-4d82-aa6e-10f60f13e208.png">

https://oktainc.atlassian.net/browse/OKTA-481541