### PR TITLE
feat(odyssey-react): add prefix and suffix text props to TextInput component

### DIFF
--- a/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
@@ -75,7 +75,7 @@
 
 .prefix,
 .suffix {
-  color: var(--StaticTextColor);
+  color: var(--AffixTextColor);
   cursor: default;
 }
 
@@ -87,6 +87,11 @@
   padding-inline-start: var(--PaddingInline);
 }
 
+.affixIcon {
+  font-size: var(--IconSize);
+  line-height: 1;
+}
+
 // Strips away the browser defaults from the input to make it as invisible as possible.
 .input {
   flex: 1;
@@ -95,6 +100,7 @@
   padding-block: 0;
   padding-inline: 0;
   border: 0;
+  font: inherit;
 
   &:focus {
     outline: 0;

--- a/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
@@ -13,8 +13,7 @@
 .root {
   @include border-radius(var(--BorderRadius));
 
-  display: block;
-  position: relative;
+  display: flex;
   width: 100%;
   max-width: var(--MaxWidth);
   margin-block: var(--MarginBlock);
@@ -34,11 +33,11 @@
   line-height: var(--LineHeight);
 
   &:hover,
-  &:focus {
+  &:focus-within {
     border-color: var(--HoverFocusBorderColor);
   }
 
-  &:focus {
+  &:focus-within {
     outline-color: var(--FocusOutlineColor);
     outline-offset: var(--FocusOutlineOffset);
     outline-style: var(--FocusOutlineStyle);
@@ -65,7 +64,7 @@
     }
   }
 
-  &:invalid:focus {
+  &:invalid:focus-within {
     outline-color: var(--InvalidFocusOutlineColor);
   }
 
@@ -81,16 +80,26 @@
   }
 }
 
-.outer {
-  position: relative;
+.prefix {
+  color: var(--PrefixTextColor);
+  padding-inline-end: var(--PaddingInline);
 }
 
-.indicator {
-  position: absolute;
-  inset-block-start: 50%;
-  inset-inline-start: var(--IndicatorInsetInlineStart);
-  transform: translateY(-50%);
-  font-size: var(--IndicatorSize);
-  line-height: 1;
-  pointer-events: none;
+.suffix {
+  color: var(--SuffixTextColor);
+  padding-inline-start: var(--PaddingInline);
+}
+
+// Strips away the browser defaults from the input to make it as invisible as possible.
+.input {
+  flex: 1;
+  margin-block: 0;
+  margin-inline: 0;
+  padding-block: 0;
+  padding-inline: 0;
+  border: 0;
+
+  &:focus {
+    outline: 0;
+  }
 }

--- a/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
@@ -63,11 +63,12 @@
   &::placeholder {
     color: var(--PlaceholderTextColor);
   }
-}
 
-.invalid {
-  border-color: var(--InvalidBorderColor);
-  &:focus-within {
+  &.invalid {
+    border-color: var(--InvalidBorderColor);
+  }
+
+  &.invalid:focus-within {
     outline-color: var(--InvalidFocusOutlineColor);
   }
 }

--- a/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
@@ -44,10 +44,6 @@
     outline-width: var(--FocusOutlineWidth);
   }
 
-  &:invalid {
-    border-color: var(--InvalidBorderColor);
-  }
-
   &:disabled {
     opacity: 1;
     color: var(--DisabledTextColor);
@@ -64,12 +60,15 @@
     }
   }
 
-  &:invalid:focus-within {
-    outline-color: var(--InvalidFocusOutlineColor);
-  }
-
   &::placeholder {
     color: var(--PlaceholderTextColor);
+  }
+}
+
+.invalid {
+  border-color: var(--InvalidBorderColor);
+  &:focus-within {
+    outline-color: var(--InvalidFocusOutlineColor);
   }
 }
 

--- a/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
@@ -73,7 +73,8 @@
   }
 }
 
-.decoration {
+.prefix,
+.suffix {
   color: var(--StaticTextColor);
   cursor: default;
 }

--- a/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
@@ -71,22 +71,18 @@
   &::placeholder {
     color: var(--PlaceholderTextColor);
   }
+}
 
