### PR TITLE
fix(odyssey-react): fix Infobox icon alignment

### DIFF
--- a/packages/odyssey-react/src/components/Infobox/Infobox.theme.ts
+++ b/packages/odyssey-react/src/components/Infobox/Infobox.theme.ts
@@ -25,7 +25,7 @@ export const theme: ThemeReducer = (theme) => ({
   IconInsetBlockStart: theme.SpaceScale3,
   IconInsetInlineStart: theme.SpaceScale3,
   IconMargin: theme.SpaceScale3,
-  IconSize: theme.FontSizeHeading4,
+  IconSize: theme.FontScale4,
 
   HeadingFontSize: theme.FontSizeHeading6,
   HeadingFontWeight: theme.FontWeightBold,


### PR DESCRIPTION
### Description
<img width="880" alt="Screen Shot 2022-05-26 at 10 50 52 AM" src="https://user-images.githubusercontent.com/36284167/170546648-4ddd0169-9637-44a8-9d67-af15d9f9b0a2.png">
<img width="523" alt="Screen Shot 2022-05-26 at 10 50 27 AM" src="https://user-images.githubusercontent.com/36284167/170546652-238025fd-ca4b-4481-a431-cc070a70f564.png">
<img width="523" alt="Screen Shot 2022-05-26 at 10 50 12 AM" src="https://user-images.githubusercontent.com/36284167/170546653-739fe803-a9d2-436f-878a-9701afb212d1.png">

