### PR TITLE
feat(odyssey-react): utilize :focus-visible for less intrusive ui

### DIFF
--- a/packages/odyssey-react/src/components/Box/_box-hover-focus.scss
+++ b/packages/odyssey-react/src/components/Box/_box-hover-focus.scss
@@ -22,22 +22,22 @@
   box-shadow: var(--HoverBoxShadow);
 }
 
-.focusBorderColorPrimary:focus {
+.focusBorderColorPrimary:focus-visible {
   border-color: var(--PrimaryBorderColor);
 }
 
-.focusBorderColorDanger:focus {
+.focusBorderColorDanger:focus-visible {
   border-color: var(--DangerBorderColor);
 }
 
-.focusRingPrimary:focus {
+.focusRingPrimary:focus-visible {
   outline-color: var(--PrimaryFocusOutlineColor);
   outline-offset: var(--FocusOutlineOffset);
   outline-style: var(--FocusOutlineStyle);
   outline-width: var(--FocusOutlineWidth);
 }
 
-.focusRingDanger:focus {
+.focusRingDanger:focus-visible {
   outline-color: var(--DangerFocusOutlineColor);
   outline-offset: var(--FocusOutlineOffset);
   outline-style: var(--FocusOutlineStyle);

--- a/packages/odyssey-react/src/components/Checkbox/Checkbox.module.scss
+++ b/packages/odyssey-react/src/components/Checkbox/Checkbox.module.scss
@@ -46,7 +46,7 @@
     }
   }
 
-  &:focus {
+  &:focus-visible {
     + .label {
       .box {
         outline-color: var(--BoxFocusOutlineColor);
@@ -104,7 +104,7 @@
       }
     }
 
-    &:focus {
+    &:focus-visible {
       + .label {
         .box {
           outline-color: var(--BoxInvalidFocusOutlineColor);

--- a/packages/odyssey-react/src/components/Link/Link.module.scss
+++ b/packages/odyssey-react/src/components/Link/Link.module.scss
@@ -21,7 +21,7 @@
     text-decoration: underline;
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--FocusOutlineColor);
     outline-offset: var(--FocusOutlineOffset);
     outline-style: var(--FocusOutlineStyle);

--- a/packages/odyssey-react/src/components/Radio/RadioButton.module.scss
+++ b/packages/odyssey-react/src/components/Radio/RadioButton.module.scss
@@ -28,7 +28,7 @@
     }
   }
 
-  &:focus,
+  &:focus-visible,
   &.focus {
     + .label {
       &::before {
@@ -87,7 +87,7 @@
       }
     }
 
-    &:focus {
+    &:focus-visible {
       + .label {
         &::before {
           outline-color: var(--CircleInvalidFocusOutlineColor);

--- a/packages/odyssey-react/src/components/Tabs/Tabs.module.scss
+++ b/packages/odyssey-react/src/components/Tabs/Tabs.module.scss
@@ -35,11 +35,11 @@
   }
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     color: var(--TabHoverTextColor);
   }
 
-  &:focus {
+  &:focus-visible {
     outline: 0;
   }
 }
@@ -47,7 +47,7 @@
 .label {
   @include border-radius(var(--LabelBorderRadius));
 
-  .tab:focus & {
+  .tab:focus-visible & {
     outline-color: var(--LabelFocusOutlineColor);
     outline-offset: var(--LabelFocusOutlineOffset);
     outline-style: var(--LabelFocusOutlineStyle);
@@ -59,7 +59,7 @@
   padding-block: var(--PanelPaddingBlock);
   padding-inline: var(--PanelPaddingInline);
 
-  &:focus {
+  &:focus-visible {
     outline: none;
   }
 }

--- a/packages/odyssey-react/src/components/Text/Text.module.scss
+++ b/packages/odyssey-react/src/components/Text/Text.module.scss
@@ -229,7 +229,7 @@
     cursor: default;
 
     // stylelint-disable-next-line selector-max-type
-    &:focus {
+    &:focus-visible {
       outline-color: var(--SummaryFocusOutlineColor);
       outline-offset: var(--SummaryFocusOutlineOffset);
       outline-style: var(--SummaryFocusOutlineStyle);


### PR DESCRIPTION
### Description

Transitions most components to use `:focus-visible` rather than `:focus`. TextInput and components sharing that form factor continue to use `:focus` for an additional affordance when inputting data.