### PR TITLE
fix: remove forwardRef from Link

### DIFF
--- a/packages/odyssey-react-mui/src/Link.tsx
+++ b/packages/odyssey-react-mui/src/Link.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { forwardRef, ReactElement } from "react";
+import { ReactElement } from "react";
 
 import { Link as MuiLink, SvgIcon } from "@mui/material";
 import type { LinkProps as MuiLinkProps } from "@mui/material";
@@ -19,26 +19,24 @@ export interface LinkProps extends MuiLinkProps {
   icon?: ReactElement;
 }
 
-export const Link = forwardRef<HTMLLinkElement | HTMLAnchorElement, LinkProps>(
-  (props) => {
-    const { icon, children, target } = props;
-    return (
-      <MuiLink {...props}>
-        {icon && <span className="Link-icon">{icon}</span>}
-        {children}
-        {target === "_blank" && (
-          <span className="Link-indicator" role="presentation">
-            <SvgIcon viewBox="0 0 16 16">
-              <path
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M13.2929 2H7.99998V1H14.5C14.7761 1 15 1.22386 15 1.5V8H14V2.70711L6.35353 10.3536L5.64642 9.64645L13.2929 2ZM1.5 4H1V4.5V14.5V15H1.5H11.5H12V14.5V8H11V14H2V5H8V4H1.5Z"
-                fill="currentColor"
-              />
-            </SvgIcon>
-          </span>
-        )}
-      </MuiLink>
-    );
-  }
-);
+export const Link = (props: LinkProps) => {
+  const { icon, children, target } = props;
+  return (
+    <MuiLink {...props}>
+      {icon && <span className="Link-icon">{icon}</span>}
+      {children}
+      {target === "_blank" && (
+        <span className="Link-indicator" role="presentation">
+          <SvgIcon viewBox="0 0 16 16">
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M13.2929 2H7.99998V1H14.5C14.7761 1 15 1.22386 15 1.5V8H14V2.70711L6.35353 10.3536L5.64642 9.64645L13.2929 2ZM1.5 4H1V4.5V14.5V15H1.5H11.5H12V14.5V8H11V14H2V5H8V4H1.5Z"
+              fill="currentColor"
+            />
+          </SvgIcon>
+        </span>
+      )}
+    </MuiLink>
+  );
+};


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
When using the `Link` component, the following error will be logged in the console:
```
Warning: forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?
```

`ref` is not used in Links so usage of `forwardRef` is unnecessary. This PR removes it from the component.
