### PR TITLE
fix: node modules not picked up by babel-plugin-fully-specified

### DIFF
--- a/packages/babel-plugin-fully-specified/src/__tests__/__snapshots__/plugin.test.js.snap
+++ b/packages/babel-plugin-fully-specified/src/__tests__/__snapshots__/plugin.test.js.snap
@@ -43,10 +43,10 @@ import * as SomethingTest from \\"./lib/something.test.js\\";"
 `;
 
 exports[`plugin should skip bare module specifiers 1`] = `
-"import babel from '@babel/core';
-import { transform } from '@babel/core';
-export * from '@babel/core';
-export { transform } from '@babel/core';"
+"import babel from \\"@babel/core/index.js\\";
+import { transform } from \\"@babel/core/index.js\\";
+export * from \\"@babel/core/index.js\\";
+export { transform } from \\"@babel/core/index.js\\";"
 `;
 
 exports[`plugin should skip style module imports 1`] = `

--- a/packages/babel-plugin-fully-specified/src/plugin.ts
+++ b/packages/babel-plugin-fully-specified/src/plugin.ts
@@ -34,8 +34,6 @@ const isNodeModule = (candidate: string): boolean => {
 };
 
 const skipModule = (candidate: string) =>
-  !candidate.startsWith(".") ||
-  isNodeModule(candidate) ||
   [".js", ".scss"].includes(extname(candidate));
 
 export function plugin({
@@ -77,7 +75,9 @@ export function plugin({
           return;
         }
 
-        const dirPath = resolve(dirname(state.filename), candidate);
+        const dirPath = isNodeModule(candidate)
+          ? dirname(require.resolve(candidate))
+          : resolve(dirname(state.filename), candidate);
 
         const fullySpecifiedLiteral = t.stringLiteral(
           existsSync(dirPath) && lstatSync(dirPath).isDirectory()


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
Webpack and Rollup (Vite) are looking at `"type": "module"` in `package.json`. This means we need to have proper identification of imports. JS allows this, but TS does not. So we have a custom plugin to handle these conversions; adding `.js` and `/index.js`.

I've gone ahead and adjusted the plugin to handle Node modules along with the existing local files.