### PR TITLE
chore(odyssey-react): add sideEffects flag to enable bundler level tree shaking

### DIFF
--- a/packages/odyssey-design-tokens/package.json
+++ b/packages/odyssey-design-tokens/package.json
@@ -8,6 +8,7 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "default": "./dist/index.js"

--- a/packages/odyssey-react-theme/package.json
+++ b/packages/odyssey-react-theme/package.json
@@ -8,6 +8,7 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "default": "./dist/index.js"

--- a/packages/odyssey-react/package.json
+++ b/packages/odyssey-react/package.json
@@ -8,6 +8,7 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "default": "./dist/index.js"


### PR DESCRIPTION
This flag gives signal to modern bundlers to proper tree shake odyssey-react package at production build stage.

Reference: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free
