### PR TITLE
Toast Updates

### DIFF
--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -73,7 +73,7 @@ export const components: ThemeOptions["components"] = {
           borderWidth: theme.mixins.borderWidth,
           borderRadius: theme.mixins.borderRadius,
           position: "relative",
-          alignItems: "start",
+          alignItems: "center",
         }),
       }),
       action: ({ ownerState, theme }) => ({
@@ -86,13 +86,6 @@ export const components: ThemeOptions["components"] = {
           transform: "translateY(-50%)",
         }),
         ...(ownerState.variant === "toast" && {
-          position: "absolute",
-          top: `calc(${theme.spacing(4)} - ${theme.spacing(1)} + ${
-            theme.mixins.borderWidth
-          })`,
-          right: `calc(${theme.spacing(4)} - ${theme.spacing(1)} + ${
-            theme.mixins.borderWidth
-          })`,
           padding: 0,
           marginLeft: 0,
           marginRight: 0,
@@ -137,6 +130,10 @@ export const components: ThemeOptions["components"] = {
         lineHeight: theme.typography.h6.lineHeight,
         fontSize: theme.typography.h6.fontSize,
         fontWeight: theme.typography.fontWeightBold,
+
+        "&:last-child": {
+          marginBlockEnd: 0,
+        },
       }),
     },
   },
