### PR TITLE
fix(odyssey-react): accessible focus states for Dismiss Button

### DIFF
--- a/packages/odyssey-react/src/components/Button/Button.module.scss
+++ b/packages/odyssey-react/src/components/Button/Button.module.scss
@@ -136,10 +136,6 @@
     background-color: var(--DismissDisabledBackgroundColor);
     color: var(--DismissDisabledTextColor);
   }
-
-  .icon {
-    display: block;
-  }
 }
 
 .clearVariant {

--- a/packages/odyssey-react/src/components/Button/Button.module.scss
+++ b/packages/odyssey-react/src/components/Button/Button.module.scss
@@ -126,7 +126,10 @@
 
   &:hover,
   &:focus {
-    background-color: rgba(var(--DismissHoverBackgroundColor), var(--DismissHoverBackgroundOpacity));
+    background-color: rgba(
+      var(--DismissHoverBackgroundColor),
+      var(--DismissHoverBackgroundOpacity)
+    );
   }
 
   &:disabled {

--- a/packages/odyssey-react/src/components/Button/Button.module.scss
+++ b/packages/odyssey-react/src/components/Button/Button.module.scss
@@ -124,14 +124,9 @@
   color: var(--DismissTextColor);
   line-height: var(--DismissLineHeight);
 
-  &:hover {
-    border-color: var(--DismissHoverBorderColor);
-    background-color: var(--DismissHoverBackgroundColor);
-  }
-
+  &:hover,
   &:focus {
-    background-color: var(--DismissFocusBackgroundColor);
-    box-shadow: 0 0 0 2px;
+    background-color: rgba(var(--DismissHoverBackgroundColor), var(--DismissHoverBackgroundOpacity));
   }
 
   &:disabled {
@@ -141,14 +136,7 @@
 
   .icon {
     display: block;
-    margin-block-start: 0.0625em;
-    margin-block-end: -0.0625em;
-    line-height: 0.9;
   }
-}
-
-.dismissInvertedVariant:focus {
-  box-shadow: 0 0 0 2px var(--DismissInvertedBoxShadowColor);
 }
 
 .clearVariant {

--- a/packages/odyssey-react/src/components/Button/Button.module.scss
+++ b/packages/odyssey-react/src/components/Button/Button.module.scss
@@ -126,10 +126,7 @@
 
   &:hover,
   &:focus {
-    background-color: rgba(
-      var(--DismissHoverBackgroundColor),
-      var(--DismissHoverBackgroundOpacity)
-    );
+    background-color: var(--DismissHoverBackgroundColor);
   }
 
   &:disabled {

--- a/packages/odyssey-react/src/components/Button/Button.theme.ts
+++ b/packages/odyssey-react/src/components/Button/Button.theme.ts
@@ -72,13 +72,13 @@ export const theme: ThemeReducer = (theme) => ({
 
   // Dismiss Variant
   DismissBackgroundColor: "transparent",
-  DismissHoverBorderColor: "transparent",
   DismissTextColor: "inherit",
   DismissDisabledTextColor: theme.ColorNeutralBase,
   DismissLineHeight: 1,
   DismissPaddingBlock: theme.SpaceScale0,
   DismissPaddingInline: theme.SpaceScale0,
-  DismissHoverBackgroundColor: "rgba(255, 255, 255, 0.6)",
+  DismissHoverBackgroundColor: "29, 29, 33",
+  DismissHoverBackgroundOpacity: 0.1,
   DismissFocusBackgroundColor: "rgba(255, 255, 255, 0.6)",
   DismissDisabledBackgroundColor: "rgba(235, 235, 237, 0.6)",
 

--- a/packages/odyssey-react/src/components/Button/Button.theme.ts
+++ b/packages/odyssey-react/src/components/Button/Button.theme.ts
@@ -77,8 +77,7 @@ export const theme: ThemeReducer = (theme) => ({
   DismissLineHeight: 1,
   DismissPaddingBlock: theme.SpaceScale0,
   DismissPaddingInline: theme.SpaceScale0,
-  DismissHoverBackgroundColor: "29, 29, 33",
-  DismissHoverBackgroundOpacity: 0.1,
+  DismissHoverBackgroundColor: "rgba(29, 29, 33, 0.1)",
   DismissFocusBackgroundColor: "rgba(255, 255, 255, 0.6)",
   DismissDisabledBackgroundColor: "rgba(235, 235, 237, 0.6)",
 


### PR DESCRIPTION
### Description

Updates Dismiss styles for better accessibility and parity with Figma.

### Follow-up breaking changes

- @josesolano-okta has proposed renaming this to "Ghost" or "Floating" since dismissal is not the only use case, I'm +1 there
- The "inverted" variant can be removed since we are using standard Button `:focus` states now

If we have good alignment on making the follow-up changes, I'll address them here. If we need to discuss, I can create cards for next sprint.

