### PR TITLE
feat(odyssey-react): clear search text

### DIFF
--- a/packages/odyssey-react/src/components/Button/Button.module.scss
+++ b/packages/odyssey-react/src/components/Button/Button.module.scss
@@ -174,26 +174,26 @@
 
 .affixVariant {
   border: 0;
-  background-color: var(--ClearBackgroundColor);
-  color: var(--ClearTextColor);
+  background-color: var(--AffixBackgroundColor);
+  color: var(--AffixTextColor);
   line-height: 1;
-  padding-block: 0;
-  padding-inline: 0;
+  padding-block: var(--AffixPadding);
+  padding-inline: var(--AffixPadding);
 
   &:hover {
-    border-color: var(--ClearHoverBorderColor);
-    background-color: var(--ClearHoverBackgroundColor);
-    color: var(--ClearHoverTextColor);
+    border-color: var(--AffixHoverBorderColor);
+    background-color: var(--AffixHoverBackgroundColor);
+    color: var(--AffixHoverTextColor);
   }
 
   &:focus {
-    background-color: var(--ClearFocusBackgroundColor);
-    color: var(--ClearFocusTextColor);
+    background-color: var(--AffixFocusBackgroundColor);
+    color: var(--AffixFocusTextColor);
   }
 
   &:disabled {
-    background-color: var(--ClearDisabledBackgroundColor);
-    color: var(--ClearDisabledTextColor);
+    background-color: var(--AffixDisabledBackgroundColor);
+    color: var(--AffixDisabledTextColor);
   }
 }
 

--- a/packages/odyssey-react/src/components/Button/Button.module.scss
+++ b/packages/odyssey-react/src/components/Button/Button.module.scss
@@ -172,6 +172,31 @@
   }
 }
 
