### PR TITLE
docs(odyssey-storybook): remove docs for unsupported Text story

### DIFF
--- a/packages/odyssey-storybook/src/components/odyssey-legacy/TextInput/TextInput.mdx
+++ b/packages/odyssey-storybook/src/components/odyssey-legacy/TextInput/TextInput.mdx
@@ -16,14 +16,6 @@ This default serves as the basis for our Text Inputs. A shown here, they require
 
 <Story id="legacy-components-textinput--text" />
 
-### Search
-
-Standalone Search provides minimal UI for searching outside of normal form contexts. Search inputs will render with the "Search" UI indicator as well as a visually hidden label.
-
-In this case, we recommend using the placeholder attribute to state the scope of your search. This text should match the hidden label.
-
-<Story id="legacy-components-textinput--search" />
-
 #### Button variant
 
 We also provide an attached button for in-page searching or avoiding placeholder text. Please follow our [Button guidelines](/components/button) when using these variants.


### PR DESCRIPTION
### Description

Removes reference to a missing story in our legacy docs.