### PR TITLE
docs(odyssey-storybook): update Banner stories to showcase all options

### DIFF
--- a/packages/odyssey-react/src/components/Banner/Banner.module.scss
+++ b/packages/odyssey-react/src/components/Banner/Banner.module.scss
@@ -108,5 +108,9 @@
   .content {
     margin-block-end: var(--ContentMobileMarginBlockEnd);
     margin-inline-end: 0;
+
+    &:last-child {
+      margin-block-end: 0;
+    }
   }
 }

--- a/packages/odyssey-storybook/.storybook/manager-head.html
+++ b/packages/odyssey-storybook/.storybook/manager-head.html
@@ -1,0 +1,5 @@
+<style>
+  .sidebar-item[id$="-dont"] {
+    display: none !important;
+  }
+</style>

--- a/packages/odyssey-storybook/applitools.config.js
+++ b/packages/odyssey-storybook/applitools.config.js
@@ -10,6 +10,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+const VRT_IGNORE = "Toast.Provider".split(" ");
+
 module.exports = {
   // NOTE: the docs for this exitcode config are incorrect as of this
   // writing. An explicit `false` value here allows a failed VRT run to
@@ -27,7 +29,7 @@ module.exports = {
     guidelinesVersion: "WCAG_2_1",
   },
   include({ name }) {
-    if (name === "Toast.Provider") return false;
+    if (VRT_IGNORE.includes(name)) return false;
     return true;
   },
 };

--- a/packages/odyssey-storybook/src/components/Banner/Banner.mdx
+++ b/packages/odyssey-storybook/src/components/Banner/Banner.mdx
@@ -6,10 +6,6 @@ import { ThemeTable } from "../../../.storybook/components";
 
 Banners let users know important messages related to their overall experience on the website. They can be purely informational messages or critical errors to act upon.
 
-## Anatomy
-
-**ANATOMY MISSING**
-
 ## Behavior
 
 Banners must be present on load and should not be trigged asynchronously, as they may not be visible. These alerts are not transient, but may be dismissed by the user.
@@ -54,27 +50,31 @@ In addition to the required content and placement, Banners have several optional
 
 Banners can utilize an optional Title to give an at-a-glance lede.
 
-**STORY MISSING**
+<Canvas>
+  <Story id="components-banner--with-title" />
+</Canvas>
 
 ### Actions
 
-It's often useful to direct users toward an appropriate action, especially for fixing errors.
+It's often useful to direct users toward an appropriate action, especially for fixing errors. Please utilize <a href="?path=/docs/components-link--monochrome">Link</a> for these actions. If it's necessary to provide the user with an action, please direct them to the appropriate flow instead of beginning a new process inline.
 
-**STORY MISSING**
-
-The actions section is limited to links. If it's necessary to provide the user with an action, please direct them to the appropriate flow instead of beginning a new process inline.
-
-**STORY MISSING**
+<Canvas>
+  <Story id="components-banner--with-link" />
+</Canvas>
 
 ### Dismissal
 
 Banners support dismissal for messages that do not persist or only require a one-time acknowledgement.
 
-**STORY MISSING**
+<Canvas>
+  <Story id="components-banner--dismissable" />
+</Canvas>
 
 ## Content Guidelines
 
-Banner content should be succinct and direct. When including an action, be sure the link text clearly indicates where it leads.
+Banner content should be succinct and direct. If possible, your content should be limited to a single line, which wraps around 80 characters. Banner content will also be visible on mobile.
+
+When including an action, be sure the link text clearly indicates where it leads.
 
 ## Props
 

--- a/packages/odyssey-storybook/src/components/Banner/Banner.stories.tsx
+++ b/packages/odyssey-storybook/src/components/Banner/Banner.stories.tsx
@@ -32,12 +32,15 @@ export default {
       control: null,
     },
     heading: {
-      defaultValue: "Banner heading",
+      defaultValue: null,
       control: "text",
     },
     content: {
-      defaultValue: "Additional string related to the heading.",
-      control: null,
+      defaultValue: "The mission to Sagitarius A has been set for January 7.",
+      control: "text",
+    },
+    onDismiss: {
+      defaultValue: false,
     },
     dismissButtonLabel: {
       defaultValue: "Dismiss banner",
@@ -66,38 +69,49 @@ const Template: Story<BannerProps> = (props) => {
     };
   }
 
-  return (
-    <Banner {...props} {...dismissProps}>
-      <Link variant="monochrome" href="https://www.okta.com">
-        Action Link
-      </Link>
-    </Banner>
-  );
+  return <Banner {...props} {...dismissProps} />;
 };
 
 export const Info = Template.bind({});
 Info.args = {
   variant: "info",
-  dismissButtonLabel: undefined,
-  onDismiss: undefined,
 };
 
 export const Danger = Template.bind({});
 Danger.args = {
   variant: "danger",
-  dismissButtonLabel: undefined,
-  onDismiss: undefined,
+  content: "Hangar 18 has been compromised.",
 };
 
 export const Caution = Template.bind({});
 Caution.args = {
   variant: "caution",
-  dismissButtonLabel: undefined,
-  onDismiss: undefined,
+  content: "Severe solar winds detected. Local system flights may be delayed.",
+};
+
+export const WithTitle = Template.bind({});
+WithTitle.args = {
+  variant: "info",
+  heading: "New launch scheduled",
+};
+
+export const WithLink = Template.bind({});
+WithLink.args = {
+  variant: "danger",
+  content: "Hangar 18 has been compromised.",
+  children: (
+    <>
+      <Link variant="monochrome" href="#">
+        View report
+      </Link>
+    </>
+  ),
 };
 
 export const Dismissable = Template.bind({});
 Dismissable.args = {
+  variant: "caution",
+  content: "Severe solar winds detected. Local system flights may be delayed.",
   onDismiss: () => {
     console.log("Banner: onDismiss!");
   },


### PR DESCRIPTION
Updates Banner's stories to cover all variations.

Also include decorators for:

- hiding Stories from the sidebar
- marking Stories as "Don't" variations for doc guidance