### PR TITLE
[Design, FixIt] update Modal display, add tokens for Padding

### DIFF
--- a/packages/odyssey-react/src/components/Modal/Modal.module.scss
+++ b/packages/odyssey-react/src/components/Modal/Modal.module.scss
@@ -70,7 +70,13 @@
 
 .header {
   display: flex;
-  flex-direction: column;
+  flex-direction: row-reverse;
+  align-items: center;
+  padding-block-end: var(--HeaderPaddingBlockEnd);
+}
+
+.heading {
+  flex: 1;
 }
 
 .dismiss {
@@ -88,6 +94,7 @@
 .footer {
   display: flex;
   justify-content: flex-end;
+  padding-block-start: var(--FooterPaddingBlockStart);
   padding-block-end: var(--FooterPaddingBlockEnd);
 }
 

--- a/packages/odyssey-react/src/components/Modal/Modal.theme.ts
+++ b/packages/odyssey-react/src/components/Modal/Modal.theme.ts
@@ -15,15 +15,23 @@ import type { ThemeReducer } from "@okta/odyssey-react-theme";
 export const theme: ThemeReducer = (theme) => ({
   AnimationDuration: theme.TransitionDurationBase,
   AnimationTimingFunction: theme.TransitionTimingBase,
+
   ContentFontSize: theme.FontSizeBody,
-  ContentPaddingBlockEnd: theme.SpaceScale5,
-  ContentPaddingBlockStart: theme.SpaceScale3,
+  ContentPaddingBlockEnd: theme.SpaceScale3,
+  ContentPaddingBlockStart: theme.SpaceScale1,
   ContentPaddingInline: 0,
+
   DialogBackgroundColor: theme.ColorBackgroundBase,
-  DialogPaddingBlockEnd: 0,
-  DialogPaddingBlockStart: theme.SpaceScale3,
+  DialogPaddingBlockEnd: theme.SpaceScale5,
+  DialogPaddingBlockStart: theme.SpaceScale5,
   DialogPaddingInline: theme.SpaceScale5,
+
   DismissMarginBlockEnd: theme.SpaceScale0,
-  FooterPaddingBlockEnd: theme.SpaceScale3,
+
+  FooterPaddingBlockStart: theme.SpaceScale3,
+  FooterPaddingBlockEnd: 0,
+
+  HeaderPaddingBlockEnd: theme.SpaceScale3,
+
   OverlayBackgroundColor: "rgba(29, 29, 33, 0.75)",
 });

--- a/packages/odyssey-react/src/components/Modal/Modal.tsx
+++ b/packages/odyssey-react/src/components/Modal/Modal.tsx
@@ -175,12 +175,14 @@ const Header: FunctionComponent<PropsModalHeader> = (props) => {
           icon={<CloseIcon title={closeMessage} />}
         />
       </span>
-      <Heading
-        id={modalHeadingId}
-        visualLevel="4"
-        noEndMargin
-        children={children}
-      />
+      <span className={styles.heading}>
+        <Heading
+          id={modalHeadingId}
+          visualLevel="4"
+          noEndMargin
+          children={children}
+        />
+      </span>
     </Box>
   );
 };


### PR DESCRIPTION
### Description

Updates our Modal to be aligned with the latest visual designs. This also adds tokens for Header, Content, and Footer padding to make updates simpler in the future.

#### Before

<img width="544" alt="Screen Shot 2022-05-05 at 2 41 46 PM" src="https://user-images.githubusercontent.com/36284167/167030306-af64051a-68c6-4ecf-9001-03c1bc482739.png">

#### After

<img width="523" alt="Screen Shot 2022-05-05 at 2 41 36 PM" src="https://user-images.githubusercontent.com/36284167/167030328-242d1abc-911b-4dbb-8e16-49f82ec77d2a.png">
