### PR TITLE
Fix: Show overflow content in Modals

### DIFF
--- a/packages/odyssey-react/src/components/Modal/Modal.module.scss
+++ b/packages/odyssey-react/src/components/Modal/Modal.module.scss
@@ -52,7 +52,7 @@
   padding-block-start: var(--DialogPaddingBlockStart);
   padding-block-end: var(--DialogPaddingBlockEnd);
   padding-inline: var(--DialogPaddingInline);
-  overflow-y: auto;
+  overflow-y: visible;
   background-color: var(--DialogBackgroundColor);
 
   .root[aria-hidden="false"] & {

--- a/packages/odyssey-storybook/src/components/Modal/Modal.stories.tsx
+++ b/packages/odyssey-storybook/src/components/Modal/Modal.stories.tsx
@@ -13,7 +13,13 @@
 import React from "react";
 import { Story } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
-import { Modal, ModalProps, Button, Text } from "../../../../odyssey-react/src";
+import {
+  Modal,
+  ModalProps,
+  Button,
+  Select,
+  Text,
+} from "../../../../odyssey-react/src";
 import ModalMdx from "./Modal.mdx";
 
 export default {
@@ -61,8 +67,17 @@ const Template: Story<ModalProps> = () => {
         <Modal.Body>
           <Text as="p">
             This is the modal content area. It's width is determined based on
-            the amount of content within it.
+            the amount of content within it. Use the dropdown below to test
+            overflow behavior.
           </Text>
+          <Select label="Destination" name="destination">
+            <Select.Option children="Venus" />
+            <Select.Option children="Nessus" />
+            <Select.Option children="Europa" />
+            <Select.Option children="Mercury" />
+            <Select.Option children="Mars" />
+            <Select.Option children="Neptune" />
+          </Select>
         </Modal.Body>
         <Modal.Footer>
           <Modal.Button variant="floating">Cancel</Modal.Button>


### PR DESCRIPTION
### Description

Previously, Modal overflow was set to `auto`, leading to scrolling behavior when a Dropdown is activated. This PR sets `overflow` to `visible` and adds a Select to the Modal story for testing.

#### Before

<img width="536" alt="Screen Shot 2022-05-25 at 11 03 27 AM" src="https://user-images.githubusercontent.com/36284167/170336732-9a53920a-640b-4666-a2ad-2677001827d8.png">

#### After

<img width="542" alt="Screen Shot 2022-05-25 at 11 04 10 AM" src="https://user-images.githubusercontent.com/36284167/170336748-d2c5f293-4b0e-4e2a-874a-a67e4ed1ac2f.png">