### PR TITLE
fix(odyssey-react): Link Icons now match text height

### DIFF
--- a/packages/odyssey-react/src/components/Link/Link.module.scss
+++ b/packages/odyssey-react/src/components/Link/Link.module.scss
@@ -33,13 +33,18 @@
   }
 }
 
-.indicator {
+.indicator,
+.icon {
   display: inline-block;
+  height: 1em;
+  line-height: 1;
+}
+
+.indicator {
   margin-inline-start: var(--IndicatorMarginInlineStart);
 }
 
 .icon {
-  display: inline-block;
   margin-inline-end: var(--IconMarginInlineEnd);
 }
 


### PR DESCRIPTION
### Description

Fixes https://oktainc.atlassian.net/browse/OKTA-481515 by ensuring Link Icons/Indicators are constrained to their associated text height. This was a Chrome-only bug--Safari and Firefox remain 💯 after the fix.

#### Before

<img width="202" alt="Screen Shot 2022-03-21 at 1 16 48 PM" src="https://user-images.githubusercontent.com/36284167/160669641-3105dfab-5138-49ed-99ba-69986df1d85d.png">

#### After

<img width="138" alt="Screen Shot 2022-03-29 at 10 17 32 AM" src="https://user-images.githubusercontent.com/36284167/160669630-ecd12a2c-026b-4593-aa4a-97050f41e089.png">
<img width="158" alt="Screen Shot 2022-03-29 at 10 17 26 AM" src="https://user-images.githubusercontent.com/36284167/160669635-7601edb8-29ee-4482-a19b-fadf86f168ab.png">
