### PR TITLE
OKTA-482329 use react portal to display the tooltip - WIP

### DIFF
--- a/packages/odyssey-react/src/components/Tooltip/Portal.tsx
+++ b/packages/odyssey-react/src/components/Tooltip/Portal.tsx
@@ -10,20 +10,27 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {  FC, useEffect } from 'react';
-import { createPortal } from 'react-dom';
+import { FC, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 
 export const Portal: FC = ({ children }) => {
-    const el = document.createElement("div");    
-  
-    useEffect(() => {
-        document.body.appendChild(el);
-        return () => {
-            document.body.removeChild(el)
-        };
-    }, [el]);
-  
-    return createPortal(children, el)
-  };
-  
-  Portal.displayName = "Portal";
+  const [el, setEl] = useState<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setEl(document.createElement("div"));
+  }, []);
+
+  useEffect(() => {
+    if (el) {
+      document.body.appendChild(el);
+      return () => {
+        document.body.removeChild(el);
+      };
+    }
+    return;
+  }, [el]);
+
+  return el ? createPortal(children, el) : null;
+};
+
+Portal.displayName = "Portal";

--- a/packages/odyssey-react/src/components/Tooltip/Portal.tsx
+++ b/packages/odyssey-react/src/components/Tooltip/Portal.tsx
@@ -21,15 +21,17 @@ export const Portal: FC = ({ children }) => {
   }, []);
 
   useEffect(() => {
-    if (el) {
-      document.body.appendChild(el);
-      return () => {
-        document.body.removeChild(el);
-      };
+    const portalElement = el;
+    if (portalElement) {
+      document.body.appendChild(portalElement);
     }
-    return;
-  }, [el]);
 
+    return () => {
+      if (portalElement) {
+        document.body.removeChild(portalElement);
+      }
+    };
+  }, [el]);
   return el ? createPortal(children, el) : null;
 };
 

--- a/packages/odyssey-react/src/components/Tooltip/Portal.tsx
+++ b/packages/odyssey-react/src/components/Tooltip/Portal.tsx
@@ -1,0 +1,29 @@
+/*!
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import {  FC, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+
+export const Portal: FC = ({ children }) => {
+    const el = document.createElement("div");    
+  
+    useEffect(() => {
+        document.body.appendChild(el);
+        return () => {
+            document.body.removeChild(el)
+        };
+    }, [el]);
+  
+    return createPortal(children, el)
+  };
+  
+  Portal.displayName = "Portal";

--- a/packages/odyssey-react/src/components/Tooltip/Tooltip.module.scss
+++ b/packages/odyssey-react/src/components/Tooltip/Tooltip.module.scss
@@ -49,14 +49,6 @@
   &::before {
     border-width: var(--TailWidth);
   }
-
-  /* stylelint-disable-next-line selector-max-universal */
-  .hasTooltip *:focus + &,
-  .hasTooltip:hover &,
-  .hasTooltip:focus & {
-    visibility: visible;
-    opacity: 1;
-  }
 }
 
 .topPosition {

--- a/packages/odyssey-react/src/components/Tooltip/Tooltip.module.scss
+++ b/packages/odyssey-react/src/components/Tooltip/Tooltip.module.scss
@@ -14,7 +14,6 @@
   @include border-radius(var(--BorderRadius));
 
   display: block;
-  visibility: hidden;
   position: absolute;
   z-index: 1;
   padding-block: calc(var(--PaddingBlock) - var(--BorderWidth));
@@ -26,7 +25,6 @@
   border-width: var(--BorderWidth);
   border-style: var(--BorderStyle);
   border-color: var(--BackgroundColor);
-  opacity: 0;
   background-color: var(--BackgroundColor);
   color: var(--TextColor);
   font-size: var(--FontSize);

--- a/packages/odyssey-react/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/odyssey-react/src/components/Tooltip/Tooltip.test.tsx
@@ -26,7 +26,7 @@ describe("Tooltip", () => {
       </Tooltip>
     );
 
-    expect(screen.getByRole(tooltip)).toBeInTheDocument();
+    expect(screen.getByRole(tooltip, { hidden: true })).toBeInTheDocument();
     expect(screen.getByRole(button)).toBeInTheDocument();
   });
 
