### PR TITLE
Remove vestigial enableStrictSsl from yarnrc

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,3 @@
-enableStrictSsl: false
-
 nodeLinker: node-modules
 
 plugins:


### PR DESCRIPTION
Removes `enableStrictSsl: false` from `.yarnrc.yml`.

It was a placeholder, and that’s been fixed in Robo Warrior (some Bacon build stuff), so now we can remove this line.