### PR TITLE
Fix: rename misspelled 'dismissable' props/docs/styles

### DIFF
--- a/packages/odyssey-react/src/components/Banner/Banner.module.scss
+++ b/packages/odyssey-react/src/components/Banner/Banner.module.scss
@@ -54,10 +54,10 @@
   display: none;
 }
 
-.isDismissable {
-  padding-block: var(--DismissablePaddingBlock);
-  padding-inline-start: var(--DismissablePaddingInlineStart);
-  padding-inline-end: var(--DismissablePaddingInlineEnd);
+.isDismissible {
+  padding-block: var(--DismissiblePaddingBlock);
+  padding-inline-start: var(--DismissiblePaddingInlineStart);
+  padding-inline-end: var(--DismissiblePaddingInlineEnd);
 }
 
 .infoVariant {

--- a/packages/odyssey-react/src/components/Banner/Banner.theme.ts
+++ b/packages/odyssey-react/src/components/Banner/Banner.theme.ts
@@ -33,9 +33,9 @@ export const theme: ThemeReducer = (theme) => ({
   DismissButtonInsetInlineEnd: theme.SpaceScale3,
   DismissButtonMarginInlineStart: theme.SpaceScale3,
 
-  DismissablePaddingBlock: theme.SpaceScale3,
-  DismissablePaddingInlineEnd: theme.SpaceScale6,
-  DismissablePaddingInlineStart: theme.SpaceScale3,
+  DismissiblePaddingBlock: theme.SpaceScale3,
+  DismissiblePaddingInlineEnd: theme.SpaceScale6,
+  DismissiblePaddingInlineStart: theme.SpaceScale3,
 
   CautionBackgroundColor: theme.ColorBackgroundCautionLight,
   CautionIconColor: theme.ColorCautionDark,

--- a/packages/odyssey-react/src/components/Banner/Banner.tsx
+++ b/packages/odyssey-react/src/components/Banner/Banner.tsx
@@ -94,7 +94,7 @@ export const Banner = withTheme(
       styles.root,
       styles[`${variant}Variant`],
       !open && styles.isDismissed,
-      onDismiss && styles.isDismissable
+      onDismiss && styles.isDismissible
     );
 
     const omitProps = useOmit(rest);

--- a/packages/odyssey-storybook/src/components/Banner/Banner.mdx
+++ b/packages/odyssey-storybook/src/components/Banner/Banner.mdx
@@ -67,7 +67,7 @@ It's often useful to direct users toward an appropriate action, especially for f
 Banners support dismissal for messages that do not persist or only require a one-time acknowledgement.
 
 <Canvas>
-  <Story id="components-banner--dismissable" />
+  <Story id="components-banner--dismissible" />
 </Canvas>
 
 ## Content Guidelines
@@ -118,10 +118,10 @@ When including an action, be sure the link text clearly indicates where it leads
         </th>
         <th scope="column">
           <span class="has-ods-tooltip">
-            <abbr aria-describedby="tip-dismissable">Dismissable</abbr>
+            <abbr aria-describedby="tip-dismissible">Dismissible</abbr>
             <aside
               class="ods-tooltip is-ods-tooltip-top"
-              id="tip-dismissable"
+              id="tip-dismissible"
               role="tooltip"
             >
               May be dismissed by the user

--- a/packages/odyssey-storybook/src/components/Banner/Banner.stories.tsx
+++ b/packages/odyssey-storybook/src/components/Banner/Banner.stories.tsx
@@ -106,15 +106,15 @@ WithLink.args = {
   ),
 };
 
-export const Dismissable = Template.bind({});
-Dismissable.args = {
+export const Dismissible = Template.bind({});
+Dismissible.args = {
   variant: "caution",
   content: "Severe solar winds detected. Local system flights may be delayed.",
   onDismiss: () => {
     console.log("Banner: onDismiss!");
   },
 };
-Dismissable.argTypes = {
+Dismissible.argTypes = {
   onDismiss: {
     control: { disable: false },
   },

--- a/packages/odyssey-storybook/src/components/Infobox/Infobox.mdx
+++ b/packages/odyssey-storybook/src/components/Infobox/Infobox.mdx
@@ -9,7 +9,7 @@ An infobox is a type of alert that provides feedback in response to a user actio
 
 ## Behavior
 
-This component may be present on load or triggered by different types of events, but they are not transient or dismissable.
+This component may be present on load or triggered by different types of events, but they are not transient or dismissible.
 
 ## Variants
 
@@ -147,10 +147,10 @@ When deploying Infoboxes, two `role`s may apply. Danger variants should utilize 
         </th>
         <th scope="column">
           <span class="has-ods-tooltip">
-            <abbr aria-describedby="tip-dismissable">Dismissable</abbr>
+            <abbr aria-describedby="tip-dismissible">Dismissible</abbr>
             <aside
               class="ods-tooltip is-ods-tooltip-top"
-              id="tip-dismissable"
+              id="tip-dismissible"
               role="tooltip"
             >
               May be dismissed by the user

--- a/packages/odyssey-storybook/src/components/Toast/Toast.mdx
+++ b/packages/odyssey-storybook/src/components/Toast/Toast.mdx
@@ -111,10 +111,10 @@ Do not use Danger Toasts for in-page errors such as invalid form fields. Instead
         </th>
         <th scope="column">
           <span class="has-ods-tooltip">
-            <abbr aria-describedby="tip-dismissable">Dismissable</abbr>
+            <abbr aria-describedby="tip-dismissible">Dismissible</abbr>
             <aside
               class="ods-tooltip is-ods-tooltip-top"
-              id="tip-dismissable"
+              id="tip-dismissible"
               role="tooltip"
             >
               May be dismissed by the user

--- a/packages/odyssey-storybook/src/guidelines/DocsStatus.stories.mdx
+++ b/packages/odyssey-storybook/src/guidelines/DocsStatus.stories.mdx
@@ -72,7 +72,7 @@ The existing Banner stories don't make distinctions regarding the optional and m
 - Info
 - Danger
 - Caution
-- Dismissable (identical to Info)
+- Dismissible (identical to Info)
 
 ##### Assumed
 
@@ -86,7 +86,7 @@ The existing Banner stories don't make distinctions regarding the optional and m
 
 - Title
 - Actions
-- Dismissable
+- Dismissible
 
 ### Button
 


### PR DESCRIPTION
### Description

Renames 'dismissable' props/docs/styles to 'dismissible'.