+.affixVariant {
+  border: 0;
+  background-color: var(--ClearBackgroundColor);
+  color: var(--ClearTextColor);
+  line-height: 1;
+  padding-block: 0;
+  padding-inline: 0;
+
+  &:hover {
+    border-color: var(--ClearHoverBorderColor);
+    background-color: var(--ClearHoverBackgroundColor);
+    color: var(--ClearHoverTextColor);
+  }
+
+  &:focus {
+    background-color: var(--ClearFocusBackgroundColor);
+    color: var(--ClearFocusTextColor);
+  }
+
+  &:disabled {
+    background-color: var(--ClearDisabledBackgroundColor);
+    color: var(--ClearDisabledTextColor);
+  }
+}
+
 /* Layouts */
 
 .wideLayout {

--- a/packages/odyssey-react/src/components/Button/Button.theme.ts
+++ b/packages/odyssey-react/src/components/Button/Button.theme.ts
@@ -96,6 +96,18 @@ export const theme: ThemeReducer = (theme) => ({
   ClearHoverTextColor: theme.ColorPaletteBlue900,
   ClearTextColor: theme.ColorPrimaryBase,
 
+  // Affix Variant
+  AffixBackgroundColor: "transparent",
+  AffixDisabledBackgroundColor: "transparent",
+  AffixDisabledTextColor: theme.ColorPaletteNeutral500,
+  AffixFocusBackgroundColor: theme.ColorPaletteNeutral200,
+  AffixFocusTextColor: theme.ColorTextBody,
+  AffixHoverBackgroundColor: theme.ColorPaletteNeutral200,
+  AffixHoverBorderColor: "transparent",
+  AffixHoverTextColor: theme.ColorTextBody,
+  AffixPadding: theme.SpaceScale0,
+  AffixTextColor: theme.ColorTextBody,
+
   // Wide Layout
   WideLayoutMarginBlock: 0,
   WideLayoutMarginBlockEnd: theme.SpaceScale3,

--- a/packages/odyssey-react/src/components/Button/Button.tsx
+++ b/packages/odyssey-react/src/components/Button/Button.tsx
@@ -49,7 +49,8 @@ interface CommonProps
     | "danger"
     | "dismiss"
     | "dismissInverted"
-    | "clear";
+    | "clear"
+    | "affix";
 
   /**
    * Extends the width of the button to that of its' parent.
@@ -65,7 +66,15 @@ interface IconProps extends CommonProps {
   icon: ReactElement;
 }
 
-export type ButtonProps = IconProps | ChildrenProps;
+interface AffixProps
+  extends Omit<CommonProps, "variant" | "children" | "icon" | "size"> {
+  variant: "affix";
+  children: never;
+  icon: ReactElement;
+  size: "s";
+}
+
+export type ButtonProps = IconProps | ChildrenProps | AffixProps;
 
 /**
  * A clickable button used for form submissions and most in-page interactions.

--- a/packages/odyssey-react/src/components/Link/Link.module.scss
+++ b/packages/odyssey-react/src/components/Link/Link.module.scss
@@ -33,13 +33,18 @@
   }
 }
 
-.indicator {
+.indicator,
+.icon {
   display: inline-block;
+  height: 1em;
+  line-height: 1;
+}
+
+.indicator {
   margin-inline-start: var(--IndicatorMarginInlineStart);
 }
 
 .icon {
-  display: inline-block;
   margin-inline-end: var(--IconMarginInlineEnd);
 }
 

--- a/packages/odyssey-react/src/components/Table/TableSortButton.module.scss
+++ b/packages/odyssey-react/src/components/Table/TableSortButton.module.scss
@@ -16,7 +16,9 @@
   width: 100%;
   padding-block: 0;
   padding-inline-start: 0;
-  padding-inline-end: calc(1em + var(--PaddingInlineEnd));
+  padding-inline-end: calc(
+    (2 * var(--SortIndicatorFontSize)) + var(--PaddingInlineEnd)
+  );
   border: 0;
   background: none;
   font-family: inherit;

--- a/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
@@ -87,21 +87,20 @@
   padding-inline-start: var(--PaddingInline);
 }
 
-.clear {
+.affixHidden {
   display: none;
-  padding-inline-start: var(--PaddingInline);
 }
 
 // stylelint-disable-next-line selector-max-type
-.clear button {
+.affixHidden button {
   padding-block: 0;
   padding-inline: 0;
   border: 0;
   line-height: 1;
 }
 
-.root:hover .clear,
-.root:focus-within .clear {
+.root:hover .affixHidden,
+.root:focus-within .affixHidden {
   display: block;
 }
 

--- a/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
@@ -88,20 +88,12 @@
 }
 
 .affixHidden {
-  display: none;
-}
-
-// stylelint-disable-next-line selector-max-type
-.affixHidden button {
-  padding-block: 0;
-  padding-inline: 0;
-  border: 0;
-  line-height: 1;
+  opacity: 0;
 }
 
 .root:hover .affixHidden,
 .root:focus-within .affixHidden {
-  display: block;
+  opacity: 1;
 }
 
 .affixIcon {

--- a/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
@@ -18,8 +18,6 @@
   max-width: var(--MaxWidth);
   margin-block: var(--MarginBlock);
   margin-inline: var(--MarginInline);
-  padding-block: calc(var(--PaddingBlock) - var(--BorderWidth));
-  padding-inline: var(--PaddingInline);
   transition-property: border-color, background-color;
   transition-duration: var(--TransitionDuration);
   transition-timing-function: var(--TransitionTimingFunction);
@@ -75,20 +73,26 @@
 
 .prefix,
 .suffix {
+  padding-block: calc(var(--PaddingBlock) - var(--BorderWidth));
   color: var(--AffixTextColor);
   cursor: default;
 }
 
 .prefix {
-  padding-inline-end: var(--PaddingInline);
+  padding-inline-start: var(--PaddingInline);
 }
 
 .suffix {
-  padding-inline-start: var(--PaddingInline);
+  padding-inline-end: var(--PaddingInline);
 }
 
 .affixHidden {
   opacity: 0;
+}
+
+.affixFull {
+  padding-block: var(--AffixPadding);
+  padding-inline-end: var(--AffixPadding);
 }
 
 .root:hover .affixHidden,
@@ -106,14 +110,16 @@
   flex: 1;
   margin-block: 0;
   margin-inline: 0;
-  padding-block: 0;
-  padding-inline: 0;
+  padding-block: calc(var(--PaddingBlock) - var(--BorderWidth));
+  padding-inline: var(--PaddingInline);
   border: 0;
+  background-color: transparent;
   font: inherit;
 
   &:focus {
     outline: 0;
   }
+
   &[type="search"] {
     &::-webkit-search-decoration,
     &::-webkit-search-cancel-button,

--- a/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
@@ -44,10 +44,6 @@
     outline-width: var(--FocusOutlineWidth);
   }
 
-  &:invalid {
-    border-color: var(--InvalidBorderColor);
-  }
-
   &:disabled {
     opacity: 1;
     color: var(--DisabledTextColor);
@@ -64,18 +60,22 @@
     }
   }
 
-  &:invalid:focus-within {
-    outline-color: var(--InvalidFocusOutlineColor);
-  }
-
   &::placeholder {
     color: var(--PlaceholderTextColor);
+  }
+
+  &.invalid {
+    border-color: var(--InvalidBorderColor);
+  }
+
+  &.invalid:focus-within {
+    outline-color: var(--InvalidFocusOutlineColor);
   }
 }
 
 .prefix,
 .suffix {
-  color: var(--StaticTextColor);
+  color: var(--AffixTextColor);
   cursor: default;
 }
 
@@ -104,6 +104,11 @@
   display: block;
 }
 
+.affixIcon {
+  font-size: var(--IconSize);
+  line-height: 1;
+}
+
 // Strips away the browser defaults from the input to make it as invisible as possible.
 .input {
   flex: 1;
@@ -112,6 +117,7 @@
   padding-block: 0;
   padding-inline: 0;
   border: 0;
+  font: inherit;
 
   &:focus {
     outline: 0;

--- a/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
@@ -87,6 +87,24 @@
   padding-inline-start: var(--PaddingInline);
 }
 
+.clear {
+  display: none;
+  padding-inline-start: var(--PaddingInline);
+}
+
+// stylelint-disable-next-line selector-max-type
+.clear button {
+  padding-block: 0;
+  padding-inline: 0;
+  border: 0;
+  line-height: 1;
+}
+
+.root:hover .clear,
+.root:focus-within .clear {
+  display: block;
+}
+
 // Strips away the browser defaults from the input to make it as invisible as possible.
 .input {
   flex: 1;
@@ -98,5 +116,18 @@
 
   &:focus {
     outline: 0;
+  }
+  &[type="search"] {
+    &::-webkit-search-decoration,
+    &::-webkit-search-cancel-button,
+    &::-webkit-search-results-button,
+    &::-webkit-search-results-decoration {
+      display: none;
+    }
+
+    &::-ms-clear,
+    &::-ms-reveal {
+      display: none;
+    }
   }
 }

--- a/packages/odyssey-react/src/components/TextInput/TextInput.test.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.test.tsx
@@ -196,5 +196,43 @@ describe("TextInput", () => {
     expect(inputElement).toHaveFocus();
   });
 
+  it("clears the input when the clear button is clicked for uncontrolled value", () => {
+    render(
+      <TextInput
+        label={label}
+        type="search"
+        defaultValue="Default uncontrolled value"
+      />
+    );
+    const inputElement = screen.getByRole("searchbox");
+    expect(inputElement).toHaveValue("Default uncontrolled value");
+    inputElement.focus();
+    const clearButton = screen.getByRole("button");
+    clearButton.click();
+    expect(screen.getByRole("searchbox")).toHaveValue("");
+  });
+
+  it("calls onchange with empty value when clear button is clicked", () => {
+    const onChange = jest.fn();
+    render(
+      <TextInput
+        label={label}
+        type="search"
+        value="controlled value"
+        onChange={onChange}
+      />
+    );
+    const inputElement = screen.getByRole("searchbox");
+    expect(inputElement).toHaveValue("controlled value");
+    inputElement.focus();
+    const clearButton = screen.getByRole("button");
+    clearButton.click();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "change" }),
+      ""
+    );
+  });
+
   a11yCheck(() => render(<TextInput label="foo" />));
 });

--- a/packages/odyssey-react/src/components/TextInput/TextInput.theme.ts
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.theme.ts
@@ -13,6 +13,7 @@
 import type { ThemeReducer } from "@okta/odyssey-react-theme";
 
 export const theme: ThemeReducer = (theme) => ({
+  AffixPadding: theme.SpaceScale0,
   AffixTextColor: theme.ColorTextSub,
   BackgroundColor: theme.ColorBackgroundBase,
   BorderColor: theme.ColorBorderUi,

--- a/packages/odyssey-react/src/components/TextInput/TextInput.theme.ts
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.theme.ts
@@ -13,6 +13,7 @@
 import type { ThemeReducer } from "@okta/odyssey-react-theme";
 
 export const theme: ThemeReducer = (theme) => ({
+  AffixTextColor: theme.ColorTextSub,
   BackgroundColor: theme.ColorBackgroundBase,
   BorderColor: theme.ColorBorderUi,
   BorderRadius: theme.BorderRadiusBase,
@@ -28,8 +29,7 @@ export const theme: ThemeReducer = (theme) => ({
   FontFamily: theme.FontFamilyBase,
   FontSize: theme.FontSizeBody,
   HoverFocusBorderColor: theme.ColorPrimaryBase,
-  IndicatorInsetInlineStart: theme.SpaceScale1,
-  IndicatorSize: "1.1487rem",
+  IconSize: "1.1487rem",
   InvalidBorderColor: theme.ColorBorderDangerBase,
   InvalidFocusOutlineColor: theme.FocusOutlineColorDanger,
   LineHeight: theme.FontLineHeightUi,
@@ -39,7 +39,6 @@ export const theme: ThemeReducer = (theme) => ({
   PaddingBlock: theme.SpaceScale1,
   PaddingInline: theme.SpaceScale1,
   PlaceholderTextColor: theme.ColorTextSub,
-  StaticTextColor: theme.ColorTextSub,
   TextColor: theme.ColorTextBody,
   TransitionDuration: theme.TransitionDurationBase,
   TransitionTimingFunction: theme.TransitionTimingBase,

--- a/packages/odyssey-react/src/components/TextInput/TextInput.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.tsx
@@ -148,7 +148,8 @@ export const TextInput = withTheme(
     const omitProps = useOmit(rest);
     const internalRef = useSharedRef(ref);
     const [isControlled] = useState(value ? true : false);
-    const [hasValue, setHasValue] = useState(defaultValue);
+    const [hasUncontrolledValue, setHasUncontrolledValue] =
+      useState(defaultValue);
 
     const setFocus = () => {
       requestAnimationFrame(() => {
@@ -159,7 +160,7 @@ export const TextInput = withTheme(
     const handleChange = useCallback(
       (event: ChangeEvent<HTMLInputElement>) => {
         if (!isControlled) {
-          setHasValue(event.target.value);
+          setHasUncontrolledValue(event.target.value);
         }
         onChange?.(event, event.target.value);
       },
@@ -191,7 +192,12 @@ export const TextInput = withTheme(
           }
         : {};
 
-    const showClearButton = isControlled ? !!value : hasValue;
+    const showClearButton = isControlled ? !!value : hasUncontrolledValue;
+    const suffixStyle = useCx(
+      styles.suffix,
+      showClearButton && styles.affixHidden
+    );
+
     return (
       <Field
         error={error}
@@ -230,23 +236,21 @@ export const TextInput = withTheme(
             defaultValue={defaultValue}
             value={value}
           />
-          {suffix && !isSearchTextInput && (
+          {(suffix || isSearchTextInput) && (
             <span
-              className={styles.suffix}
+              className={suffixStyle}
               aria-hidden="true"
-              onClick={setFocus}
+              onClick={isSearchTextInput ? undefined : setFocus}
             >
-              {suffix}
-            </span>
-          )}
-          {isSearchTextInput && showClearButton && (
-            <span className={styles.clear} aria-hidden="true">
-              <Button
-                variant="clear"
-                size="s"
-                icon={<CloseCircleFilledIcon />}
-                onClick={onClear}
-              />
+              {!isSearchTextInput && suffix}
+              {isSearchTextInput && showClearButton && (
+                <Button
+                  variant="clear"
+                  size="s"
+                  icon={<CloseCircleFilledIcon />}
+                  onClick={onClear}
+                />
+              )}
             </span>
           )}
         </div>

--- a/packages/odyssey-react/src/components/TextInput/TextInput.tsx
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.tsx
@@ -259,8 +259,7 @@ export const TextInput = withTheme(
               {!isSearchTextInput && suffix}
               {isSearchTextInput && showClearButton && (
                 <Button
-                  variant="clear"
-                  size="s"
+                  variant="affix"
                   icon={<CloseCircleFilledIcon />}
                   onClick={onClear}
                 />

--- a/packages/odyssey-storybook/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/odyssey-storybook/src/components/TextInput/TextInput.stories.tsx
@@ -73,6 +73,15 @@ export const Search = Template.bind({});
 Search.args = {
   defaultValue: "Search Planets",
   type: "search",
+  required: false,
+  label: undefined,
+};
+
+export const ControlledSearch = Template.bind({});
+ControlledSearch.args = {
+  type: "search",
+  value: "Ruby Ruby Ruby Ruby Soho",
+  label: "Destination Unknown",
 };
 
 export const Prefix = Template.bind({});
@@ -87,4 +96,5 @@ Suffix.args = {
   label: "Time til destination",
   type: "text",
   suffix: "minutes",
+  required: false,
 };


### PR DESCRIPTION
### Description
Add a cross-browser solution for clearing text for the search variation of the `TextInput` component.

- A new button variant was added for use in inputs. Thanks @edburyenegren-okta for all the css
- Still wondering if all the logic for the suffix and the prefix be abstracted to separate components? Not sure how that works with the style and theme.
- The logic still seems complicated to me, but it was the only way to get it to work correctly for both the controlled and uncontrolled scenarios. Suggestions for simplification welcome. 

### Screenshot 

https://user-images.githubusercontent.com/89409747/161340865-7bc360ed-bee8-4258-864a-f19dbe40564e.mov


