### PR TITLE
[WIP] Testing `:focus-visible` in place of `:focus`

### DIFF
--- a/packages/odyssey-react/src/components/Box/_box-hover-focus.scss
+++ b/packages/odyssey-react/src/components/Box/_box-hover-focus.scss
@@ -22,22 +22,22 @@
   box-shadow: var(--HoverBoxShadow);
 }
 
-.focusBorderColorPrimary:focus {
+.focusBorderColorPrimary:focus-visible {
   border-color: var(--PrimaryBorderColor);
 }
 
-.focusBorderColorDanger:focus {
+.focusBorderColorDanger:focus-visible {
   border-color: var(--DangerBorderColor);
 }
 
-.focusRingPrimary:focus {
+.focusRingPrimary:focus-visible {
   outline-color: var(--PrimaryFocusOutlineColor);
   outline-offset: var(--FocusOutlineOffset);
   outline-style: var(--FocusOutlineStyle);
   outline-width: var(--FocusOutlineWidth);
 }
 
-.focusRingDanger:focus {
+.focusRingDanger:focus-visible {
   outline-color: var(--DangerFocusOutlineColor);
   outline-offset: var(--FocusOutlineOffset);
   outline-style: var(--FocusOutlineStyle);

--- a/packages/odyssey-react/src/components/Button/Button.module.scss
+++ b/packages/odyssey-react/src/components/Button/Button.module.scss
@@ -41,7 +41,7 @@
     background-color: var(--PrimaryHoverBackgroundColor);
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--FocusOutlineColor);
     outline-offset: var(--FocusOutlineOffset);
     outline-style: var(--FocusOutlineStyle);
@@ -84,7 +84,7 @@
     color: var(--SecondaryHoverTextColor);
   }
 
-  &:focus {
+  &:focus-visible {
     background-color: var(--SecondaryFocusBackgroundColor);
     color: var(--SecondaryFocusTextColor);
   }
@@ -104,7 +104,7 @@
     background-color: var(--DangerHoverBackgroundColor);
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--DangerFocusOutlineColor);
     background-color: var(--DangerFocusBackgroundColor);
   }
@@ -124,7 +124,7 @@
   line-height: var(--FloatingLineHeight);
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     background-color: var(--FloatingHoverBackgroundColor);
   }
 
@@ -144,7 +144,7 @@
     color: var(--ClearHoverTextColor);
   }
 
-  &:focus {
+  &:focus-visible {
     background-color: var(--ClearFocusBackgroundColor);
     color: var(--ClearFocusTextColor);
   }

--- a/packages/odyssey-react/src/components/Checkbox/Checkbox.module.scss
+++ b/packages/odyssey-react/src/components/Checkbox/Checkbox.module.scss
@@ -46,7 +46,7 @@
     }
   }
 
-  &:focus {
+  &:focus-visible {
     + .label {
       .box {
         outline-color: var(--BoxFocusOutlineColor);
@@ -104,7 +104,7 @@
       }
     }
 
-    &:focus {
+    &:focus-visible {
       + .label {
         .box {
           outline-color: var(--BoxInvalidFocusOutlineColor);

--- a/packages/odyssey-react/src/components/Link/Link.module.scss
+++ b/packages/odyssey-react/src/components/Link/Link.module.scss
@@ -21,7 +21,7 @@
     text-decoration: underline;
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--FocusOutlineColor);
     outline-offset: var(--FocusOutlineOffset);
     outline-style: var(--FocusOutlineStyle);

--- a/packages/odyssey-react/src/components/NativeSelect/NativeSelect.module.scss
+++ b/packages/odyssey-react/src/components/NativeSelect/NativeSelect.module.scss
@@ -38,11 +38,11 @@
   }
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     border-color: var(--HoverFocusBorderColor);
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--FocusOutlineColor);
     outline-offset: var(--FocusOutlineOffset);
     outline-style: var(--FocusOutlineStyle);
@@ -64,7 +64,7 @@
     }
   }
 
-  &:invalid:focus {
+  &:invalid:focus-visible {
     outline-color: var(--InvalidFocusOutlineColor);
   }
 }

--- a/packages/odyssey-react/src/components/Radio/RadioButton.module.scss
+++ b/packages/odyssey-react/src/components/Radio/RadioButton.module.scss
@@ -28,7 +28,7 @@
     }
   }
 
