### PR TITLE
TextField: update :read-only and :disabled styles

### DIFF
--- a/packages/odyssey-react-mui/src/themes/odyssey/components.tsx
+++ b/packages/odyssey-react-mui/src/themes/odyssey/components.tsx
@@ -532,9 +532,13 @@ export const components: ThemeOptions["components"] = {
   },
   MuiInputBase: {
     styleOverrides: {
-      root: {
+      root: ({ ownerState, theme }) => ({
         lineHeight: "1.14285714",
-      },
+
+        ...(ownerState.readOnly === true && {
+          backgroundColor: theme.palette.grey[50],
+        }),
+      }),
       input: {
         boxSizing: "border-box",
         height: "auto",
@@ -674,10 +678,11 @@ export const components: ThemeOptions["components"] = {
         [`&.${outlinedInputClasses.disabled} .${outlinedInputClasses.notchedOutline}`]:
           {
             borderColor: theme.palette.action.disabled,
+            pointerEvents: "auto",
           },
         [`&.${outlinedInputClasses.disabled}`]: {
           backgroundColor: theme.palette.grey[50],
-          pointerEvents: "none",
+          cursor: "not-allowed",
         },
         ...(ownerState.startAdornment && {
           paddingLeft: theme.spacing(3),


### PR DESCRIPTION
### Description

Makes `:read-only` and `:disabled` styles more distinct.

Note: this does not match the design spec perfectly due to some issues with `OutlinedInput`. We should be able to match the spec perfectly once we refactor toward using `InputBase` as suggested by @glenfannin-okta.
