### PR TITLE
Apply ODS Icons to MuiAlert, set props for SvgIcon

### DIFF
--- a/packages/odyssey-react-mui/src/themes/odyssey/components.tsx
+++ b/packages/odyssey-react-mui/src/themes/odyssey/components.tsx
@@ -23,10 +23,10 @@ export const components: ThemeOptions["components"] = {
   MuiAlert: {
     defaultProps: {
       iconMapping: {
-        error: <AlertTriangleFilledIcon fontSize="inherit" />,
-        info: <InformationCircleFilledIcon fontSize="inherit" />,
-        success: <CheckCircleFilledIcon fontSize="inherit" />,
-        warning: <AlertTriangleFilledIcon fontSize="inherit" />,
+        error: <AlertTriangleFilledIcon />,
+        info: <InformationCircleFilledIcon />,
+        success: <CheckCircleFilledIcon />,
+        warning: <AlertTriangleFilledIcon />,
       },
     },
     styleOverrides: {
@@ -705,6 +705,12 @@ export const components: ThemeOptions["components"] = {
         vertical: "bottom",
         horizontal: "right",
       },
+    },
+  },
+  MuiSvgIcon: {
+    defaultProps: {
+      fontSize: "inherit",
+      color: "inherit",
     },
   },
   MuiTab: {

--- a/packages/odyssey-react-mui/src/themes/odyssey/components.tsx
+++ b/packages/odyssey-react-mui/src/themes/odyssey/components.tsx
@@ -13,9 +13,22 @@
 import type { ThemeOptions } from "@mui/material";
 //import radioClasses from "@mui/material";
 import { outlinedInputClasses } from "@mui/material/OutlinedInput";
+import {
+  AlertTriangleFilledIcon,
+  CheckCircleFilledIcon,
+  InformationCircleFilledIcon,
+} from "../../components/Icon";
 
 export const components: ThemeOptions["components"] = {
   MuiAlert: {
+    defaultProps: {
+      iconMapping: {
+        error: <AlertTriangleFilledIcon fontSize="inherit" />,
+        info: <InformationCircleFilledIcon fontSize="inherit" />,
+        success: <CheckCircleFilledIcon fontSize="inherit" />,
+        warning: <AlertTriangleFilledIcon fontSize="inherit" />,
+      },
+    },
     styleOverrides: {
       root: ({ ownerState, theme }) => ({
         padding: theme.spacing(4),


### PR DESCRIPTION
### Description

Themes `Alert` to utilize ODS icons by default and sets default props for `SvgIcon`.