### PR TITLE
fix: textAlign logical value in FormHelperText for RTL support

### DIFF
--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -667,6 +667,7 @@ export const components: ThemeOptions["components"] = {
         "&:last-child": {
           marginBottom: 0,
         },
+        textAlign: "start",
       }),
     },
   },


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
FormHelperText component uses `text-align: left` by default, this makes the text incompatible with RTL languages. The purpose of this PR is to apply the logical counterpart to the left align CSS property. 

**Left aligned** using `text-align: start`:
<img width="1261" alt="Screen Shot 2023-01-18 at 11 33 43 AM" src="https://user-images.githubusercontent.com/97472729/213242654-25671800-b545-45b5-b1a2-9a1ef889c317.png">

**Right aligned** using `text-align: start`:
<img width="1070" alt="Screen Shot 2023-01-18 at 11 33 06 AM" src="https://user-images.githubusercontent.com/97472729/213242762-48ba00c0-7cf5-4cde-b6bd-46206e57ca06.png">

