### PR TITLE
fix(odyssey-react-mui): don't require children prop for Icon buttons

### DIFF
--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -347,16 +347,24 @@ export const components: ThemeOptions["components"] = {
         },
       }),
 
-      endIcon: ({ theme }) => ({
+      endIcon: ({ theme, ownerState }) => ({
         display: "inline-flex",
         margin: 0,
         marginInlineStart: theme.spacing(2),
+
+        ...(ownerState.children === undefined && {
+          marginInlineStart: 0,
+        }),
       }),
 
-      startIcon: ({ theme }) => ({
+      startIcon: ({ theme, ownerState }) => ({
         display: "inline-flex",
         margin: 0,
         marginInlineEnd: theme.spacing(2),
+
+        ...(ownerState.children === undefined && {
+          marginInlineEnd: 0,
+        }),
       }),
     },
   },

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.mdx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.mdx
@@ -113,6 +113,7 @@ You should pair Disabled Buttons with a Tooltip if the user would benefit from a
 <Canvas>
   <Story id="mui-components-button--icon-only" />
 </Canvas>
+
 ## References
 
 - <a href="https://mui.com/material-ui/api/button/">Button API</a> - Material UI

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
@@ -111,6 +111,6 @@ ButtonWithIcon.args = {
 
 export const IconOnly = Template.bind({});
 IconOnly.args = {
-  children: "",
+  children: undefined,
   startIcon: <AddIcon />,
 };


### PR DESCRIPTION
### Description

Better interface for icon-only buttons. Prior `children=""` support is left in place to prevent a breaking change.