### PR TITLE
fix(odyssey-react): update Tab states to be more accessible

### DIFF
--- a/packages/odyssey-react/src/components/Tabs/Tabs.module.scss
+++ b/packages/odyssey-react/src/components/Tabs/Tabs.module.scss
@@ -29,10 +29,29 @@
   color: var(--TabTextColor);
   font-family: inherit;
   font-size: var(--TabFontSize);
-  font-weight: var(--TabFontWeight);
 
   &:last-child {
     margin-inline-end: 0;
+  }
+
+  &:hover,
+  &:focus {
+    color: var(--TabHoverTextColor);
+  }
+
+  &:focus {
+    outline: 0;
+  }
+}
+
+.label {
+  @include border-radius(var(--LabelBorderRadius));
+
+  .tab:focus & {
+    outline-color: var(--LabelFocusOutlineColor);
+    outline-offset: var(--LabelFocusOutlineOffset);
+    outline-style: var(--LabelFocusOutlineStyle);
+    outline-width: var(--LabelFocusOutlineWidth);
   }
 }
 
@@ -47,6 +66,9 @@
 
 /* Tab states */
 .selected {
+  color: var(--TabSelectedTextColor);
+  font-weight: var(--TabSelectedFontWeight);
+
   &::before {
     content: "";
     position: absolute;

--- a/packages/odyssey-react/src/components/Tabs/Tabs.test.tsx
+++ b/packages/odyssey-react/src/components/Tabs/Tabs.test.tsx
@@ -36,7 +36,10 @@ describe("Tabs", () => {
     );
 
     expect(getByText("TabPanel 1")).toBeVisible();
-    expect(getByText("Tab 1")).toHaveAttribute("aria-selected", "true");
+    expect(getByText("Tab 1").parentElement).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
     expect(getByRole(roleTabList)).toBeInTheDocument();
     expect(getByRole(roleTabPanel)).toBeInTheDocument();
   });
@@ -57,7 +60,10 @@ describe("Tabs", () => {
     );
 
     expect(getByText("TabPanel 2")).toBeVisible();
-    expect(getByText("Tab 2")).toHaveAttribute("aria-selected", "true");
+    expect(getByText("Tab 2").parentElement).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
   });
 
   it("changes the selected tabpanel when a tab is clicked", () => {
@@ -78,8 +84,14 @@ describe("Tabs", () => {
     fireEvent.click(getByText("Tab 3"));
 
     expect(getByText("TabPanel 3")).toBeVisible();
-    expect(getByText("Tab 3")).toHaveAttribute("aria-selected", "true");
-    expect(getByText("Tab 1")).toHaveAttribute("aria-selected", "false");
+    expect(getByText("Tab 3").parentElement).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+    expect(getByText("Tab 1").parentElement).toHaveAttribute(
+      "aria-selected",
+      "false"
+    );
   });
 
   it("should invoke the onTabChange callback when a different tab is selected", () => {
@@ -123,7 +135,7 @@ describe("Tabs", () => {
     fireEvent.keyUp(getByRole(roleTabList), { key: "End", code: "End" });
 
     await waitFor(() => {
-      expect(getByText("Tab 3")).toHaveFocus();
+      expect(getByText("Tab 3").parentElement).toHaveFocus();
     });
   });
 
@@ -146,7 +158,7 @@ describe("Tabs", () => {
     fireEvent.keyUp(getByRole(roleTabList), { key: "Home", code: "Home" });
 
     await waitFor(() => {
-      expect(getByText("Tab 1")).toHaveFocus();
+      expect(getByText("Tab 1").parentElement).toHaveFocus();
     });
   });
 
@@ -173,7 +185,7 @@ describe("Tabs", () => {
     });
 
     await waitFor(() => {
-      expect(getByText("Tab 1")).toHaveFocus();
+      expect(getByText("Tab 1").parentElement).toHaveFocus();
     });
   });
 
@@ -200,7 +212,7 @@ describe("Tabs", () => {
     });
 
     await waitFor(() => {
-      expect(getByText("Tab 3")).toHaveFocus();
+      expect(getByText("Tab 3").parentElement).toHaveFocus();
     });
   });
 

--- a/packages/odyssey-react/src/components/Tabs/Tabs.theme.ts
+++ b/packages/odyssey-react/src/components/Tabs/Tabs.theme.ts
@@ -37,5 +37,5 @@ export const theme: ThemeReducer = (theme) => ({
 
   TabSelectedBackgroundColor: theme.ColorPrimaryBase,
   TabSelectedFontWeight: theme.FontWeightBold,
-  TabSelectedTextColor: theme.ColorTextBody
+  TabSelectedTextColor: theme.ColorTextBody,
 });

--- a/packages/odyssey-react/src/components/Tabs/Tabs.theme.ts
+++ b/packages/odyssey-react/src/components/Tabs/Tabs.theme.ts
@@ -20,12 +20,22 @@ export const theme: ThemeReducer = (theme) => ({
   PanelPaddingBlock: theme.SpaceScale5,
   PanelPaddingInline: 0,
 
-  TabTextColor: theme.ColorPaletteNeutral900,
+  LabelBorderRadius: theme.BorderRadiusBase,
+  LabelFocusOutlineColor: theme.FocusOutlineColorPrimary,
+  LabelFocusOutlineOffset: theme.FocusOutlineOffsetBase,
+  LabelFocusOutlineStyle: theme.FocusOutlineStyle,
+  LabelFocusOutlineWidth: theme.FocusOutlineWidthTight,
+
+  TabTextColor: theme.ColorTextSub,
   TabFontSize: theme.FontSizeBody,
-  TabFontWeight: theme.FontWeightBold,
   TabMarginBlock: 0,
   TabMarginInline: theme.SpaceScale4,
   TabPaddingBlock: theme.SpaceScale3,
   TabPaddingInline: 0,
+
+  TabHoverTextColor: theme.ColorPrimaryBase,
+
   TabSelectedBackgroundColor: theme.ColorPrimaryBase,
+  TabSelectedFontWeight: theme.FontWeightBold,
+  TabSelectedTextColor: theme.ColorTextBody
 });

--- a/packages/odyssey-react/src/components/Tabs/Tabs.tsx
+++ b/packages/odyssey-react/src/components/Tabs/Tabs.tsx
@@ -211,7 +211,7 @@ const Tab = function TabsTab({
       fontSize={false}
       fontWeight={false}
     >
-      {children}
+      <span className={styles.label}>{children}</span>
     </Box>
   );
 };


### PR DESCRIPTION
### Description

Addresses minor a11y issues for `:focus` and updates designs to match the latest from @josesolano-okta.

- Tabs are now Text, Sub in color unless Selected (then Primary, Base)
- Tabs are now normal weight unless Selected (then Bold)
- Hover state text is now in Primary, Base
- Focus state now happens at the label level instead of the label container and it is styled the same as a focused link

![tabs](https://user-images.githubusercontent.com/36284167/161320560-eb52dc88-87d8-408c-ad7c-a5890fd809fa.gif)