### PR TITLE
fix(odyssey-react-mui): fixes focus outline on Infobox links

### DIFF
--- a/packages/odyssey-react-mui/src/themes/odyssey/components.tsx
+++ b/packages/odyssey-react-mui/src/themes/odyssey/components.tsx
@@ -96,6 +96,7 @@ export const components: ThemeOptions["components"] = {
       message: ({ ownerState, theme }) => ({
         padding: 0,
         lineHeight: theme.typography.body1.lineHeight,
+        overflow: "visible",
         ...(ownerState.variant === "banner" && {
           display: "flex",
           justifyContent: "space-between",


### PR DESCRIPTION
### Description

Fixes previously hidden outline on `:focus-visible` `<Link>` inside `Alert.Message`.