### PR TITLE
TextField: UI updates

### DIFF
--- a/packages/odyssey-react-mui/src/themes/odyssey/components.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/components.ts
@@ -12,6 +12,7 @@
 
 import type { ThemeOptions } from "@mui/material";
 //import radioClasses from "@mui/material";
+import { outlinedInputClasses } from "@mui/material/OutlinedInput";
 
 export const components: ThemeOptions["components"] = {
   MuiAlert: {
@@ -598,10 +599,35 @@ export const components: ThemeOptions["components"] = {
   MuiOutlinedInput: {
     defaultProps: {
       notched: false,
+      minRows: 3,
     },
     styleOverrides: {
       root: ({ ownerState, theme }) => ({
-        "&.Mui-disabled": {
+        [`&:hover .${outlinedInputClasses.notchedOutline}`]: {
+          borderColor: theme.palette.text.primary,
+        },
+        [`&.${outlinedInputClasses.focused} .${outlinedInputClasses.notchedOutline}`]:
+          {
+            borderColor: theme.palette.primary.main,
+            borderWidth: 2,
+          },
+        [`&.${outlinedInputClasses.error} .${outlinedInputClasses.notchedOutline}`]:
+          {
+            borderColor: theme.palette.error.main,
+          },
+        [`&.${outlinedInputClasses.error}:hover .${outlinedInputClasses.notchedOutline}`]:
+          {
+            borderColor: theme.palette.error.dark,
+          },
+        [`&.${outlinedInputClasses.error}.${outlinedInputClasses.focused} .${outlinedInputClasses.notchedOutline}`]:
+          {
+            borderColor: theme.palette.error.main,
+          },
+        [`&.${outlinedInputClasses.disabled} .${outlinedInputClasses.notchedOutline}`]:
+          {
+            borderColor: theme.palette.action.disabled,
+          },
+        [`&.${outlinedInputClasses.disabled}`]: {
           pointerEvents: "none",
         },
         ...(ownerState.startAdornment && {
@@ -610,19 +636,21 @@ export const components: ThemeOptions["components"] = {
         ...(ownerState.endAdornment && {
           paddingRight: theme.spacing(3),
         }),
+        ...(ownerState.multiline && {
+          padding: "0",
+          ...(ownerState.size === "small" && {
+            padding: "0",
+          }),
+        }),
       }),
       input: ({ theme }) => ({
         padding: `calc(${theme.spacing(3)} - 1px) ${theme.spacing(3)}`,
-        border: "1px solid transparent",
+        borderWidth: theme.mixins.borderWidth,
+        borderStyle: theme.mixins.borderStyle,
+        borderColor: "transparent",
       }),
       notchedOutline: ({ theme }) => ({
         borderColor: theme.palette.grey[500],
-        ".MuiOutlinedInput-root:hover &": {
-          borderColor: theme.palette.primary.main,
-        },
-        ".MuiOutlinedInput-root.Mui-error:hover &": {
-          borderColor: theme.palette.error.dark,
-        },
       }),
     },
   },

--- a/packages/odyssey-react-mui/src/themes/odyssey/components.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/components.ts
@@ -628,6 +628,7 @@ export const components: ThemeOptions["components"] = {
             borderColor: theme.palette.action.disabled,
           },
         [`&.${outlinedInputClasses.disabled}`]: {
+          backgroundColor: theme.palette.grey[50],
           pointerEvents: "none",
         },
         ...(ownerState.startAdornment && {

--- a/packages/odyssey-react-mui/src/themes/odyssey/palette.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/palette.ts
@@ -94,7 +94,7 @@ export const palette: ThemeOptions["palette"] = {
     hoverOpacity: 0.04,
     selected: "rgba(0, 0, 0, 0.08)",
     selectedOpacity: 0.08,
-    disabled: "rgba(0, 0, 0, 0.26)",
+    disabled: Tokens.ColorPaletteNeutral200,
     disabledBackground: "rgba(0, 0, 0, 0.12)",
     disabledOpacity: 0.38,
     focus: "rgba(0, 0, 0, 0.12)",

--- a/packages/odyssey-storybook/src/components/odyssey-mui/TextField/TextField.mdx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/TextField/TextField.mdx
@@ -24,6 +24,12 @@ Textareas should be used for multi-line text inputs. As the user types the field
   <Story id="mui-components-text-field--multiline" />
 </Canvas>
 
+### Hints
+
+<Canvas>
+  <Story id="mui-components-text-field--hint" />
+</Canvas>
+
 ### Adornments
 
 Adornments may be added to inputs to create additional affordances or behavior. Odyssey supports icon and text adornments.

--- a/packages/odyssey-storybook/src/components/odyssey-mui/TextField/TextField.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/TextField/TextField.stories.tsx
@@ -50,7 +50,7 @@ export default {
     },
     hint: {
       control: "text",
-      defaultValue: "Specify your destination within the Sol system.",
+      defaultValue: null,
     },
     invalid: {
       control: "boolean",
@@ -136,6 +136,11 @@ Invalid.args = {
   error: "This field is required.",
 };
 
+export const Hint = Template.bind({});
+Hint.args = {
+  hint: "Specify your destination within the Sol system.",
+};
+
 export const Adornment = Template.bind({});
 Adornment.args = {
   endAdornment: <InputAdornment position="end">kg</InputAdornment>,
@@ -146,7 +151,6 @@ Adornment.args = {
 export const Email = Template.bind({});
 Email.args = {
   autoComplete: "work email",
-  hint: null,
   label: "Company email",
   type: "email",
 };
@@ -154,7 +158,6 @@ Email.args = {
 export const Multiline = Template.bind({});
 Multiline.args = {
   autoComplete: "shipping street-address",
-  hint: "Your complete address, preferably on a terrestrial body",
   label: "Permanent residence",
   multiline: true,
 };
@@ -162,7 +165,6 @@ Multiline.args = {
 export const Password = Template.bind({});
 Password.args = {
   autoComplete: "current-password",
-  hint: null,
   label: "Password",
   type: "password",
 };
@@ -170,7 +172,6 @@ Password.args = {
 export const Tel = Template.bind({});
 Tel.args = {
   autoComplete: "mobile tel",
-  hint: null,
   label: "Phone number",
   startAdornment: <InputAdornment position="start">+1</InputAdornment>,
   type: "tel",


### PR DESCRIPTION
### Description

- Hover state for the input field is now `gray[900]`
- Text area now has correct padding, defaults to 3 rows
- Hint default is now `null`
- Adds a text field story for `hint`
- Updates `disabled` state