### PR TITLE
chore(odyssey-storybook): add mui button icon stories

### DIFF
--- a/packages/odyssey-react-mui/src/themes/odyssey/components.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/components.ts
@@ -74,8 +74,9 @@ export const components: ThemeOptions["components"] = {
         style: {
           backgroundColor: "#da372c",
           color: "#ffffff",
+          borderColor: "transparent",
+
           "&:hover": {
-            borderColor: "transparent",
             backgroundColor: "#640019",
           },
 
@@ -85,13 +86,11 @@ export const components: ThemeOptions["components"] = {
           },
 
           "&:active": {
-            borderColor: "transparent",
             backgroundColor: "#da372c",
           },
 
           "&:disabled": {
             color: "#ffffff",
-            borderColor: "#f88c90",
             backgroundColor: "#f88c90",
           },
         },

--- a/packages/odyssey-react-mui/src/themes/odyssey/components.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/components.ts
@@ -147,8 +147,7 @@ export const components: ThemeOptions["components"] = {
       },
     ],
     styleOverrides: {
-      root: ({ ownerState }) => ({
-        ...ownerState,
+      root: () => ({
         fontWeight: 600,
         paddingBlock: "0.85714286rem",
         paddingInline: "0.85714286rem",

--- a/packages/odyssey-react-mui/src/themes/odyssey/components.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/components.ts
@@ -145,6 +145,17 @@ export const components: ThemeOptions["components"] = {
           },
         },
       },
+      {
+        // icon only
+        props: { children: "" },
+        style: {
+          minWidth: "auto",
+
+          ".MuiButton-startIcon": {
+            margin: "0",
+          },
+        },
+      },
     ],
     styleOverrides: {
       root: () => ({
@@ -180,6 +191,10 @@ export const components: ThemeOptions["components"] = {
         "&:disabled": {
           cursor: "not-allowed",
           pointerEvents: "inherit", // in order to have cursor: not-allowed, must change pointer-events from 'none'
+        },
+
+        ".MuiButton-startIcon > *:nth-of-type(1)": {
+          fontSize: "inherit",
         },
       }),
     },

--- a/packages/odyssey-storybook/src/components/MuiButton/MuiButton.mdx
+++ b/packages/odyssey-storybook/src/components/MuiButton/MuiButton.mdx
@@ -104,6 +104,15 @@ You should pair Disabled Buttons with a Tooltip if the user would benefit from a
   <Story id="mui-components-button--button-primary-disabled" />
 </Canvas>
 
+## Icons
+
+<Canvas>
+  <Story id="mui-components-button--button-with-icon" />
+</Canvas>
+
+<Canvas>
+  <Story id="mui-components-button--icon-only" />
+</Canvas>
 ## References
 
 - <a href="https://mui.com/material-ui/api/button/">Button API</a> - Material UI

--- a/packages/odyssey-storybook/src/components/MuiButton/MuiButton.stories.tsx
+++ b/packages/odyssey-storybook/src/components/MuiButton/MuiButton.stories.tsx
@@ -15,6 +15,7 @@ import type { Story } from "@storybook/react";
 import { Button } from "@mui/material";
 import type { ButtonProps } from "@mui/material";
 import { MuiThemeDecorator } from "../../../.storybook/components/MuiThemeDecorator";
+import { SettingsIcon } from "../../../../odyssey-react/src";
 
 import ButtonMdx from "./MuiButton.mdx";
 
@@ -115,4 +116,16 @@ ButtonPrimaryDisabled.args = {
   children: "Button label",
   variant: "primary",
   disabled: true,
+};
+
+export const ButtonWithIcon = Template.bind({});
+ButtonWithIcon.args = {
+  children: "Button label",
+  startIcon: <SettingsIcon />,
+};
+
+export const IconOnly = Template.bind({});
+IconOnly.args = {
+  children: "",
+  startIcon: <SettingsIcon />,
 };


### PR DESCRIPTION

### Description
- fixes style override for component MuiButton which was breaking a couple prop situations, such as `startIcon`, `endIcon`, and `data-*`
- adds stories for button text with icon and button with icon only
- adds style overrides for icon to match odyssey
- fixes button variant danger in disabled state
<img width="318" alt="Screen Shot 2022-06-29 at 4 38 20 PM" src="https://user-images.githubusercontent.com/71431120/176563896-c394734d-343d-463d-80b4-618834cbac24.png">

