### PR TITLE
fix(odyssey-react): make invalid border behavior consistent

### DIFF
--- a/packages/odyssey-react/src/components/Checkbox/Checkbox.module.scss
+++ b/packages/odyssey-react/src/components/Checkbox/Checkbox.module.scss
@@ -87,6 +87,12 @@
       .box {
         border-color: var(--BoxInvalidBorderColor);
       }
+
+      &:hover {
+        .box {
+          border-color: var(--BoxInvalidHoverBorderColor);
+        }
+      }
     }
 
     &:checked,
@@ -94,16 +100,6 @@
       + .label {
         .box {
           background-color: var(--BoxInvalidBackgroundColor);
-        }
-      }
-    }
-
-    &:not(:checked) {
-      + .label {
-        &:hover {
-          .box {
-            border-color: var(--BoxInvalidHoverBorderColor);
-          }
         }
       }
     }

--- a/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
@@ -66,6 +66,10 @@
 
   &.invalid {
     border-color: var(--InvalidBorderColor);
+
+    &:hover {
+      border-color: var(--InvalidHoverBorderColor);
+    }
   }
 
   &.invalid:focus-within {

--- a/packages/odyssey-react/src/components/TextInput/TextInput.theme.ts
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.theme.ts
@@ -31,6 +31,7 @@ export const theme: ThemeReducer = (theme) => ({
   HoverFocusBorderColor: theme.ColorPrimaryBase,
   IconSize: "1.1487rem",
   InvalidBorderColor: theme.ColorBorderDangerBase,
+  InvalidHoverBorderColor: theme.ColorDangerDark,
   InvalidFocusOutlineColor: theme.FocusOutlineColorDanger,
   LineHeight: theme.FontLineHeightUi,
   MarginBlock: 0,


### PR DESCRIPTION
### Description

Makes `border-color` `:hover` behavior consistent across invalid Form controls.