@@ -239,7 +236,7 @@ export const components: ThemeOptions["components"] = {
       {
         props: { variant: "floating" },
         style: ({ theme }) => ({
-          backgroundColor: theme.palette.common.white,
+          backgroundColor: "transparent",
           color: theme.palette.text.primary,
           borderColor: "transparent",
 
@@ -265,7 +262,7 @@ export const components: ThemeOptions["components"] = {
         props: { size: "s" },
         style: ({ theme }) => ({
           paddingBlock: `calc(${theme.spacing(2)} - 1px)`,
-          paddingInline: `calc(${theme.spacing(3)} - 1px)`,
+          paddingInline: `calc(${theme.spacing(2)} - 1px)`,
           fontSize: "1rem",
         }),
       },
@@ -346,6 +343,10 @@ export const components: ThemeOptions["components"] = {
         display: "inline-flex",
         margin: 0,
         marginInlineEnd: theme.spacing(2),
+
+        "&:only-child": {
+          margin: 0,
+        },
       }),
     },
   },

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Toast/Toast.mdx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Toast/Toast.mdx
@@ -170,7 +170,7 @@ Do not use Error Toasts for in-page errors such as invalid form fields. Instead,
         <td>Info, Success, Warning, Error</td>
         <td>Yes</td>
         <td>Yes</td>
-        <td>No</td>
+        <td>Optional</td>
         <td>No</td>
       </tr>
     </tbody>

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Toast/Toast.mdx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Toast/Toast.mdx
@@ -15,12 +15,10 @@ Each Toast is made up of up to three parts: Severity, Title, and Message.
   <dd>
     This indicates the toast's status as Info, Success, Warning, or Error.
   </dd>
-  <dt>Title (optional)</dt>
-  <dd>Provides quick context; one line max</dd>
-  <dt>Message</dt>
+  <dt>Content</dt>
   <dd>
-    Supplemental information. Be concise - less than three lines of content - as
-    your Toast will soon vanish!
+    Be concise - less than three lines of content - as your Toast will soon
+    vanish!
   </dd>
 </dl>
 
@@ -35,6 +33,12 @@ Toasts may be triggered by different types of events, but they are always transi
 The Toast pen will take care of positioning and layout automatically. Toasts will appear in the bottom, ending corner above all other content.
 
 If multiple Toasts are triggered in a short time, they will stack in order of appearance. For visual consistency, Toasts will resize to match the largest Toast visible.
+
+### Dismissible
+
+<Canvas>
+  <Story id="mui-components-alerts-toast--dismissible-static" />
+</Canvas>
 
 ## Severity
 

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Toast/Toast.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Toast/Toast.stories.tsx
@@ -16,6 +16,8 @@ import {
   Alert,
   AlertTitle,
   Button,
+  CloseIcon,
+  Link,
   Snackbar,
   Stack,
 } from "@okta/odyssey-react-mui";
@@ -32,10 +34,18 @@ export default {
     },
   },
   argTypes: {
+    action: {
+      control: "text",
+      default: null,
+    },
     content: {
       control: "text",
       defaultValue:
         "The mission to Sagitarius A has been scheduled for January 7.",
+    },
+    isDismissible: {
+      control: "boolean",
+      defaultValue: null,
     },
     role: {
       control: "radio",
@@ -46,10 +56,6 @@ export default {
       control: "radio",
       options: ["error", "info", "success", "warning"],
       defaultValue: "info",
-    },
-    title: {
-      control: "string",
-      defaultValue: "Moonbase Alpha-6",
     },
   },
   decorators: [MuiThemeDecorator],
@@ -68,13 +74,34 @@ const DefaultTemplate: Story = (args) => {
   return (
     <>
       <Button variant="primary" onClick={handleClick}>
-        Open {args.severity} snackbar
+        Open {args.severity} toast
       </Button>
       <Stack spacing={2} sx={{ width: "100%" }}>
-        <Snackbar open={open} autoHideDuration={6000} onClose={handleClose}>
-          <Alert severity={args.severity} variant="toast">
-            {args.title && <AlertTitle>{args.title}</AlertTitle>}
-            {args.content}
+        <Snackbar
+          open={open}
+          autoHideDuration={args.isDismissible === true ? undefined : 6000}
+          onClose={handleClose}
+        >
+          <Alert
+            severity={args.severity}
+            variant="toast"
+            action={
+              args.isDismissible && (
+                <Button
+                  aria-label="close"
+                  onClick={() => {
+                    setOpen(false);
+                  }}
+                  variant="floating"
+                  size="s"
+                >
+                  <CloseIcon fontSize="inherit" />
+                </Button>
+              )
+            }
+          >
+            <AlertTitle>{args.content}</AlertTitle>
+            {args.action && args.action}
           </Alert>
         </Snackbar>
       </Stack>
@@ -84,29 +111,37 @@ const DefaultTemplate: Story = (args) => {
 
 const StaticTemplate: Story = (args) => {
   return (
-    <Alert severity={args.severity} variant="toast">
-      {args.title && <AlertTitle>{args.title}</AlertTitle>}
-      {args.content}
+    <Alert
+      severity={args.severity}
+      variant="toast"
+      action={
+        args.isDismissible && (
+          <Button
+            aria-label="close"
+            variant="floating"
+            size="s"
+            startIcon={<CloseIcon />}
+          ></Button>
+        )
+      }
+    >
+      <AlertTitle>{args.content}</AlertTitle>
+      {args.action && args.action}
     </Alert>
   );
 };
 
 export const Info = DefaultTemplate.bind({});
-Info.args = {
-  title: null,
-};
+Info.args = {};
 
 export const InfoStatic = StaticTemplate.bind({});
-InfoStatic.args = {
-  title: null,
-};
+InfoStatic.args = {};
 
 export const Error = DefaultTemplate.bind({});
 Error.args = {
   content: "Hangar 18 has been compromised.",
   role: "alert",
   severity: "error",
-  title: "Security breach",
 };
 
 export const ErrorStatic = StaticTemplate.bind({});
@@ -114,7 +149,6 @@ ErrorStatic.args = {
   content: "Hangar 18 has been compromised.",
   role: "alert",
   severity: "error",
-  title: "Security breach",
 };
 
 export const Warning = DefaultTemplate.bind({});
@@ -122,7 +156,6 @@ Warning.args = {
   content: "Severe solar winds detected. Local system flights may be delayed.",
   role: "status",
   severity: "warning",
-  title: "Safety warning",
 };
 
 export const WarningStatic = StaticTemplate.bind({});
@@ -130,7 +163,6 @@ WarningStatic.args = {
   content: "Severe solar winds detected. Local system flights may be delayed.",
   role: "status",
   severity: "warning",
-  title: "Safety warning",
 };
 
 export const Success = DefaultTemplate.bind({});
@@ -138,7 +170,6 @@ Success.args = {
   content: "Docking completed successfully.",
   role: "status",
   severity: "success",
-  title: null,
 };
 
 export const SuccessStatic = StaticTemplate.bind({});
@@ -146,5 +177,24 @@ SuccessStatic.args = {
   content: "Docking completed successfully.",
   role: "status",
   severity: "success",
-  title: null,
+};
+
+export const Dismissible = DefaultTemplate.bind({});
+Dismissible.args = {
+  action: (
+    <Link href="#anchor" variant="monochrome">
+      View report
+    </Link>
+  ),
+  isDismissible: true,
+};
+
+export const DismissibleStatic = StaticTemplate.bind({});
+DismissibleStatic.args = {
+  action: (
+    <Link href="#anchor" variant="monochrome">
+      View report
+    </Link>
+  ),
+  isDismissible: true,
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Toast/Toast.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Toast/Toast.stories.tsx
@@ -34,7 +34,7 @@ export default {
     },
   },
   argTypes: {
-    action: {
+    actionLink: {
       control: "text",
       default: null,
     },
@@ -64,23 +64,23 @@ export default {
 const DefaultTemplate: Story = (args) => {
   const [open, setOpen] = React.useState(false);
 
-  const handleClick = () => {
+  const openToast = React.useCallback(() => {
     setOpen(true);
-  };
-
-  const handleClose = () => {
+  }, []);
+  const closeToast = React.useCallback(() => {
     setOpen(false);
-  };
+  }, []);
+
   return (
     <>
-      <Button variant="primary" onClick={handleClick}>
-        Open {args.severity} toast
+      <Button variant="primary" onClick={openToast}>
+        Open {args.severity} snackbar Open {args.severity} toast
       </Button>
       <Stack spacing={2} sx={{ width: "100%" }}>
         <Snackbar
           open={open}
           autoHideDuration={args.isDismissible === true ? undefined : 6000}
-          onClose={handleClose}
+          onClose={closeToast}
         >
           <Alert
             severity={args.severity}
@@ -89,9 +89,7 @@ const DefaultTemplate: Story = (args) => {
               args.isDismissible && (
                 <Button
                   aria-label="close"
-                  onClick={() => {
-                    setOpen(false);
-                  }}
+                  onClick={closeToast}
                   variant="floating"
                   size="s"
                 >
@@ -101,7 +99,7 @@ const DefaultTemplate: Story = (args) => {
             }
           >
             <AlertTitle>{args.content}</AlertTitle>
-            {args.action && args.action}
+            {args.actionLink && args.actionLink}
           </Alert>
         </Snackbar>
       </Stack>
@@ -126,7 +124,7 @@ const StaticTemplate: Story = (args) => {
       }
     >
       <AlertTitle>{args.content}</AlertTitle>
-      {args.action && args.action}
+      {args.actionLink && args.actionLink}
     </Alert>
   );
 };
@@ -181,7 +179,7 @@ SuccessStatic.args = {
 
 export const Dismissible = DefaultTemplate.bind({});
 Dismissible.args = {
-  action: (
+  actionLink: (
     <Link href="#anchor" variant="monochrome">
       View report
     </Link>
@@ -191,7 +189,7 @@ Dismissible.args = {
 
 export const DismissibleStatic = StaticTemplate.bind({});
 DismissibleStatic.args = {
-  action: (
+  actionLink: (
     <Link href="#anchor" variant="monochrome">
       View report
     </Link>


### PR DESCRIPTION
### Description

Preview: https://214d1ce.ods.dev/?path=/docs/mui-components-alerts-toast--info

#### Additions

- Toasts now support `action`
- A dismissible variant is now available
  - When we move to wrapping and exporting, we'll revisit when each prop is allowed (e.g. is `action` only allowed in conjunction with `isDismissible`)

#### Changes

- Toast no longer supports `content` and `title`
- `content` now uses the "title" styling of other Alerts
- Toast layout updated to center-align flex contents; removed any absolute positioning

#### Fixes

- `floating` buttons now correctly have their background set to "transparent"
- `s` sized buttons now have the correct padding
- `startIcon` now drops it's margin if the button has no other content