### PR TITLE
Theme for Select, Native

### DIFF
--- a/packages/odyssey-react-mui/src/themes/odyssey/components.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/components.ts
@@ -207,10 +207,9 @@ export const components: ThemeOptions["components"] = {
       },
     ],
     styleOverrides: {
-      root: () => ({
+      root: ({ theme }) => ({
         fontWeight: 600,
-        paddingBlock: "0.85714286rem",
-        paddingInline: "0.85714286rem",
+        padding: `calc(${theme.spacing(3)} - 1px) ${theme.spacing(3)}`,
         display: "inline-block",
         position: "relative",
         marginBlock: "0",
@@ -239,7 +238,7 @@ export const components: ThemeOptions["components"] = {
 
         "&:disabled": {
           cursor: "not-allowed",
-          pointerEvents: "inherit", // in order to have cursor: not-allowed, must change pointer-events from 'none'
+          pointerEvents: "inherit", // in order to have cursor: not-allowed, must change pointer-events from "none"
         },
 
         ".MuiButton-startIcon > *:nth-of-type(1)": {
@@ -308,6 +307,25 @@ export const components: ThemeOptions["components"] = {
       circle: ({ ownerState }) => ({
         ...(ownerState.variant === "indeterminate" && {
           strokeDasharray: "160%, 360%",
+        }),
+      }),
+    },
+  },
+  MuiFormControl: {
+    styleOverrides: {
+      root: ({ ownerState, theme }) => ({
+        width: "100%",
+        maxWidth: "32rem",
+        ...(ownerState.margin === "normal" && {
+          marginTop: 0,
+          marginBottom: theme.spacing(4),
+        }),
+        ...(ownerState.margin === "dense" && {
+          marginTop: 0,
+          marginBottom: theme.spacing(4),
+        }),
+        ...(ownerState.fullWidth && {
+          maxWidth: "100%",
         }),
       }),
     },
@@ -399,6 +417,29 @@ export const components: ThemeOptions["components"] = {
       },
     },
   },
+  MuiInputLabel: {
+    defaultProps: {
+      disableAnimation: true,
+      shrink: false,
+    },
+    styleOverrides: {
+      root: ({ ownerState }) => ({
+        // @ts-expect-error: Incorrect typing in MUI
+        ...(ownerState.formControl && {
+          position: "initial",
+          transform: "none",
+        }),
+        ...(ownerState.variant === "outlined" && {
+          pointerEvents: "initial",
+          transform: "none",
+          maxWidth: "100%",
+          ...(ownerState.size === "small" && {
+            transform: "none",
+          }),
+        }),
+      }),
+    },
+  },
   MuiLink: {
     styleOverrides: {
       root: {
@@ -469,6 +510,41 @@ export const components: ThemeOptions["components"] = {
       },
     ],
   },
+  MuiNativeSelect: {
+    defaultProps: {
+      variant: "outlined",
+    },
+    styleOverrides: {
+      icon: ({ theme }) => ({
+        color: theme.palette.text.primary,
+      }),
+    },
+  },
+  MuiOutlinedInput: {
+    defaultProps: {
+      notched: false,
+    },
+    styleOverrides: {
+      root: {
+        "&.Mui-disabled": {
+          pointerEvents: "none",
+        },
+      },
+      input: ({ theme }) => ({
+        padding: `calc(${theme.spacing(3)} - 1px) ${theme.spacing(3)}`,
+        border: "1px solid transparent",
+      }),
+      notchedOutline: ({ theme }) => ({
+        borderColor: theme.palette.grey[500],
+        ".MuiOutlinedInput-root:hover &": {
+          borderColor: theme.palette.primary.main,
+        },
+        ".MuiOutlinedInput-root.Mui-error:hover &": {
+          borderColor: theme.palette.error.dark,
+        },
+      }),
+    },
+  },
   MuiRadio: {
     defaultProps: {
       size: "small",
@@ -502,18 +578,6 @@ export const components: ThemeOptions["components"] = {
     styleOverrides: {
       paragraph: {
         marginBottom: "1.14285714rem",
-      },
-    },
-  },
-  MuiSvgIcon: {
-    styleOverrides: {
-      root: {
-        fontSize: "1rem",
-        height: "1em",
-        position: "relative",
-        top: "-0.0625em",
-        verticalAlign: "middle",
-        width: "1em",
       },
     },
   },

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Select/Select.mdx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Select/Select.mdx
@@ -1,0 +1,59 @@
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+
+<Meta anchor />
+
+# Select
+
+Often referred to as a “dropdown menu” this input triggers a menu of options a user can select. Country and state Selects are common examples.
+
+## Behavior
+
+Interacting with a Select displays a list of values to choose from. Choosing a value will override any previous selection and close the Select.
+
+Odyssey also supports a Multi-Select variant that allows users to select many values.
+
+To support expected functionality and behaviors, Select relies on the Choices.js library. Odyssey provides fallback styling when Choices.js isn't available.
+
+## Variants
+
+Odyssey provides support for both single and multi-value Selects.
+
+### Single Select
+
+The default Select allows users to choose a single value from a list of options. Selecting another option will replace the first.
+
+### Multi-Select
+
+The Multi-Select variant allows users to choose more than one value from the list of options.
+
+### Native Select
+
+The browser-native `<select>` component may be used by passing `<Select>` the `native` prop.
+
+#### Single
+
+<Canvas>
+  <Story id="mui-components-select--native-default" />
+</Canvas>
+
+<Canvas>
+  <Story id="mui-components-select--native-disabled" />
+</Canvas>
+
+<Canvas>
+  <Story id="mui-components-select--native-invalid" />
+</Canvas>
+
+#### Multi
+
+## Usage
+
+Selects are most useful when users are choosing between 7-15 options. For smaller sets, Radio Buttons are more effective. For larger sets, a Text Input with autocompletion may be a better fit.
+
+Selects perform better when the options are familiar to the user. If a user may be unfamiliar with their options or need to compare them, use Radio Buttons.
+
+Select inputs should not have a default selected unless a majority of users will be choosing it.
+
+## Props
+
+<ArgsTable />

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Select/Select.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Select/Select.stories.tsx
@@ -1,0 +1,94 @@
+/*!
+ * Copyright (c) 2021-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { Story } from "@storybook/react";
+import { FormControl, FormHelperText, InputLabel, Select } from "@mui/material";
+import { visuallyHidden } from "@mui/utils";
+import { MuiThemeDecorator } from "../../../../.storybook/components";
+
+import SelectMdx from "./Select.mdx";
+
+export default {
+  title: `MUI Components/Select`,
+  component: Select,
+  parameters: {
+    docs: {
+      page: SelectMdx,
+    },
+  },
+  argTypes: {
+    disabled: {
+      control: "boolean",
+      defaultValue: false,
+    },
+    error: {
+      control: "text",
+      defaultValue: null,
+    },
+    hint: {
+      control: "text",
+      defaultValue: "Select your destination within the Sol system.",
+    },
+    invalid: {
+      control: "boolean",
+      defaultValue: false,
+    },
+    label: {
+      control: "text",
+      defaultValue: "Destination",
+    },
+  },
+  decorators: [MuiThemeDecorator],
+};
+
+const NativeTemplate: Story = (args) => {
+  const {} = args;
+  return (
+    <FormControl disabled={args.disabled} error={args.invalid}>
+      <InputLabel id="demo-simple-select-label">{args.label}</InputLabel>
+      {args.hint && <FormHelperText>{args.hint}</FormHelperText>}
+      <Select
+        labelId="demo-simple-select-label"
+        id="demo-simple-select"
+        label={args.label}
+        native
+      >
+        <option value="earth">Earth</option>
+        <option value="mars">Mars</option>
+        <option value="ceres">Ceres</option>
+        <option value="eros">Eros</option>
+        <option value="tycho">Tycho Station</option>
+        <option value="phoebe">Phoebe</option>
+        <option value="ganymede">Ganymede</option>
+      </Select>
+      {args.error && (
+        <FormHelperText error>
+          <span style={visuallyHidden}>Error:</span> {args.error}
+        </FormHelperText>
+      )}
+    </FormControl>
+  );
+};
+
+export const NativeDefault = NativeTemplate.bind({});
+NativeDefault.args = {};
+
+export const NativeDisabled = NativeTemplate.bind({});
+NativeDisabled.args = {
+  disabled: true,
+};
+
+export const NativeInvalid = NativeTemplate.bind({});
+NativeInvalid.args = {
+  invalid: true,
+  error: "This field is required.",
+};


### PR DESCRIPTION
### Description

Adds theming for:

- Button
  - Adds variables for padding, adjusts height
- FormControl
  - Adds correct `width` and `max-width` behavior
- InputLabel
  - Disables "floating" behavior for labels
- NativeSelect
  - Adds some fallback styling; `<Select native>` should be preferred
- OutlinedInput
  - Adds theme to match ODS
- SvgIcon
  - Removes individual icon styling for now; MUI relies on the parent component setting styles

Adds stories for:
- `<Select native>`