### PR TITLE
Button: rename "dismiss" to "floating"

### DIFF
--- a/packages/odyssey-react/src/components/Banner/Banner.tsx
+++ b/packages/odyssey-react/src/components/Banner/Banner.tsx
@@ -118,7 +118,7 @@ export const Banner = withTheme(
         {onDismiss && (
           <span className={styles.dismissButton}>
             <Button
-              variant="dismiss"
+              variant="floating"
               onClick={onDismiss}
               aria-label={dismissButtonLabel}
               icon={<CloseIcon />}

--- a/packages/odyssey-react/src/components/Button/Button.module.scss
+++ b/packages/odyssey-react/src/components/Button/Button.module.scss
@@ -115,23 +115,22 @@
   }
 }
 
-.dismissVariant,
-.dismissInvertedVariant {
-  padding-block: var(--DismissPaddingBlock);
-  padding-inline: var(--DismissPaddingInline);
+.floatingVariant {
+  padding-block: var(--FloatingPaddingBlock);
+  padding-inline: var(--FloatingPaddingInline);
   border: 0;
-  background-color: var(--DismissBackgroundColor);
-  color: var(--DismissTextColor);
-  line-height: var(--DismissLineHeight);
+  background-color: var(--FloatingBackgroundColor);
+  color: var(--FloatingTextColor);
+  line-height: var(--FloatingLineHeight);
 
   &:hover,
   &:focus {
-    background-color: var(--DismissHoverBackgroundColor);
+    background-color: var(--FloatingHoverBackgroundColor);
   }
 
   &:disabled {
-    background-color: var(--DismissDisabledBackgroundColor);
-    color: var(--DismissDisabledTextColor);
+    background-color: var(--FloatingDisabledBackgroundColor);
+    color: var(--FloatingDisabledTextColor);
   }
 }
 

--- a/packages/odyssey-react/src/components/Button/Button.theme.ts
+++ b/packages/odyssey-react/src/components/Button/Button.theme.ts
@@ -70,19 +70,16 @@ export const theme: ThemeReducer = (theme) => ({
   DangerHoverBackgroundColor: theme.ColorPaletteRed900,
   DangerHoverBorderColor: theme.ColorBorderDangerDark,
 
-  // Dismiss Variant
-  DismissBackgroundColor: "transparent",
-  DismissTextColor: "inherit",
-  DismissDisabledTextColor: theme.ColorNeutralBase,
-  DismissLineHeight: 1,
-  DismissPaddingBlock: theme.SpaceScale0,
-  DismissPaddingInline: theme.SpaceScale0,
-  DismissHoverBackgroundColor: "rgba(29, 29, 33, 0.1)",
-  DismissFocusBackgroundColor: "rgba(255, 255, 255, 0.6)",
-  DismissDisabledBackgroundColor: "rgba(235, 235, 237, 0.6)",
-
-  // Dismiss Inverted Variant
-  DismissInvertedBoxShadowColor: theme.ColorPaletteNeutralWhite,
+  // Floating Variant
+  FloatingBackgroundColor: "transparent",
+  FloatingTextColor: "inherit",
+  FloatingDisabledTextColor: theme.ColorNeutralBase,
+  FloatingLineHeight: 1,
+  FloatingPaddingBlock: theme.SpaceScale0,
+  FloatingPaddingInline: theme.SpaceScale0,
+  FloatingHoverBackgroundColor: "rgba(29, 29, 33, 0.1)",
+  FloatingFocusBackgroundColor: "rgba(255, 255, 255, 0.6)",
+  FloatingDisabledBackgroundColor: "rgba(235, 235, 237, 0.6)",
 
   // Clear Variant
   ClearBackgroundColor: "transparent",

--- a/packages/odyssey-react/src/components/Button/Button.tsx
+++ b/packages/odyssey-react/src/components/Button/Button.tsx
@@ -43,13 +43,7 @@ interface CommonProps
    * The visual variant to be displayed to the user.
    * @default primary
    */
-  variant?:
-    | "primary"
-    | "secondary"
-    | "danger"
-    | "dismiss"
-    | "dismissInverted"
-    | "clear";
+  variant?: "primary" | "secondary" | "danger" | "floating" | "clear";
 
   /**
    * Extends the width of the button to that of its' parent.

--- a/packages/odyssey-react/src/components/Modal/Modal.tsx
+++ b/packages/odyssey-react/src/components/Modal/Modal.tsx
@@ -171,7 +171,7 @@ const Header: FunctionComponent<PropsModalHeader> = (props) => {
       <span className={styles.dismiss}>
         <Modal.Button
           close
-          variant="dismiss"
+          variant="floating"
           icon={<CloseIcon title={closeMessage} />}
         />
       </span>

--- a/packages/odyssey-react/src/components/Toast/Toast.tsx
+++ b/packages/odyssey-react/src/components/Toast/Toast.tsx
@@ -149,7 +149,7 @@ export const Toast = withTheme(
         {body && <p className={styles.body}>{body}</p>}
         <span className={styles.dismiss}>
           <Button
-            variant={variant === "caution" ? "dismiss" : "dismissInverted"}
+            variant="floating"
             onClick={onDismiss}
             icon={<CloseIcon title={dismissButtonLabel} />}
           />

--- a/packages/odyssey-storybook/src/components/Button/Button.mdx
+++ b/packages/odyssey-storybook/src/components/Button/Button.mdx
@@ -18,7 +18,7 @@ Visually, a Button is a rounded rectangle with a descriptive caption at its cent
 
 ## Variants
 
-In Odyssey there are five Button variants: Primary, Secondary, Danger, Clear, and Dismiss.
+In Odyssey there are five Button variants: Primary, Secondary, Danger, Clear, and Floating.
 
 ### Primary
 
@@ -56,14 +56,14 @@ They pair well with Primary and Secondary Buttons.
   <Story id="components-button--clear" />
 </Canvas>
 
-### Dismiss
+### Floating
 
-The Dismiss Button should only be used for dismissing UI. Typically, this Button is included as part of a larger Odyssey component, but may be useful when constructing unique UIs.
+The Floating Button should only be used for dismissing UI. Typically, this Button is included as part of a larger Odyssey component, but may be useful when constructing unique UIs.
 
-The Dismiss Button has unique padding and will inherit the text color of it's parent UI.
+The Floating Button has unique padding and will inherit the text color of it's parent UI.
 
 <Canvas>
-  <Story id="components-button--dismiss" />
+  <Story id="components-button--floating" />
 </Canvas>
 
 ## Sizes

--- a/packages/odyssey-storybook/src/components/Button/Button.stories.tsx
+++ b/packages/odyssey-storybook/src/components/Button/Button.stories.tsx
@@ -66,9 +66,9 @@ Clear.args = {
   variant: "clear",
 };
 
-export const Dismiss = Template.bind({});
-Dismiss.args = {
-  variant: "dismiss",
+export const Floating = Template.bind({});
+Floating.args = {
+  variant: "floating",
   icon: <CloseIcon title="close" />,
   children: undefined,
 };


### PR DESCRIPTION
### Description

Renames our "dismiss" Button variant to "floating" and removes the previous "invertedDismiss" variant.

Use cases remain the same until we combine "clear" and "floating" into one variant.