### PR TITLE
build: use fixed node version instead of alias

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v2
         with:
-          node-version: lts/gallium
+          node-version: v16.15.0
           cache: yarn
       - name: node_modules cache
         uses: actions/cache@v2

--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -15,7 +15,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v2
         with:
-          node-version: lts/gallium
+          node-version: v16.15.0
           cache: yarn
       - name: node_modules cache
         uses: actions/cache@v2

--- a/.github/workflows/x-browser-vrt.yml
+++ b/.github/workflows/x-browser-vrt.yml
@@ -18,7 +18,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v2
         with:
-          node-version: lts/gallium
+          node-version: v16.15.0
           cache: yarn
       - name: node_modules cache
         uses: actions/cache@v2

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/gallium
+v16.15.0

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-NODE_VERSION=lts/gallium
+NODE_VERSION=v16.15.0
 
 echo "installing node ${NODE_VERSION}"
 if setup_service node $NODE_VERSION; then


### PR DESCRIPTION
### Description

Uses `v16.15.0` instead of `lts/gallium`.