### PR TITLE
[Docs] Make "Docs" tab the default rather than "Canvas"

### DIFF
--- a/packages/odyssey-storybook/.storybook/preview.js
+++ b/packages/odyssey-storybook/.storybook/preview.js
@@ -20,6 +20,7 @@ export const parameters = {
       locales: "",
     },
   },
+  viewMode: "docs",
   previewTabs: {
     "storybook/docs/panel": { index: -1 },
   },

--- a/packages/odyssey-storybook/src/components/Banner/Banner.mdx
+++ b/packages/odyssey-storybook/src/components/Banner/Banner.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/Banner/Banner.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # Banner
 

--- a/packages/odyssey-storybook/src/components/Box/Box.mdx
+++ b/packages/odyssey-storybook/src/components/Box/Box.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { Canvas, Meta, Story, ArgsTable } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/Box/Box.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # Box
 

--- a/packages/odyssey-storybook/src/components/Button/Button.mdx
+++ b/packages/odyssey-storybook/src/components/Button/Button.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/Button/Button.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # Button
 

--- a/packages/odyssey-storybook/src/components/Checkbox/Checkbox.mdx
+++ b/packages/odyssey-storybook/src/components/Checkbox/Checkbox.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/Checkbox/Checkbox.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # Checkbox
 

--- a/packages/odyssey-storybook/src/components/CircularLoadIndicator/CircularLoadIndicator.mdx
+++ b/packages/odyssey-storybook/src/components/CircularLoadIndicator/CircularLoadIndicator.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/CircularLoadIndicator/CircularLoadIndicator.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # CircularLoadIndicator
 

--- a/packages/odyssey-storybook/src/components/Field/Field.mdx
+++ b/packages/odyssey-storybook/src/components/Field/Field.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/Field/Field.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # Field
 

--- a/packages/odyssey-storybook/src/components/FieldGroup/FieldGroup.mdx
+++ b/packages/odyssey-storybook/src/components/FieldGroup/FieldGroup.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/FieldGroup/FieldGroup.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # FieldGroup
 

--- a/packages/odyssey-storybook/src/components/Form/Form.mdx
+++ b/packages/odyssey-storybook/src/components/Form/Form.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/Form/Form.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # Form
 

--- a/packages/odyssey-storybook/src/components/Heading/Heading.mdx
+++ b/packages/odyssey-storybook/src/components/Heading/Heading.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/Heading/Heading.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # Heading
 

--- a/packages/odyssey-storybook/src/components/Infobox/Infobox.mdx
+++ b/packages/odyssey-storybook/src/components/Infobox/Infobox.mdx
@@ -1,7 +1,9 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/Infobox/Infobox.theme";
 import { CheckIcon, CloseIcon } from "../../../../odyssey-react/src";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # Infobox
 

--- a/packages/odyssey-storybook/src/components/Link/Link.mdx
+++ b/packages/odyssey-storybook/src/components/Link/Link.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/Link/Link.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # Link
 

--- a/packages/odyssey-storybook/src/components/List/List.mdx
+++ b/packages/odyssey-storybook/src/components/List/List.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/List/List.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # List
 

--- a/packages/odyssey-storybook/src/components/Modal/Modal.mdx
+++ b/packages/odyssey-storybook/src/components/Modal/Modal.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/Modal/Modal.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # Modal
 

--- a/packages/odyssey-storybook/src/components/NativeSelect/NativeSelect.mdx
+++ b/packages/odyssey-storybook/src/components/NativeSelect/NativeSelect.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/NativeSelect/NativeSelect.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # NativeSelect
 

--- a/packages/odyssey-storybook/src/components/Radio/Radio.mdx
+++ b/packages/odyssey-storybook/src/components/Radio/Radio.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/Radio/RadioButton.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # Radio
 

--- a/packages/odyssey-storybook/src/components/Select/Select.mdx
+++ b/packages/odyssey-storybook/src/components/Select/Select.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/Select/Select.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # Select
 

--- a/packages/odyssey-storybook/src/components/Status/Status.mdx
+++ b/packages/odyssey-storybook/src/components/Status/Status.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/Status/Status.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # Status
 

--- a/packages/odyssey-storybook/src/components/Table/Table.mdx
+++ b/packages/odyssey-storybook/src/components/Table/Table.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/Table/Table.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # Table
 

--- a/packages/odyssey-storybook/src/components/Tabs/Tabs.mdx
+++ b/packages/odyssey-storybook/src/components/Tabs/Tabs.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/Tabs/Tabs.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # Tabs
 

--- a/packages/odyssey-storybook/src/components/TagList/TagList.mdx
+++ b/packages/odyssey-storybook/src/components/TagList/TagList.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/TagList/TagList.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # TagList
 

--- a/packages/odyssey-storybook/src/components/Text/Text.mdx
+++ b/packages/odyssey-storybook/src/components/Text/Text.mdx
@@ -1,7 +1,9 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Text } from "../../../../odyssey-react/src";
 import { theme } from "../../../../odyssey-react/src/components/Text/Text.theme";
 import { ThemeTable } from "../../../.storybook/components";
-import { Text } from "../../../../odyssey-react/src";
+
+<Meta anchor />
 
 # Text
 

--- a/packages/odyssey-storybook/src/components/TextArea/TextArea.mdx
+++ b/packages/odyssey-storybook/src/components/TextArea/TextArea.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/TextArea/TextArea.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # TextArea
 

--- a/packages/odyssey-storybook/src/components/TextInput/TextInput.mdx
+++ b/packages/odyssey-storybook/src/components/TextInput/TextInput.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/TextInput/TextInput.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # Text Input
 

--- a/packages/odyssey-storybook/src/components/Toast/Toast.mdx
+++ b/packages/odyssey-storybook/src/components/Toast/Toast.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/Toast/Toast.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # Toast
 

--- a/packages/odyssey-storybook/src/components/Tooltip/Tooltip.mdx
+++ b/packages/odyssey-storybook/src/components/Tooltip/Tooltip.mdx
@@ -1,6 +1,8 @@
-import { Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { theme } from "../../../../odyssey-react/src/components/Tooltip/Tooltip.theme";
 import { ThemeTable } from "../../../.storybook/components";
+
+<Meta anchor />
 
 # Tooltip
 


### PR DESCRIPTION
### Description

This makes "Docs" tab our default when viewing Storybook. The addition of `<Meta anchor />` is required on `.mdx` pages with stories, so that Storybook doesn't auto-scroll to the first CSF on load.