-  &[type="search"] {
-    padding-inline-start: calc(
-      var(--IndicatorSize) + var(--IndicatorInsetInlineStart) +
-        var(--SearchPaddingInlineStart)
-    );
-  }
+.decoration {
+  color: var(--StaticTextColor);
+  cursor: default;
 }
 
 .prefix {
-  color: var(--PrefixTextColor);
   padding-inline-end: var(--PaddingInline);
 }
 
 .suffix {
-  color: var(--SuffixTextColor);
   padding-inline-start: var(--PaddingInline);
 }
 

--- a/packages/odyssey-react/src/components/TextInput/TextInput.test.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.test.tsx
@@ -167,7 +167,7 @@ describe("TextInput", () => {
     expect(suffixElement.className).toEqual("suffix");
   });
 
-  it.only("doesn't render the prefix if type is search", () => {
+  it("doesn't render the prefix if type is search", () => {
     render(<TextInput label={label} prefix="test prefix" type="search" />);
     expect(screen.queryByText("test prefix")).toBeNull();
     expect(screen.getByLabelText(label)).toHaveAttribute("type", "search");

--- a/packages/odyssey-react/src/components/TextInput/TextInput.test.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.test.tsx
@@ -20,6 +20,19 @@ const textBox = "textbox";
 const label = "Destination";
 
 describe("TextInput", () => {
+  beforeEach(() => {
+    jest
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        callback(0);
+        return 0;
+      });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("renders into the document", () => {
     render(<TextInput label={label} />);
 
@@ -157,20 +170,44 @@ describe("TextInput", () => {
     render(<TextInput label={label} prefix="test prefix" />);
     const prefixElement = screen.getByText("test prefix");
     expect(prefixElement).toBeInTheDocument();
-    expect(prefixElement.className).toEqual("prefix");
+    expect(prefixElement.className).toContain("prefix");
   });
 
   it("renders the suffix", () => {
     render(<TextInput label={label} suffix="test suffix" />);
     const suffixElement = screen.getByText("test suffix");
     expect(suffixElement).toBeInTheDocument();
-    expect(suffixElement.className).toEqual("suffix");
+    expect(suffixElement.className).toContain("suffix");
   });
 
-  it("doesn't render the prefix if type is search", () => {
-    render(<TextInput label={label} prefix="test prefix" type="search" />);
+  it("doesn't render the prefix or suffix if type is search", () => {
+    render(
+      <TextInput
+        label={label}
+        prefix="test prefix"
+        type="search"
+        suffix="test suffix"
+      />
+    );
     expect(screen.queryByText("test prefix")).toBeNull();
+    expect(screen.queryByText("test suffix")).toBeNull();
     expect(screen.getByLabelText(label)).toHaveAttribute("type", "search");
+  });
+
+  it("gives the input focus when prefix is clicked", () => {
+    render(<TextInput label={label} prefix="test prefix" />);
+    const prefixElement = screen.getByText("test prefix");
+    prefixElement.click();
+    const inputElement = screen.getByRole(textBox);
+    expect(inputElement).toHaveFocus();
+  });
+
+  it("gives the  input focus when suffix is clicked", () => {
+    render(<TextInput label={label} suffix="test suffix" />);
+    const prefixElement = screen.getByText("test suffix");
+    prefixElement.click();
+    const inputElement = screen.getByRole(textBox);
+    expect(inputElement).toHaveFocus();
   });
 
   a11yCheck(() => render(<TextInput label="foo" />));

--- a/packages/odyssey-react/src/components/TextInput/TextInput.test.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.test.tsx
@@ -153,5 +153,25 @@ describe("TextInput", () => {
     expect(ref).toHaveBeenLastCalledWith(screen.getByRole(textBox));
   });
 
+  it("renders the prefix", () => {
+    render(<TextInput label={label} prefix="test prefix" />);
+    const prefixElement = screen.getByText("test prefix");
+    expect(prefixElement).toBeInTheDocument();
+    expect(prefixElement.className).toEqual("prefix");
+  });
+
+  it("renders the suffix", () => {
+    render(<TextInput label={label} suffix="test suffix" />);
+    const suffixElement = screen.getByText("test suffix");
+    expect(suffixElement).toBeInTheDocument();
+    expect(suffixElement.className).toEqual("suffix");
+  });
+
+  it.only("doesn't render the prefix if type is search", () => {
+    render(<TextInput label={label} prefix="test prefix" type="search" />);
+    expect(screen.queryByText("test prefix")).toBeNull();
+    expect(screen.getByLabelText(label)).toHaveAttribute("type", "search");
+  });
+
   a11yCheck(() => render(<TextInput label="foo" />));
 });

--- a/packages/odyssey-react/src/components/TextInput/TextInput.test.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.test.tsx
@@ -180,20 +180,6 @@ describe("TextInput", () => {
     expect(suffixElement.className).toContain("suffix");
   });
 
-  it("doesn't render the prefix or suffix if type is search", () => {
-    render(
-      <TextInput
-        label={label}
-        prefix="test prefix"
-        type="search"
-        suffix="test suffix"
-      />
-    );
-    expect(screen.queryByText("test prefix")).toBeNull();
-    expect(screen.queryByText("test suffix")).toBeNull();
-    expect(screen.getByLabelText(label)).toHaveAttribute("type", "search");
-  });
-
   it("gives the input focus when prefix is clicked", () => {
     render(<TextInput label={label} prefix="test prefix" />);
     const prefixElement = screen.getByText("test prefix");

--- a/packages/odyssey-react/src/components/TextInput/TextInput.theme.ts
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.theme.ts
@@ -13,6 +13,7 @@
 import type { ThemeReducer } from "@okta/odyssey-react-theme";
 
 export const theme: ThemeReducer = (theme) => ({
+  AffixTextColor: theme.ColorTextSub,
   BackgroundColor: theme.ColorBackgroundBase,
   BorderColor: theme.ColorBorderUi,
   BorderRadius: theme.BorderRadiusBase,
@@ -28,8 +29,7 @@ export const theme: ThemeReducer = (theme) => ({
   FontFamily: theme.FontFamilyBase,
   FontSize: theme.FontSizeBody,
   HoverFocusBorderColor: theme.ColorPrimaryBase,
-  IndicatorInsetInlineStart: theme.SpaceScale1,
-  IndicatorSize: "1.1487rem",
+  IconSize: "1.1487rem",
   InvalidBorderColor: theme.ColorBorderDangerBase,
   InvalidFocusOutlineColor: theme.FocusOutlineColorDanger,
   LineHeight: theme.FontLineHeightUi,
@@ -39,7 +39,6 @@ export const theme: ThemeReducer = (theme) => ({
   PaddingBlock: theme.SpaceScale1,
   PaddingInline: theme.SpaceScale1,
   PlaceholderTextColor: theme.ColorTextSub,
-  StaticTextColor: theme.ColorTextSub,
   TextColor: theme.ColorTextBody,
   TransitionDuration: theme.TransitionDurationBase,
   TransitionTimingFunction: theme.TransitionTimingBase,

--- a/packages/odyssey-react/src/components/TextInput/TextInput.theme.ts
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.theme.ts
@@ -39,12 +39,8 @@ export const theme: ThemeReducer = (theme) => ({
   PaddingBlock: theme.SpaceScale1,
   PaddingInline: theme.SpaceScale1,
   PlaceholderTextColor: theme.ColorTextSub,
+  StaticTextColor: theme.ColorTextSub,
   TextColor: theme.ColorTextBody,
   TransitionDuration: theme.TransitionDurationBase,
   TransitionTimingFunction: theme.TransitionTimingBase,
-
-  SearchPaddingInlineStart: theme.SpaceScale1,
-
-  PrefixTextColor: theme.ColorTextSub,
-  SuffixTextColor: theme.ColorTextSub,
 });

--- a/packages/odyssey-react/src/components/TextInput/TextInput.theme.ts
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.theme.ts
@@ -39,8 +39,12 @@ export const theme: ThemeReducer = (theme) => ({
   PaddingBlock: theme.SpaceScale1,
   PaddingInline: theme.SpaceScale1,
   PlaceholderTextColor: theme.ColorTextSub,
-  SearchPaddingInlineStart: theme.SpaceScale1,
   TextColor: theme.ColorTextBody,
   TransitionDuration: theme.TransitionDurationBase,
   TransitionTimingFunction: theme.TransitionTimingBase,
+
+  SearchPaddingInlineStart: theme.SpaceScale1,
+
+  PrefixTextColor: theme.ColorTextSub,
+  SuffixTextColor: theme.ColorTextSub,
 });

--- a/packages/odyssey-react/src/components/TextInput/TextInput.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.tsx
@@ -103,7 +103,7 @@ interface CommonProps
   onFocus?: FocusEventHandler<HTMLInputElement>;
 }
 
-interface SearchProps extends Omit<CommonProps, "type" | "prefix"> {
+interface SearchProps extends Omit<CommonProps, "type" | "prefix" | "suffix"> {
   type: "search";
   prefix?: never;
   suffix?: never;

--- a/packages/odyssey-react/src/components/TextInput/TextInput.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.tsx
@@ -154,7 +154,7 @@ export const TextInput = withTheme(
 
     useEffect(() => {
       setIsValid(checkInputValidity(internalRef));
-    }, [internalRef, required, type]);
+    }, [internalRef, required, type, value]);
 
     const setFocus = () => {
       requestAnimationFrame(() => {

--- a/packages/odyssey-react/src/components/TextInput/TextInput.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.tsx
@@ -165,10 +165,6 @@ export const TextInput = withTheme(
       !!error && `${oid}-error`
     );
 
-    const decoratedSuffix = useCx(styles.decoration, suffix && styles.suffix);
-
-    const decoratedPrefix = useCx(styles.decoration, prefix && styles.prefix);
-
     const ariaProps =
       hint || error
         ? {
@@ -189,7 +185,7 @@ export const TextInput = withTheme(
         <div className={styles.root}>
           {(prefix || isSearchTextInput) && (
             <span
-              className={decoratedPrefix}
+              className={styles.prefix}
               aria-hidden="true"
               onClick={setFocus}
             >
@@ -216,7 +212,7 @@ export const TextInput = withTheme(
           />
           {suffix && !isSearchTextInput && (
             <span
-              className={decoratedSuffix}
+              className={styles.suffix}
               aria-hidden="true"
               onClick={setFocus}
             >

--- a/packages/odyssey-react/src/components/TextInput/TextInput.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.tsx
@@ -172,6 +172,11 @@ export const TextInput = withTheme(
           }
         : {};
 
+    const prefixStyles = useCx(
+      styles.prefix,
+      isSearchTextInput && styles.affixIcon
+    );
+
     return (
       <Field
         error={error}
@@ -185,7 +190,7 @@ export const TextInput = withTheme(
         <div className={styles.root}>
           {(prefix || isSearchTextInput) && (
             <span
-              className={styles.prefix}
+              className={prefixStyles}
               aria-hidden="true"
               onClick={setFocus}
             >

--- a/packages/odyssey-react/src/components/TextInput/TextInput.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.tsx
@@ -177,6 +177,11 @@ export const TextInput = withTheme(
       isSearchTextInput && styles.affixIcon
     );
 
+    const rootStyles = useCx(
+      styles.root,
+      !internalRef.current?.checkValidity() && styles.invalid
+    );
+
     return (
       <Field
         error={error}
@@ -187,7 +192,7 @@ export const TextInput = withTheme(
         optionalLabel={optionalLabel}
         required={required}
       >
-        <div className={styles.root}>
+        <div className={rootStyles}>
           {(prefix || isSearchTextInput) && (
             <span
               className={prefixStyles}

--- a/packages/odyssey-react/src/components/TextInput/TextInput.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.tsx
@@ -24,7 +24,7 @@ import type { CommonFieldProps } from "../Field/types";
 import { theme } from "./TextInput.theme";
 import styles from "./TextInput.module.scss";
 
-export interface TextInputProps
+interface CommonProps
   extends CommonFieldProps,
     Omit<
       ComponentPropsWithRef<"input">,
@@ -39,7 +39,7 @@ export interface TextInputProps
    * The underlying input element type
    * @default text
    */
-  type?: "text" | "email" | "url" | "tel" | "search" | "password";
+  type?: "text" | "email" | "url" | "tel" | "password";
 
   /**
    * The underlying input element name attribute
@@ -102,6 +102,14 @@ export interface TextInputProps
    */
   onFocus?: FocusEventHandler<HTMLInputElement>;
 }
+
+interface SearchProps extends Omit<CommonProps, "type" | "prefix"> {
+  type: "search";
+  prefix?: never;
+  suffix?: never;
+}
+
+export type TextInputProps = CommonProps | SearchProps;
 
 /**
  * Text inputs allow users to edit and input data.

--- a/packages/odyssey-react/src/components/TextInput/TextInput.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.tsx
@@ -157,6 +157,10 @@ export const TextInput = withTheme(
       !!error && `${oid}-error`
     );
 
+    const decoratedSuffix = useCx(styles.decoration, suffix && styles.suffix);
+
+    const decoratedPrefix = useCx(styles.decoration, prefix && styles.prefix);
+
     const ariaProps =
       hint || error
         ? {
@@ -177,7 +181,7 @@ export const TextInput = withTheme(
         <div className={styles.root}>
           {(prefix || isSearchTextInput) && (
             <span
-              className={styles.prefix}
+              className={decoratedPrefix}
               aria-hidden="true"
               onClick={setFocus}
             >
@@ -202,9 +206,9 @@ export const TextInput = withTheme(
             defaultValue={defaultValue}
             value={value}
           />
-          {suffix && (
+          {suffix && !isSearchTextInput && (
             <span
-              className={styles.suffix}
+              className={decoratedSuffix}
               aria-hidden="true"
               onClick={setFocus}
             >

--- a/packages/odyssey-react/src/utils/useSharedRef.ts
+++ b/packages/odyssey-react/src/utils/useSharedRef.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
  *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
@@ -10,11 +10,21 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-export { cx, useCx } from "./cx";
-export { forwardRefWithStatics } from "./forwardRefWithStatics";
-export { oid, useOid } from "./oid";
-export { omit, useOmit } from "./omit";
-export { toCamelCase, toPascalCase } from "./convertCase";
-export { useFocus } from "./focusHandling";
-export type { PolymorphicForwardRef } from "./polymorphic";
-export { useSharedRef } from "./useSharedRef";
+import { ForwardedRef, RefObject, useEffect, useRef } from "react";
+
+export function useSharedRef<T>(ref?: ForwardedRef<T>): RefObject<T> {
+  const internalRef = useRef<T>(null);
+
+  useEffect(() => {
+    if (!ref) {
+      return;
+    }
+    if (typeof ref === "function") {
+      ref(internalRef.current);
+    } else {
+      ref.current = internalRef.current;
+    }
+  }, [ref, internalRef]);
+
+  return internalRef;
+}

--- a/packages/odyssey-react/src/utils/useSharedRef.ts
+++ b/packages/odyssey-react/src/utils/useSharedRef.ts
@@ -10,8 +10,12 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { ForwardedRef, RefObject, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
+import type { ForwardedRef, RefObject } from "react";
 
+/**
+ * hook to intercept and share a ref with an upstream client
+ */
 export function useSharedRef<T>(ref?: ForwardedRef<T>): RefObject<T> {
   const internalRef = useRef<T>(null);
 

--- a/packages/odyssey-storybook/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/odyssey-storybook/src/components/TextInput/TextInput.stories.tsx
@@ -45,6 +45,8 @@ export default {
     onChange: { control: false },
     onBlur: { control: false },
     onFocus: { control: false },
+    prefix: { control: "text" },
+    suffix: { control: "text" },
   },
 };
 
@@ -71,4 +73,19 @@ export const Search = Template.bind({});
 Search.args = {
   defaultValue: "Search Planets",
   type: "search",
+  prefix: "testing",
+};
+
+export const Prefix = Template.bind({});
+Prefix.args = {
+  label: "Phone Number",
+  type: "tel",
+  prefix: "+1",
+};
+
+export const Suffix = Template.bind({});
+Suffix.args = {
+  label: "Time til destination",
+  type: "text",
+  suffix: "minutes",
 };

--- a/packages/odyssey-storybook/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/odyssey-storybook/src/components/TextInput/TextInput.stories.tsx
@@ -73,7 +73,6 @@ export const Search = Template.bind({});
 Search.args = {
   defaultValue: "Search Planets",
   type: "search",
-  prefix: "testing",
 };
 
 export const Prefix = Template.bind({});


### PR DESCRIPTION
### Description

This PR exposes `prefix` and `suffix` string props for the `TextInput` component.
`prefix` insert a string before the input, `suffix` will append a string after the input
If the `TextInput` is `type="search"` then any prefix text will be ignored

## Screenshots
![image](https://user-images.githubusercontent.com/89409747/160716878-80d77613-09d4-4dc0-993e-8c160fd8777a.png)
