### PR TITLE
fix(odyssey-react-mui): remove `body` from type mods

### DIFF
--- a/packages/odyssey-react-mui/src/themes/odyssey/components.types.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/components.types.ts
@@ -59,7 +59,6 @@ declare module "@mui/material/Link" {
     body1: false;
     body2: false;
     button: false;
-    caption: false;
     h1: false;
     h2: false;
     h3: false;

--- a/packages/odyssey-react-mui/src/themes/odyssey/typography.types.ts
+++ b/packages/odyssey-react-mui/src/themes/odyssey/typography.types.ts
@@ -25,17 +25,16 @@ declare module "@mui/material/styles" {
 
 declare module "@mui/material/Typography" {
   interface TypographyPropsVariantOverrides {
-    body1: true;
+    body1: true; // Design may refer to this as "body"
     body2: false;
-    body: true;
     button: false;
     kbd: true;
     legend: true;
     overline: false;
-    subtitle1: true;
+    subtitle1: true; // Design may refer to this as "caption"
     subtitle2: false;
-    default: true; // used by Link
-    monochrome: true; // used by Link
+    default: true; // used by <Link>
+    monochrome: true; // used by <Link>
   }
 }
 


### PR DESCRIPTION
### Description

A small fix to ensure our typography type mods match the available styles.