@@ -38,7 +38,7 @@ describe("Tooltip", () => {
     );
 
     expect(screen.getByRole(button)).toHaveAttribute("aria-describedby", "foo");
-    expect(screen.getByRole(tooltip)).toHaveAttribute("id", "foo");
+    expect(screen.getByRole(tooltip, { hidden: true })).toHaveAttribute("id", "foo");
   });
 
   it("invokes ref with expected args after render", () => {
@@ -51,7 +51,7 @@ describe("Tooltip", () => {
     );
 
     expect(ref).toHaveBeenCalledTimes(1);
-    expect(ref).toHaveBeenLastCalledWith(screen.getByRole(tooltip));
+    expect(ref).toHaveBeenLastCalledWith(screen.getByRole(tooltip, { hidden: true }));
   });
 
   a11yCheck(() =>

--- a/packages/odyssey-react/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/odyssey-react/src/components/Tooltip/Tooltip.test.tsx
@@ -38,7 +38,10 @@ describe("Tooltip", () => {
     );
 
     expect(screen.getByRole(button)).toHaveAttribute("aria-describedby", "foo");
-    expect(screen.getByRole(tooltip, { hidden: true })).toHaveAttribute("id", "foo");
+    expect(screen.getByRole(tooltip, { hidden: true })).toHaveAttribute(
+      "id",
+      "foo"
+    );
   });
 
   it("invokes ref with expected args after render", () => {
@@ -51,7 +54,9 @@ describe("Tooltip", () => {
     );
 
     expect(ref).toHaveBeenCalledTimes(1);
-    expect(ref).toHaveBeenLastCalledWith(screen.getByRole(tooltip, { hidden: true }));
+    expect(ref).toHaveBeenLastCalledWith(
+      screen.getByRole(tooltip, { hidden: true })
+    );
   });
 
   a11yCheck(() =>

--- a/packages/odyssey-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/odyssey-react/src/components/Tooltip/Tooltip.tsx
@@ -10,7 +10,13 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import React, { cloneElement, forwardRef, useRef, useState } from "react";
+import React, {
+  cloneElement,
+  CSSProperties,
+  forwardRef,
+  useRef,
+  useState,
+} from "react";
 import type { ReactElement, ComponentPropsWithRef } from "react";
 import { withTheme } from "@okta/odyssey-react-theme";
 import { useCx, useOid, useOmit } from "../../utils";
@@ -58,7 +64,11 @@ export const Tooltip = withTheme(
     const omitProps = useOmit(rest);
     const tooltipClasses = useCx(styles.root, styles[`${position}Position`]);
     const clone = cloneElement(children, { "aria-describedby": oid });
-    const [tooltipStyles, setTooltipStyles] = useState({});
+    const [tooltipStyles, setTooltipStyles] = useState<CSSProperties>({
+      visibility: "hidden",
+      opacity: 0,
+      display: "none",
+    });
     const [timeoutFn, setTimeoutFn] = useState<NodeJS.Timeout | null>();
     const { SpaceScale1 } = useTheme();
 

--- a/packages/odyssey-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/odyssey-react/src/components/Tooltip/Tooltip.tsx
@@ -19,6 +19,7 @@ import styles from "./Tooltip.module.scss";
 import { theme } from "./Tooltip.theme";
 import { Portal } from "./Portal";
 import { useTheme } from "@okta/odyssey-react-theme";
+import { getHideTooltipStyles, getShowTooltipStyles } from "./utils";
 
 export interface TooltipProps
   extends Omit<
@@ -57,51 +58,18 @@ export const Tooltip = withTheme(
     const omitProps = useOmit(rest);
     const tooltipClasses = useCx(styles.root, styles[`${position}Position`]);
     const clone = cloneElement(children, { "aria-describedby": oid });
-    const [coords, setCoords] = useState({});
+    const [tooltipStyles, setTooltipStyles] = useState({});
     const [timeoutFn, setTimeoutFn] = useState<NodeJS.Timeout | null>();
     const { SpaceScale1 } = useTheme();
-    const remValue = Number(SpaceScale1.replace("rem", ""));
-    const pxValue =
-      remValue *
-      parseFloat(getComputedStyle(document.documentElement).fontSize);
-    const getPosition = (rect: DOMRect) => {
-      switch (position) {
-        default:
-        case "top":
-          return {
-            left: rect.x + rect.width / 2,
-            top: rect.y - pxValue,
-          };
-        case "bottom":
-          return {
-            left: rect.x + rect.width / 2,
-            top: rect.y + rect.height + pxValue,
-          };
-        case "end":
-          return {
-            left: rect.x + rect.width,
-            top: rect.y + rect.height / 2,
-          };
-        case "start":
-          return {
-            left: rect.x,
-            top: rect.y + rect.height / 2,
-          };
-      }
-    };
+
     const showTooltip = () => {
       if (!tooltipRef || !tooltipRef.current) {
         return;
       }
-      const rect = tooltipRef.current.getBoundingClientRect();
-      const location = getPosition(rect);
       const timeout = setTimeout(
         () =>
-          setCoords({
-            ...location,
-            position: "absolute",
-            visibility: "visible",
-            opacity: 1,
+          setTooltipStyles({
+            ...getShowTooltipStyles(position, tooltipRef, SpaceScale1),
           }),
         1000
       );
@@ -109,7 +77,7 @@ export const Tooltip = withTheme(
     };
 
     const hideTooltip = () => {
-      setCoords({ ...coords, visibility: "hidden", opacity: 0 });
+      setTooltipStyles({ ...tooltipStyles, ...getHideTooltipStyles() });
       if (timeoutFn) {
         clearTimeout(timeoutFn);
       }
@@ -128,7 +96,7 @@ export const Tooltip = withTheme(
           {clone}
         </span>
         <Portal>
-          <span style={{ ...coords }}>
+          <span style={{ ...tooltipStyles }}>
             <Box
               as="aside"
               {...omitProps}

--- a/packages/odyssey-react/src/components/Tooltip/utils.ts
+++ b/packages/odyssey-react/src/components/Tooltip/utils.ts
@@ -15,8 +15,10 @@ import { RefObject } from "react";
 function getPosition(
   position: "top" | "end" | "bottom" | "start",
   rect: DOMRect,
-  paddingValue: number
+  paddingValue: number,
+  direction: string
 ) {
+    console.log('direction: ' + direction);
   switch (position) {
     default:
     case "top":
@@ -30,13 +32,19 @@ function getPosition(
         top: rect.y + rect.height + paddingValue,
       };
     case "end":
-      return {
+      return direction === 'ltr' ? {
         left: rect.x + rect.width,
+        top: rect.y + rect.height / 2,
+      } : {
+        left: rect.x,
         top: rect.y + rect.height / 2,
       };
     case "start":
-      return {
+      return direction === 'ltr' ? {
         left: rect.x,
+        top: rect.y + rect.height / 2,
+      } : {
+        left: rect.x + rect.width,
         top: rect.y + rect.height / 2,
       };
   }
@@ -57,7 +65,8 @@ export function getShowTooltipStyles(
     parseFloat(getComputedStyle(document.documentElement).fontSize);
 
   const rect = tooltipRef.current.getBoundingClientRect();
-  const location = getPosition(position, rect, paddingValue);
+  const direction = window.getComputedStyle(tooltipRef.current, null).getPropertyValue('direction');
+  const location = getPosition(position, rect, paddingValue, direction);
   return {
     ...location,
     position: "absolute",

--- a/packages/odyssey-react/src/components/Tooltip/utils.ts
+++ b/packages/odyssey-react/src/components/Tooltip/utils.ts
@@ -10,14 +10,14 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { RefObject } from "react";
+import { CSSProperties, RefObject } from "react";
 
 function getPosition(
   position: "top" | "end" | "bottom" | "start",
   rect: DOMRect,
   paddingValue: number,
   direction: string
-) {    
+) {
   switch (position) {
     default:
     case "top":
@@ -31,32 +31,35 @@ function getPosition(
         top: rect.y + rect.height + paddingValue,
       };
     case "end":
-      return direction === 'ltr' ? {
-        left: rect.x + rect.width,
-        top: rect.y + rect.height / 2,
-      } : {
-        left: rect.x,
-        top: rect.y + rect.height / 2,
-      };
+      return direction === "ltr"
+        ? {
+            left: rect.x + rect.width,
+            top: rect.y + rect.height / 2,
+          }
+        : {
+            left: rect.x,
+            top: rect.y + rect.height / 2,
+          };
     case "start":
-      return direction === 'ltr' ? {
-        left: rect.x,
-        top: rect.y + rect.height / 2,
-      } : {
-        left: rect.x + rect.width,
-        top: rect.y + rect.height / 2,
-      };
+      return direction === "ltr"
+        ? {
+            left: rect.x,
+            top: rect.y + rect.height / 2,
+          }
+        : {
+            left: rect.x + rect.width,
+            top: rect.y + rect.height / 2,
+          };
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function getShowTooltipStyles(
   position: "top" | "end" | "bottom" | "start",
   tooltipRef: RefObject<HTMLDivElement>,
   themePadding: string
-) {
+): CSSProperties {
   if (!tooltipRef || !tooltipRef.current) {
-    return;
+    return {};
   }
   const remPadding = Number(themePadding.replace("rem", ""));
   const paddingValue =
@@ -64,7 +67,9 @@ export function getShowTooltipStyles(
     parseFloat(getComputedStyle(document.documentElement).fontSize);
 
   const rect = tooltipRef.current.getBoundingClientRect();
-  const direction = window.getComputedStyle(tooltipRef.current, null).getPropertyValue('direction');
+  const direction = window
+    .getComputedStyle(tooltipRef.current, null)
+    .getPropertyValue("direction");
   const location = getPosition(position, rect, paddingValue, direction);
   return {
     ...location,
@@ -74,9 +79,6 @@ export function getShowTooltipStyles(
   };
 }
 
-export function getHideTooltipStyles(): {
-  visibility: string;
-  opacity: number;
-} {
+export function getHideTooltipStyles(): CSSProperties {
   return { visibility: "hidden", opacity: 0 };
 }

--- a/packages/odyssey-react/src/components/Tooltip/utils.ts
+++ b/packages/odyssey-react/src/components/Tooltip/utils.ts
@@ -17,8 +17,7 @@ function getPosition(
   rect: DOMRect,
   paddingValue: number,
   direction: string
-) {
-    console.log('direction: ' + direction);
+) {    
   switch (position) {
     default:
     case "top":

--- a/packages/odyssey-react/src/components/Tooltip/utils.ts
+++ b/packages/odyssey-react/src/components/Tooltip/utils.ts
@@ -1,0 +1,74 @@
+/*!
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { RefObject } from "react";
+
+function getPosition(
+  position: "top" | "end" | "bottom" | "start",
+  rect: DOMRect,
+  paddingValue: number
+) {
+  switch (position) {
+    default:
+    case "top":
+      return {
+        left: rect.x + rect.width / 2,
+        top: rect.y - paddingValue,
+      };
+    case "bottom":
+      return {
+        left: rect.x + rect.width / 2,
+        top: rect.y + rect.height + paddingValue,
+      };
+    case "end":
+      return {
+        left: rect.x + rect.width,
+        top: rect.y + rect.height / 2,
+      };
+    case "start":
+      return {
+        left: rect.x,
+        top: rect.y + rect.height / 2,
+      };
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function getShowTooltipStyles(
+  position: "top" | "end" | "bottom" | "start",
+  tooltipRef: RefObject<HTMLDivElement>,
+  themePadding: string
+) {
+  if (!tooltipRef || !tooltipRef.current) {
+    return;
+  }
+  const remPadding = Number(themePadding.replace("rem", ""));
+  const paddingValue =
+    remPadding *
+    parseFloat(getComputedStyle(document.documentElement).fontSize);
+
+  const rect = tooltipRef.current.getBoundingClientRect();
+  const location = getPosition(position, rect, paddingValue);
+  return {
+    ...location,
+    position: "absolute",
+    visibility: "visible",
+    opacity: 1,
+  };
+}
+
+export function getHideTooltipStyles(): {
+  visibility: string;
+  opacity: number;
+} {
+  return { visibility: "hidden", opacity: 0 };
+}

--- a/packages/odyssey-storybook/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/odyssey-storybook/src/components/Tooltip/Tooltip.stories.tsx
@@ -13,13 +13,14 @@
 import React from "react";
 import type { Story } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import { Tooltip, TooltipProps, Button } from "../../../../odyssey-react/src";
+import { Tooltip, TooltipProps, Button, Box } from "@okta/odyssey-react";
+import { Tooltip as Source } from "../../../../odyssey-react/src";
 
 import TooltipMdx from "./Tooltip.mdx";
 
 export default {
   title: `Components/Tooltip`,
-  component: Tooltip,
+  component: Source,
   parameters: {
     layout: "centered",
     docs: {
@@ -29,7 +30,12 @@ export default {
 };
 
 const Template: Story<TooltipProps> = () => (
-  <>
+  <Box padding="xl" backgroundColor="danger-light" overflow="hidden">
+    <Tooltip label="Starting tooltip label" position="start">
+      <Button onClick={action("Starting button clicked")} variant="clear">
+        Start
+      </Button>
+    </Tooltip>
     <Tooltip label="Top tooltip label" position="top">
       <Button variant="primary" onClick={action("Top button clicked")}>
         Top
@@ -45,12 +51,7 @@ const Template: Story<TooltipProps> = () => (
         Bottom
       </Button>
     </Tooltip>
-    <Tooltip label="Starting tooltip label" position="start">
-      <Button onClick={action("Starting button clicked")} variant="clear">
-        Start
-      </Button>
-    </Tooltip>
-  </>
+  </Box>
 );
 
 export const Default = Template.bind({});

--- a/packages/odyssey-storybook/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/odyssey-storybook/src/components/Tooltip/Tooltip.stories.tsx
@@ -13,14 +13,13 @@
 import React from "react";
 import type { Story } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import { Tooltip, TooltipProps, Button, Box } from "@okta/odyssey-react";
-import { Tooltip as Source } from "../../../../odyssey-react/src";
+import { Tooltip, TooltipProps, Button } from "../../../../odyssey-react/src";
 
 import TooltipMdx from "./Tooltip.mdx";
 
 export default {
   title: `Components/Tooltip`,
-  component: Source,
+  component: Tooltip,
   parameters: {
     layout: "centered",
     docs: {
@@ -30,12 +29,7 @@ export default {
 };
 
 const Template: Story<TooltipProps> = () => (
-  <Box padding="xl" backgroundColor="danger-light" overflow="hidden">
-    <Tooltip label="Starting tooltip label" position="start">
-      <Button onClick={action("Starting button clicked")} variant="clear">
-        Start
-      </Button>
-    </Tooltip>
+  <>
     <Tooltip label="Top tooltip label" position="top">
       <Button variant="primary" onClick={action("Top button clicked")}>
         Top
@@ -51,7 +45,12 @@ const Template: Story<TooltipProps> = () => (
         Bottom
       </Button>
     </Tooltip>
-  </Box>
+    <Tooltip label="Starting tooltip label" position="start">
+      <Button onClick={action("Starting button clicked")} variant="clear">
+        Start
+      </Button>
+    </Tooltip>
+  </>
 );
 
 export const Default = Template.bind({});


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description
Work in Progress

In order to avoid clipping if the tooltip is enclosed in a container with `overflow: hidden`, we use [react Portal](https://reactjs.org/docs/portals.html) to mount the tooltip on a separate div and then position it using javascript based on the enclosing element that will show tooltip. 

- the div is mounted and then removed if the element is no longer displayed
- the positioning is based on the element
- RTL is done
- currently initial tooltip show delay is hardcoded. It should probably be a `prop` passed in as there's no corresponding value in the theme object.

<!-- Describe the change you are introducing -->
The current CSS is no longer used to find the position and display of the tooltip.



https://user-images.githubusercontent.com/82399951/164094106-886fa38a-bccf-4cef-8259-abf811639058.mov




https://user-images.githubusercontent.com/82399951/164802156-07011a32-313c-43ef-81b6-657926523d99.mov


