### PR TITLE
make Link a11y-compliant in all cases

### DIFF
--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -861,10 +861,10 @@ export const components: ThemeOptions["components"] = {
     styleOverrides: {
       root: ({ theme }) => ({
         color: theme.palette.primary.main,
-        textDecoration: "none",
+        textDecoration: "underline",
 
         "&:hover": {
-          color: theme.palette.primary.main,
+          color: theme.palette.primary.dark,
           textDecoration: "underline",
         },
 


### PR DESCRIPTION
### Description

Makes link a11y-compliant per @josesolano-okta's rec here: https://oktainc.atlassian.net/browse/OKTA-566351

More context on this request here: https://okta.slack.com/archives/C7T2H3KNJ/p1673453694499269