### PR TITLE
Enable custom variables/types for MUI's `Shape`

### DIFF
--- a/packages/odyssey-react-mui/src/themes/odyssey/components.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/components.ts
@@ -31,7 +31,7 @@ export const components: ThemeOptions["components"] = {
           borderWidth: 0,
         }),
         ...(ownerState.variant === "infobox" && {
-          borderStyle: "solid",
+          borderStyle: theme.shape.borderStyle,
           borderWidth: 1,
           "&:not(:last-child)": {
             marginBottom: theme.spacing(4),
@@ -39,7 +39,7 @@ export const components: ThemeOptions["components"] = {
         }),
         ...(ownerState.variant === "toast" && {
           maxWidth: theme.mixins.maxWidth,
-          borderStyle: "solid",
+          borderStyle: theme.shape.borderStyle,
           borderWidth: 1,
           position: "relative",
           alignItems: "start",
@@ -57,10 +57,10 @@ export const components: ThemeOptions["components"] = {
         ...(ownerState.variant === "toast" && {
           position: "absolute",
           top: `calc(${theme.spacing(4)} - ${theme.spacing(1)} + ${
-            theme.mixins.borderWidth
+            theme.shape.borderWidth
           })`,
           right: `calc(${theme.spacing(4)} - ${theme.spacing(1)} + ${
-            theme.mixins.borderWidth
+            theme.shape.borderWidth
           })`,
           padding: 0,
           marginLeft: 0,
@@ -269,7 +269,7 @@ export const components: ThemeOptions["components"] = {
         transitionDuration: "100ms",
         transitionTimingFunction: "linear",
         borderWidth: "1px",
-        borderStyle: "solid",
+        borderStyle: theme.shape.borderStyle,
         outlineColor: "transparent",
         outlineOffset: "0",
         fontSize: "1rem",

--- a/packages/odyssey-react-mui/src/themes/odyssey/mixins.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/mixins.ts
@@ -14,7 +14,5 @@ import type { ThemeOptions } from "@mui/material";
 import * as Tokens from "@okta/odyssey-design-tokens";
 
 export const mixins: ThemeOptions["mixins"] = {
-  // These tokens work as expected with the TS mods in mixins.types.ts
   maxWidth: Tokens.FontLineLengthMax,
-  borderWidth: Tokens.BorderWidthBase,
 };

--- a/packages/odyssey-react-mui/src/themes/odyssey/mixins.types.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/mixins.types.ts
@@ -13,12 +13,10 @@
 declare module "@mui/material/styles" {
   // These mods work as expectd to allow the values in mixins.ts
   interface Mixins {
-    borderWidth?: string;
     maxWidth?: string;
   }
 
   interface MixinsOptions {
-    borderWidth?: string;
     maxWidth?: string;
   }
 }

--- a/packages/odyssey-react-mui/src/themes/odyssey/mixins.types.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/mixins.types.ts
@@ -11,6 +11,7 @@
  */
 
 declare module "@mui/material/styles" {
+  // These mods work as expectd to allow the values in mixins.ts
   interface Mixins {
     borderWidth?: string;
     maxWidth?: string;

--- a/packages/odyssey-react-mui/src/themes/odyssey/shape.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/shape.ts
@@ -15,4 +15,6 @@ import * as Tokens from "@okta/odyssey-design-tokens";
 
 export const shape: ThemeOptions["shape"] = {
   borderRadius: Tokens.BorderRadiusBase,
+  // Expected: Mods should work identically to mixins.ts/mixins.types.ts
+  borderStyle: Tokens.BorderStyleBase,
 };

--- a/packages/odyssey-react-mui/src/themes/odyssey/shape.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/shape.ts
@@ -15,6 +15,6 @@ import * as Tokens from "@okta/odyssey-design-tokens";
 
 export const shape: ThemeOptions["shape"] = {
   borderRadius: Tokens.BorderRadiusBase,
-  // Expected: Mods should work identically to mixins.ts/mixins.types.ts
   borderStyle: Tokens.BorderStyleBase,
+  borderWidth: Tokens.BorderWidthBase,
 };

--- a/packages/odyssey-react-mui/src/themes/odyssey/shape.types.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/shape.types.ts
@@ -10,11 +10,15 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import type { ThemeOptions } from "@mui/material";
-import * as Tokens from "@okta/odyssey-design-tokens";
+declare module "@mui/material/styles" {
+  // These mods work as expectd to allow the values in mixins.ts
+  interface Shape {
+    borderStyle?: string;
+  }
 
-export const mixins: ThemeOptions["mixins"] = {
-  // These tokens work as expected with the TS mods in mixins.types.ts
-  maxWidth: Tokens.FontLineLengthMax,
-  borderWidth: Tokens.BorderWidthBase,
-};
+  interface ShapeOptions {
+    borderStyle?: string;
+  }
+}
+
+export {};

--- a/packages/odyssey-react-mui/src/themes/odyssey/shape.types.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/shape.types.ts
@@ -10,14 +10,19 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+interface Shape {
+  borderRadius?: string;
+  borderStyle?: string;
+  borderWidth?: string;
+}
+
 declare module "@mui/material/styles" {
-  // These mods work as expectd to allow the values in mixins.ts
-  interface Shape {
-    borderStyle?: string;
+  interface Theme {
+    shape: Shape;
   }
 
-  interface ShapeOptions {
-    borderStyle?: string;
+  interface ThemeOptions {
+    shape: Shape;
   }
 }
 

--- a/packages/odyssey-react-mui/src/themes/odyssey/theme.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/theme.ts
@@ -15,7 +15,7 @@ import { createTheme } from "@mui/material/styles";
 import { palette } from "./palette";
 import "./palette.types";
 import { shape } from "./shape";
-import "./shape.types.ts";
+import "./shape.types";
 import { mixins } from "./mixins";
 import "./mixins.types";
 import { spacing } from "./spacing";

--- a/packages/odyssey-react-mui/src/themes/odyssey/theme.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/theme.ts
@@ -15,6 +15,7 @@ import { createTheme } from "@mui/material/styles";
 import { palette } from "./palette";
 import "./palette.types";
 import { shape } from "./shape";
+import "./shape.types.ts";
 import { mixins } from "./mixins";
 import "./mixins.types";
 import { spacing } from "./spacing";


### PR DESCRIPTION
### Description

This is allows for custom variables and typing on MUI's `theme.shape`. Because this interface is not exported at the top level, we've had to take a different approach from other TS mods.

Note: this also introduces a breaking change of relocating `border` properties from `theme.mixins` into `theme.shape`.

Many thanks to @KevinGhadyani-Okta for his assistance here!