### PR TITLE
fix(odyssey-react-mui): provide safety dec for input box-shadow

### DIFF
--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -1125,6 +1125,7 @@ export const components: ThemeOptions["components"] = {
         height: "auto",
         paddingBlock: `calc(${theme.spacing(3)} - ${theme.mixins.borderWidth})`,
         paddingInline: theme.spacing(3),
+        boxShadow: "none",
 
         [`.${inputBaseClasses.disabled} &`]: {
           pointerEvents: "auto",


### PR DESCRIPTION
Adds `boxShadow: "none"` safety for users in mixed-style environments.