### PR TITLE
Docs: Infobox stories

### DIFF
--- a/packages/odyssey-storybook/.storybook/manager-head.html
+++ b/packages/odyssey-storybook/.storybook/manager-head.html
@@ -1,5 +1,6 @@
 <style>
-  .sidebar-item[id$="-dont"] {
+  .sidebar-item[id$="-dont"],
+  .sidebar-item[id$="-do"] {
     display: none !important;
   }
 </style>

--- a/packages/odyssey-storybook/.storybook/preview-head.html
+++ b/packages/odyssey-storybook/.storybook/preview-head.html
@@ -27,4 +27,39 @@
   .sbdocs .sbdocs-a {
     color: #1662dd;
   }
+
+  .sbdocs .sb-do,
+  .sbdocs .sb-dont {
+    border-inline-start-width: 0.57142857rem;
+  }
+
+  .sbdocs .sb-do {
+    border-color: #00b478;
+  }
+
+  .sbdocs .sb-dont {
+    border-color: #da372c;
+  }
+
+  .sbdocs .sb-marker {
+    display: inline-block;
+    margin-block-start: 1.14285714rem;
+    padding-block: 0.57142857rem;
+    padding-inline: 0.85714286rem;
+    border-radius: 1em;
+    color: #ffffff;
+  }
+
+  .sbdocs .sb-marker--do {
+    background-color: #00b478;
+  }
+
+  .sbdocs .sb-marker--dont {
+    background-color: #da372c;
+  }
+
+  .sbdocs .sb-do .innerZoomElementWrapper > div,
+  .sbdocs .sb-dont .innerZoomElementWrapper > div {
+    display: block;
+  }
 </style>

--- a/packages/odyssey-storybook/applitools.config.js
+++ b/packages/odyssey-storybook/applitools.config.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-const VRT_IGNORE = "Toast.Provider".split(" ");
+const VRT_IGNORE = "Toast.Provider Infobox.Form Infobox.Table".split(" ");
 
 module.exports = {
   // NOTE: the docs for this exitcode config are incorrect as of this

--- a/packages/odyssey-storybook/src/components/Infobox/Infobox.mdx
+++ b/packages/odyssey-storybook/src/components/Infobox/Infobox.mdx
@@ -1,14 +1,11 @@
 import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/Infobox/Infobox.theme";
+import { CheckIcon, CloseIcon } from "../../../../odyssey-react/src";
 import { ThemeTable } from "../../../.storybook/components";
 
 # Infobox
 
 An infobox is a type of alert that provides feedback in response to a user action or system activity.
-
-## Anatomy
-
-**ANATOMY MISSING**
 
 ## Behavior
 
@@ -62,11 +59,15 @@ Avoid overusing Infobox within the same view. They are intended to draw the eye,
 
 It is ideal to direct users toward an appropriate action, especially for addressing errors. Infoboxes allow for both inline and separated actions. To preserve clarity, limit Infoboxes to one link.
 
-**STORY MISSING**
+<Canvas>
+  <Story id="components-infobox--with-link-inline" />
+</Canvas>
 
 The actions section is limited to links. If it's necessary to provide the user with an action, please direct them to the appropriate flow instead of beginning a new process inline.
 
-**STORY MISSING**
+<Canvas>
+  <Story id="components-infobox--with-link" />
+</Canvas>
 
 ### Placement
 
@@ -74,19 +75,27 @@ Infoboxes should be displayed above the content they apply to but not higher tha
 
 For example, a Form error should be displayed above all Fieldsets, but below the Form title.
 
-**STORY MISSING**
+<Canvas className="sb-do">
+  <Story id="components-infobox--form-do" />
+  <span class="sb-marker sb-marker--do">
+    <CheckIcon /> Do
+  </span>
+</Canvas>
 
 Stay away from nesting Infoboxes within information-dense UI like Tables. If you need to convey something about an individual data point, consider another design solution.
 
-**STORY MISSING**
+<Canvas className="sb-dont">
+  <Story id="components-infobox--table-dont" />
+  <span class="sb-marker sb-marker--dont">
+    <CloseIcon /> Don't
+  </span>
+</Canvas>
 
 ## Content Guidelines
 
 These messages may be used for longer content than Toast or Banner, but shouldn't go beyond two paragraphs. When including an inline link or action, be sure the link text clearly indicates where it leads.
 
 Do not include images or other UIs within Infobox.
-
-**STORY MISSING**
 
 ### Content Areas
 

--- a/packages/odyssey-storybook/src/components/Infobox/Infobox.stories.tsx
+++ b/packages/odyssey-storybook/src/components/Infobox/Infobox.stories.tsx
@@ -11,9 +11,16 @@
  */
 
 import React from "react";
-import type { ReactElement } from "react";
 import { Story } from "@storybook/react";
-import { Infobox, InfoboxProps, Link } from "../../../../odyssey-react/src";
+import {
+  Infobox,
+  InfoboxProps,
+  Button,
+  Form,
+  Link,
+  Table,
+  TextInput,
+} from "../../../../odyssey-react/src";
 import InfoboxMdx from "./Infobox.mdx";
 
 export default {
@@ -28,22 +35,27 @@ export default {
     children: {
       control: { type: null },
     },
+    variant: {
+      control: { type: "radio" },
+    },
     heading: {
-      defaultValue: "Infobox heading",
+      control: { type: "text" },
+    },
+    content: {
+      control: { type: "text" },
+    },
+    actions: {
       control: { type: "text" },
     },
   },
 };
 
-const content =
-  "An infobox is a type of alert that provides feedback in response to a user action or system activity.";
-const actions = (
-  <Link href="https://ww.okta.com" variant="monochrome">
-    Link to associated action
-  </Link>
-);
-
-const Template: Story<InfoboxProps> = ({ heading, variant }) => (
+const Template: Story<InfoboxProps> = ({
+  heading,
+  variant,
+  content,
+  actions,
+}) => (
   <Infobox
     heading={heading}
     variant={variant}
@@ -52,24 +64,157 @@ const Template: Story<InfoboxProps> = ({ heading, variant }) => (
   />
 );
 
+const FormTemplate: Story<InfoboxProps> = ({
+  heading,
+  variant,
+  content,
+  actions,
+}) => (
+  <Form heading="Sign in">
+    <Infobox
+      heading={heading}
+      variant={variant}
+      content={content}
+      actions={actions}
+    />
+    <TextInput type="text" label="Username" disabled />
+    <TextInput type="password" label="Authorization code" disabled />
+    <Form.Actions>
+      <Button variant="primary" disabled>
+        Login
+      </Button>
+    </Form.Actions>
+  </Form>
+);
+
+const TableTemplate: Story<InfoboxProps> = ({
+  heading,
+  variant,
+  content,
+  actions,
+}) => (
+  <Table
+    screenReaderCaption="Information about the largest and smallest planets."
+    caption="Big and small planets"
+    withContainer={true}
+  >
+    <Table.Header>
+      <Table.Row>
+        <Table.HeaderCell scope="col">Planet</Table.HeaderCell>
+        <Table.HeaderCell scope="col" format={"num"}>
+          Radius (km)
+        </Table.HeaderCell>
+        <Table.HeaderCell scope="col">Type</Table.HeaderCell>
+        <Table.HeaderCell scope="col" format={"date"}>
+          Perihelion date
+        </Table.HeaderCell>
+      </Table.Row>
+    </Table.Header>
+    <Table.Body>
+      <Table.Row>
+        <Table.DataCell>Jupiter</Table.DataCell>
+        <Table.DataCell format={"num"}>69,911</Table.DataCell>
+        <Table.DataCell>Gas giant</Table.DataCell>
+        <Table.DataCell format={"date"}>January 21, 2023</Table.DataCell>
+      </Table.Row>
+      <Table.Row>
+        <Table.DataCell>
+          Pluto
+          <Infobox
+            heading={heading}
+            variant={variant}
+            content={content}
+            actions={actions}
+          />
+        </Table.DataCell>
+        <Table.DataCell format={"num"}>6,371</Table.DataCell>
+        <Table.DataCell>Terrestrial</Table.DataCell>
+        <Table.DataCell format={"date"}>January 2, 2021</Table.DataCell>
+      </Table.Row>
+      <Table.Row>
+        <Table.DataCell>Mercury</Table.DataCell>
+        <Table.DataCell format={"num"}>1,737</Table.DataCell>
+        <Table.DataCell>Terrestrial</Table.DataCell>
+        <Table.DataCell format={"date"}>&ndash;</Table.DataCell>
+      </Table.Row>
+    </Table.Body>
+  </Table>
+);
+
 export const Info = Template.bind({});
 Info.args = {
   variant: "info",
+  heading: "Moonbase Alpha-6",
+  content:
+    "You are currently logged in from Moonbase Alpha-6, located on Luna.",
 };
 
 export const Danger = Template.bind({});
 Danger.args = {
   variant: "danger",
+  heading: "Safety checks have failed",
+  content:
+    "An issue has been discovered with your fuel mixture ratios. Please reconfigure your fuel mixture and perform safety checks again.",
 };
 
 export const Caution = Template.bind({});
 Caution.args = {
   variant: "caution",
+  heading: "Safety checks incomplete",
+  content:
+    "Safety checks must be completed before this mission can be approved for launch.",
 };
 
 export const Success = Template.bind({});
 Success.args = {
   variant: "success",
+  heading: "Ready for lift-off",
+  content:
+    "Safety checks are complete, and this mission has been approved for launch.",
 };
 
-export const ContentOnly = (): ReactElement => <Infobox content={content} />;
+export const WithLink = Template.bind({});
+WithLink.args = {
+  variant: "danger",
+  heading: "Safety checks have failed",
+  content:
+    "An issue has been discovered with your fuel mixture ratios. Please reconfigure your fuel mixture and perform safety checks again.",
+  actions: (
+    <>
+      <Link href="#" variant="monochrome">
+        Visit fueling console
+      </Link>
+    </>
+  ),
+};
+
+export const WithLinkInline = Template.bind({});
+WithLinkInline.args = {
+  variant: "danger",
+  heading: "Safety checks have failed",
+  content: (
+    <>
+      An issue has been discovered with your fuel mixture ratios. Please{" "}
+      <Link href="#" variant="monochrome">
+        reconfigure your fuel mixture
+      </Link>{" "}
+      and perform safety checks again.
+    </>
+  ),
+};
+
+export const FormDo = FormTemplate.bind({});
+FormDo.storyName = "Infobox.Form";
+FormDo.args = {
+  variant: "danger",
+  heading: "Espionage detected!",
+  content: "Your access has been disabled. Please contact a Site Director.",
+};
+
+export const TableDont = TableTemplate.bind({});
+TableDont.storyName = "Infobox.Table";
+TableDont.args = {
+  variant: "danger",
+  heading: "Too small!",
+  content: "This little guy has been reclassified.",
+};

--- a/packages/odyssey-storybook/src/components/Infobox/Infobox.stories.tsx
+++ b/packages/odyssey-storybook/src/components/Infobox/Infobox.stories.tsx
@@ -101,11 +101,11 @@ const TableTemplate: Story<InfoboxProps> = ({
     <Table.Header>
       <Table.Row>
         <Table.HeaderCell scope="col">Planet</Table.HeaderCell>
-        <Table.HeaderCell scope="col" format={"num"}>
+        <Table.HeaderCell scope="col" format="num">
           Radius (km)
         </Table.HeaderCell>
         <Table.HeaderCell scope="col">Type</Table.HeaderCell>
-        <Table.HeaderCell scope="col" format={"date"}>
+        <Table.HeaderCell scope="col" format="date">
           Perihelion date
         </Table.HeaderCell>
       </Table.Row>
@@ -113,9 +113,9 @@ const TableTemplate: Story<InfoboxProps> = ({
     <Table.Body>
       <Table.Row>
         <Table.DataCell>Jupiter</Table.DataCell>
-        <Table.DataCell format={"num"}>69,911</Table.DataCell>
+        <Table.DataCell format="num">69,911</Table.DataCell>
         <Table.DataCell>Gas giant</Table.DataCell>
-        <Table.DataCell format={"date"}>January 21, 2023</Table.DataCell>
+        <Table.DataCell format="date">January 21, 2023</Table.DataCell>
       </Table.Row>
       <Table.Row>
         <Table.DataCell>
@@ -127,15 +127,15 @@ const TableTemplate: Story<InfoboxProps> = ({
             actions={actions}
           />
         </Table.DataCell>
-        <Table.DataCell format={"num"}>6,371</Table.DataCell>
+        <Table.DataCell format="num">6,371</Table.DataCell>
         <Table.DataCell>Terrestrial</Table.DataCell>
-        <Table.DataCell format={"date"}>January 2, 2021</Table.DataCell>
+        <Table.DataCell format="date">January 2, 2021</Table.DataCell>
       </Table.Row>
       <Table.Row>
         <Table.DataCell>Mercury</Table.DataCell>
-        <Table.DataCell format={"num"}>1,737</Table.DataCell>
+        <Table.DataCell format="num">1,737</Table.DataCell>
         <Table.DataCell>Terrestrial</Table.DataCell>
-        <Table.DataCell format={"date"}>&ndash;</Table.DataCell>
+        <Table.DataCell format="date">&ndash;</Table.DataCell>
       </Table.Row>
     </Table.Body>
   </Table>


### PR DESCRIPTION
### Description

- Updates `Infobox` stories to include previous examples and variants
- Adds "Do" and "Don't" styling for stories

### Screenshots

New decorators for Do / Don't examples:

<img width="1022" alt="Screen Shot 2022-04-15 at 1 01 54 PM" src="https://user-images.githubusercontent.com/36284167/163626690-5a674a93-7f81-4dad-8b46-bae95cbf3c62.png">
<img width="1024" alt="Screen Shot 2022-04-15 at 1 01 47 PM" src="https://user-images.githubusercontent.com/36284167/163626695-60b0aba4-db27-40fb-a835-6a2634ec5567.png">

