### PR TITLE
MUI Theme: CircularProgress

### DIFF
--- a/packages/odyssey-react-mui/src/themes/odyssey/components.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/components.ts
@@ -18,6 +18,27 @@ export const components: ThemeOptions["components"] = {
       boxSizing: "border-box",
     },
   },
+  MuiCircularProgress: {
+    defaultProps: {
+      size: "1.14285714rem",
+      thickness: 8,
+      color: "primary",
+      disableShrink: false,
+      variant: "indeterminate",
+    },
+    styleOverrides: {
+      root: ({ ownerState }) => ({
+        ...(ownerState.color !== "inherit" && {
+          color: "#00297a",
+        }),
+      }),
+      circle: ({ ownerState }) => ({
+        ...(ownerState.variant === "indeterminate" && {
+          strokeDasharray: "160%, 360%",
+        }),
+      }),
+    },
+  },
   MuiFormLabel: {
     styleOverrides: {
       root: {

--- a/packages/odyssey-storybook/src/components/CircularProgress/CircularProgress.mdx
+++ b/packages/odyssey-storybook/src/components/CircularProgress/CircularProgress.mdx
@@ -1,0 +1,17 @@
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+
+<Meta anchor />
+
+# CircularProgress
+
+<Canvas>
+  <Story id="mui-components-circular-progress--indeterminate" />
+</Canvas>
+
+<Canvas>
+  <Story id="mui-components-circular-progress--determinate" />
+</Canvas>
+
+## Props
+
+<ArgsTable />

--- a/packages/odyssey-storybook/src/components/CircularProgress/CircularProgress.stories.tsx
+++ b/packages/odyssey-storybook/src/components/CircularProgress/CircularProgress.stories.tsx
@@ -1,0 +1,51 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import React from "react";
+import { Story } from "@storybook/react";
+import { CircularProgress, CircularProgressProps } from "@mui/material";
+import { MuiThemeDecorator } from "../../../.storybook/components/MuiThemeDecorator";
+
+import CircularProgressMdx from "./CircularProgress.mdx";
+
+export default {
+  title: `MUI Components/Circular Progress`,
+  component: CircularProgress,
+  parameters: {
+    docs: {
+      page: CircularProgressMdx,
+    },
+  },
+  argTypes: {
+    variant: {
+      options: ["indeterminate", "determinate"],
+      control: { type: "radio" },
+    },
+    value: {
+      control: { type: "number" },
+    },
+  },
+  decorators: [MuiThemeDecorator],
+};
+
+const Template: Story<CircularProgressProps> = (props) => (
+  <CircularProgress {...props} />
+);
+
+export const Indeterminate = Template.bind({});
+Indeterminate.args = {};
+
+export const Determinate = Template.bind({});
+Determinate.args = {
+  variant: "determinate",
+  value: 70,
+};


### PR DESCRIPTION
### Description

This adds a component theme for `<CircularProgress>` as well as stories for the `determiniate` and `indeterminate` variants.

#### Caveats

The theme values here are still hard-coded. This will be refactored whenever variables are available for use within `theme`.

MUI uses a single `svg` circle, which precludes us from styling this to match exactly (ODS uses two differently-colored circles). My feeling is that we should lead with this and then construct our own `CircularProgress` component later if the style differentiation is important.

This theme does not include a theme override for the animation. While this is possible, I am unclear on what that syntax should look like within the theme object. 

@magizh-okta @josesolano-okta if this is acceptable, I will leave this as-is for now and we can revisit after the theming rush. If we want the animation and timing to match, I can pair with @jeffbelser-okta this week.