### PR TITLE
fix(odyssey-react): MultiSelect dismissal is visible again

### DIFF
--- a/packages/odyssey-react/src/components/Select/Select.module.scss
+++ b/packages/odyssey-react/src/components/Select/Select.module.scss
@@ -280,7 +280,7 @@
     background-color: var(--ButtonBackgroundColor);
     background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg viewBox='0 0 14 14' fill='none' xmlns='http://www.w3.org/2000/svg' class='ods-icon'%3E%3Cpath d='M2.323 10.118a1.102 1.102 0 1 0 1.559 1.56L7 8.558l3.118 3.118a1.102 1.102 0 0 0 1.56-1.559L8.558 7l3.118-3.118a1.102 1.102 0 0 0-1.559-1.56L7 5.442 3.882 2.323a1.102 1.102 0 1 0-1.56 1.559L5.442 7l-3.118 3.118Z' fill='%23fff'/%3E%3C/svg%3E");
     background-position: center;
-    background-size: calc(var(--LineHeight) * 1em - 1em);
+    background-size: var(--DismissSize);
     line-height: 1;
 
     &:hover,

--- a/packages/odyssey-react/src/components/Select/Select.theme.ts
+++ b/packages/odyssey-react/src/components/Select/Select.theme.ts
@@ -30,6 +30,7 @@ export const theme: ThemeReducer = (theme) => ({
   DisabledReadonlyBorderColor: theme.ColorBorderDisabled,
   DisabledReadonlyHoverBorderColor: theme.ColorBorderDisabled,
   DisabledTextColor: theme.ColorTextSub,
+  DismissSize: theme.SpaceScale1,
   FocusOutlineColor: theme.FocusOutlineColorPrimary,
   FocusOutlineOffset: theme.FocusOutlineOffsetTight,
   FocusOutlineStyle: theme.FocusOutlineStyle,


### PR DESCRIPTION
### Description

#### Before

![image (1)](https://user-images.githubusercontent.com/36284167/165817518-5b65fd3e-9eb4-462d-9eef-94311e08d191.png)

#### After

<img width="462" alt="Screen Shot 2022-04-28 at 10 59 53 AM" src="https://user-images.githubusercontent.com/36284167/165817562-bbafecc6-62d0-4daf-bf89-088302a38430.png">