-  &:focus,
+  &:focus-visible,
   &.focus {
     + .label {
       &::before {
@@ -87,7 +87,7 @@
       }
     }
 
-    &:focus {
+    &:focus-visible {
       + .label {
         &::before {
           outline-color: var(--CircleInvalidFocusOutlineColor);

--- a/packages/odyssey-react/src/components/Select/Select.module.scss
+++ b/packages/odyssey-react/src/components/Select/Select.module.scss
@@ -37,11 +37,11 @@
   line-height: var(--LineHeight);
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     border-color: var(--HoverFocusBorderColor);
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--FocusOutlineColor);
     outline-offset: var(--FocusOutlineOffset);
     outline-style: var(--FocusOutlineStyle);
@@ -67,7 +67,7 @@
   &:invalid {
     border-color: var(--InvalidBorderColor);
 
-    &:focus {
+    &:focus-visible {
       outline-color: var(--InvalidFocusOutlineColor);
     }
   }
@@ -92,7 +92,7 @@
   overflow: hidden;
   font-size: var(--FontSize);
 
-  &:focus,
+  &:focus-visible,
   &.focused,
   .focus & {
     @include border-radius(var(--BorderRadius));
@@ -133,7 +133,7 @@
       }
     }
 
-    &:focus,
+    &:focus-visible,
     &.focused {
       outline: 0;
     }
@@ -144,7 +144,7 @@
   }
 
   .invalid & {
-    &:focus,
+    &:focus-visible,
     &.focused {
       @include border-radius(var(--BorderRadius));
 
@@ -203,11 +203,11 @@
     opacity: 0.25;
 
     &:hover,
-    &:focus {
+    &:focus-visible {
       opacity: 1;
     }
 
-    &:focus {
+    &:focus-visible {
       outline-color: var(--FocusOutlineColor);
       outline-offset: var(--FocusOutlineOffset);
       outline-style: var(--FocusOutlineStyle);
@@ -284,7 +284,7 @@
     line-height: 1;
 
     &:hover,
-    &:focus {
+    &:focus-visible {
       background-color: var(--ButtonHoverFocusBackgroundColor);
     }
   }
@@ -557,7 +557,7 @@
   text-indent: -9999px;
   appearance: none;
 
-  &:focus {
+  &:focus-visible {
     outline: none;
   }
 }
@@ -576,7 +576,7 @@
   padding-inline-end: 0;
   vertical-align: baseline;
 
-  &:focus {
+  &:focus-visible {
     outline: 0;
   }
 

--- a/packages/odyssey-react/src/components/Tabs/Tabs.module.scss
+++ b/packages/odyssey-react/src/components/Tabs/Tabs.module.scss
@@ -35,11 +35,11 @@
   }
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     color: var(--TabHoverTextColor);
   }
 
-  &:focus {
+  &:focus-visible {
     outline: 0;
   }
 }
@@ -47,7 +47,7 @@
 .label {
   @include border-radius(var(--LabelBorderRadius));
 
-  .tab:focus & {
+  .tab:focus-visible & {
     outline-color: var(--LabelFocusOutlineColor);
     outline-offset: var(--LabelFocusOutlineOffset);
     outline-style: var(--LabelFocusOutlineStyle);
@@ -59,7 +59,7 @@
   padding-block: var(--PanelPaddingBlock);
   padding-inline: var(--PanelPaddingInline);
 
-  &:focus {
+  &:focus-visible {
     outline: none;
   }
 }

--- a/packages/odyssey-react/src/components/Text/Text.module.scss
+++ b/packages/odyssey-react/src/components/Text/Text.module.scss
@@ -229,7 +229,7 @@
     cursor: default;
 
     // stylelint-disable-next-line selector-max-type
-    &:focus {
+    &:focus-visible {
       outline-color: var(--SummaryFocusOutlineColor);
       outline-offset: var(--SummaryFocusOutlineOffset);
       outline-style: var(--SummaryFocusOutlineStyle);

--- a/packages/odyssey-react/src/components/TextArea/TextArea.module.scss
+++ b/packages/odyssey-react/src/components/TextArea/TextArea.module.scss
@@ -39,11 +39,11 @@
   line-height: var(--LineHeight);
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     border-color: var(--HoverFocusBorderColor);
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--FocusOutlineColor);
     outline-offset: var(--FocusOutlineOffset);
     outline-style: var(--FocusOutlineStyle);
@@ -70,7 +70,7 @@
     }
   }
 
-  &:invalid:focus {
+  &:invalid:focus-visible {
     outline-color: var(--InvalidFocusOutlineColor);
   }
 

--- a/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
@@ -33,11 +33,11 @@
   line-height: var(--LineHeight);
 
   &:hover,
-  &:focus-within {
+  &:focus-visible-within {
     border-color: var(--HoverFocusBorderColor);
   }
 
-  &:focus-within {
+  &:focus-visible-within {
     outline-color: var(--FocusOutlineColor);
     outline-offset: var(--FocusOutlineOffset);
     outline-style: var(--FocusOutlineStyle);
@@ -72,7 +72,7 @@
     }
   }
 
-  &.invalid:focus-within {
+  &.invalid:focus-visible-within {
     outline-color: var(--InvalidFocusOutlineColor);
   }
 }
@@ -106,7 +106,7 @@
   border: 0;
   font: inherit;
 
-  &:focus {
+  &:focus-visible {
     outline: 0;
   }
 }

--- a/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
+++ b/packages/odyssey-react/src/components/TextInput/TextInput.module.scss
@@ -33,11 +33,11 @@
   line-height: var(--LineHeight);
 
   &:hover,
-  &:focus-visible-within {
+  &:focus-within {
     border-color: var(--HoverFocusBorderColor);
   }
 
-  &:focus-visible-within {
+  &:focus-within {
     outline-color: var(--FocusOutlineColor);
     outline-offset: var(--FocusOutlineOffset);
     outline-style: var(--FocusOutlineStyle);
@@ -72,7 +72,7 @@
     }
   }
 
-  &.invalid:focus-visible-within {
+  &.invalid:focus-within {
     outline-color: var(--InvalidFocusOutlineColor);
   }
 }

--- a/packages/odyssey-react/src/components/Toast/Toast.module.scss
+++ b/packages/odyssey-react/src/components/Toast/Toast.module.scss
@@ -30,7 +30,7 @@
   color: var(--TextColor);
 
   &:hover,
-  &:focus-visible-within {
+  &:focus-within {
     animation-delay: 0s, var(--HoverOutAnimationDelay);
   }
 

--- a/packages/odyssey-react/src/components/Toast/Toast.module.scss
+++ b/packages/odyssey-react/src/components/Toast/Toast.module.scss
@@ -30,7 +30,7 @@
   color: var(--TextColor);
 
   &:hover,
-  &:focus-within {
+  &:focus-visible-within {
     animation-delay: 0s, var(--HoverOutAnimationDelay);
   }
 

--- a/packages/odyssey-react/src/components/Tooltip/Tooltip.module.scss
+++ b/packages/odyssey-react/src/components/Tooltip/Tooltip.module.scss
@@ -53,9 +53,9 @@
   }
 
   /* stylelint-disable-next-line selector-max-universal */
-  .hasTooltip *:focus + &,
+  .hasTooltip *:focus-visible + &,
   .hasTooltip:hover &,
-  .hasTooltip:focus & {
+  .hasTooltip:focus-visible & {
     visibility: visible;
     opacity: 1;
   }

--- a/packages/odyssey-react/src/scss/abstracts/_mixins.scss
+++ b/packages/odyssey-react/src/scss/abstracts/_mixins.scss
@@ -85,13 +85,13 @@
 
   /* stylelint-disable selector-class-pattern */
   &:hover,
-  &:focus,
+  &:focus-visible,
   &.is-ods-input-hover,
   &.is-ods-input-focus {
     border-color: cv("blue");
   }
 
-  &:focus,
+  &:focus-visible,
   &.is-ods-input-focus {
     @include outline;
   }
@@ -118,7 +118,7 @@
   &.is-ods-input-invalid {
     border-color: $color-danger-base;
 
-    &:focus {
+    &:focus-visible {
       @include outline($focus-ring-danger);
     }
   }


### PR DESCRIPTION
### Description

It may behoove us to utilize `:focus-visible` throughout the system in order to make pointer interactions feel more natural while still providing visible focus states during keyboard interactions.

Current open questions/concerns:

- `:focus-visible` isn't available in all the browsers we support, so we'd need a polyfill or fallbacks for IE11
- We'd want this behavior to be uniform throughout the system to avoid confusing users with inconsistency
- We should enumerate current focus states and whether this selector is more appropriate for those components
- While WCAG criterion 2.4.7 refers to "keyboard focus", we'll want to ensure this change doesn't compromise on usability in another way (e.g. users with low digital literacy or low-vision users with pointer devices)