### PR TITLE
fix(odyssey-react-mui): fix Button :focus-visible styles

### DIFF
--- a/packages/odyssey-react-mui/src/themes/odyssey/components.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/components.ts
@@ -124,6 +124,10 @@ export const components: ThemeOptions["components"] = {
             backgroundColor: theme.palette.primary.dark,
           },
 
+          "&:focus-visible": {
+            outlineColor: theme.palette.primary.main,
+          },
+
           "&:active": {
             backgroundColor: theme.palette.primary.main,
           },
@@ -140,15 +144,14 @@ export const components: ThemeOptions["components"] = {
           backgroundColor: theme.palette.grey[50],
           borderColor: theme.palette.grey[200],
           color: theme.palette.text.primary,
-          "&:hover": {
-            background: theme.palette.primary.lighter,
+          "&:hover, &:focus-visible": {
+            backgroundColor: theme.palette.primary.lighter,
             borderColor: theme.palette.primary.light,
             color: theme.palette.primary.main,
           },
 
           "&:focus-visible": {
-            backgroundColor: theme.palette.primary.main,
-            color: theme.palette.primary.main,
+            outlineColor: theme.palette.primary.main,
           },
 
           "&:active": {
@@ -174,7 +177,7 @@ export const components: ThemeOptions["components"] = {
           },
 
           "&:focus-visible": {
-            outlineColor: theme.palette.error.light,
+            outlineColor: theme.palette.error.main,
             backgroundColor: theme.palette.error.dark,
           },
 
@@ -198,6 +201,9 @@ export const components: ThemeOptions["components"] = {
           "&:hover, &:focus-visible": {
             backgroundColor: "rgba(29, 29, 33, 0.1)",
             borderColor: "transparent",
+          },
+          "&:focus-visible": {
+            outlineColor: theme.palette.primary.main,
           },
           "&:active": {
             backgroundColor: "rgba(29, 29, 33, 0.2)",


### PR DESCRIPTION
### Description

Adds appropriate styling for `:focus-visible` states on `Button`.

#### Screens

<img width="138" alt="Screen Shot 2022-08-10 at 11 39 34 AM" src="https://user-images.githubusercontent.com/36284167/183994846-93839302-fd73-4fc7-94a1-d2978428dd38.png">
<img width="135" alt="Screen Shot 2022-08-10 at 11 39 30 AM" src="https://user-images.githubusercontent.com/36284167/183994858-94c62861-7fcd-48e7-a60c-833ce96826f3.png">
<img width="136" alt="Screen Shot 2022-08-10 at 11 39 25 AM" src="https://user-images.githubusercontent.com/36284167/183994866-f1d76bc1-9b98-4496-ac62-b04d15519003.png">
<img width="144" alt="Screen Shot 2022-08-10 at 11 39 21 AM" src="https://user-images.githubusercontent.com/36284167/183994874-16c64e35-6c3c-482c-9256-c96e42d8a5d2.png">
