### PR TITLE
Infobox: remove width constraints

### DIFF
--- a/packages/odyssey-react/src/components/Infobox/Infobox.module.scss
+++ b/packages/odyssey-react/src/components/Infobox/Infobox.module.scss
@@ -14,7 +14,7 @@
   @include border-radius(var(--BorderRadius));
 
   position: relative;
-  max-width: calc(var(--MaxLineLength) + calc(var(--PaddingInline) * 2));
+  max-width: 100%;
   padding-block: var(--PaddingBlock);
   padding-inline: calc(
     var(--IconSize) + var(--IconMargin) + var(--PaddingInline)

--- a/packages/odyssey-react/src/components/Infobox/Infobox.theme.ts
+++ b/packages/odyssey-react/src/components/Infobox/Infobox.theme.ts
@@ -19,8 +19,6 @@ export const theme: ThemeReducer = (theme) => ({
   BorderWidth: theme.BorderWidthBase,
   ColumnGap: theme.SpaceScale2,
   MarginBlockEnd: theme.SpaceScale3,
-  // eslint-disable-next-line @okta/odyssey/no-invalid-theme-properties
-  MaxLineLength: theme.FontLineLengthMax,
   PaddingBlock: theme.SpaceScale3,
   PaddingInline: theme.SpaceScale3,
 

--- a/packages/odyssey-storybook/src/components/Infobox/Infobox.mdx
+++ b/packages/odyssey-storybook/src/components/Infobox/Infobox.mdx
@@ -73,9 +73,9 @@ The actions section is limited to links. If it's necessary to provide the user w
 
 ### Placement
 
-Infoboxes should be displayed above the content they apply to but not higher than their scope.
+Infoboxes will stretch to fit the width of their parent. Be mindful of this behavior, as it will help indicate the scope of their messaging. Infoboxes should be displayed above the content they apply to but not higher than their scope.
 
-For example, a Form error should be displayed above all Fieldsets, but below the Form title.
+For example, a Form error should be displayed above all Fieldsets, but below the Form title. In this example, the Infobox is constrained to the width of the Form.
 
 <Canvas className="sb-do">
   <Story id="components-infobox--form-do" />


### PR DESCRIPTION
### Description

This PR sets Infobox's `max-width` to `100%` as requested here: https://oktainc.atlassian.net/browse/OKTA-500082

The docs have also been updated to indicate that Infobox will now be constrained by its parent.

### Shots

<img width="1023" alt="Screen Shot 2022-05-23 at 10 40 58 AM" src="https://user-images.githubusercontent.com/36284167/169876928-97dbed62-13cd-49f8-9376-eaec68105ef8.png">

<img width="1021" alt="Screen Shot 2022-05-23 at 10 41 14 AM" src="https://user-images.githubusercontent.com/36284167/169876923-7250fdb1-2fb8-4e58-a846-c59adc4e1c7b.png">

<img width="1028" alt="Screen Shot 2022-05-23 at 10 41 04 AM" src="https://user-images.githubusercontent.com/36284167/169876926-47c98114-4bbf-4e64-b97a-70225d5ff93a.png">

