### PR TITLE
fix(odyssey-react-mui): override MuiBackdrop colors correctly

### DIFF
--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -142,9 +142,13 @@ export const components: ThemeOptions["components"] = {
   },
   MuiBackdrop: {
     styleOverrides: {
-      root: {
-        //backgroundColor: "rgba(29,29,33,0.75)",
-      },
+      root: ({ ownerState }) => ({
+        backgroundColor: "rgba(29,29,33,0.75)",
+
+        ...(ownerState.invisible === true && {
+          backgroundColor: "transparent",
+        }),
+      }),
     },
   },
   MuiButton: {


### PR DESCRIPTION
### Description

`MuiBackdrop` always inherits from `root`, even when using `invisible`, so we need to override both.