### PR TITLE
docs(odyssey-storybook): remove inline link example from Infobox

### DIFF
--- a/packages/odyssey-storybook/src/components/odyssey-mui/Infobox/Infobox.mdx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Infobox/Infobox.mdx
@@ -56,13 +56,7 @@ Avoid overusing Infobox within the same view. They are intended to draw the eye,
 
 ### Actions
 
-It is ideal to direct users toward an appropriate action, especially for addressing errors. Infoboxes allow for both inline and separated actions. To preserve clarity, limit Infoboxes to one link.
-
-<Canvas>
-  <Story id="mui-components-alerts-infobox--inline-link" />
-</Canvas>
-
-Interactive content should be limited to a single Link. If it's necessary to provide the user with an action, please direct them to the appropriate flow instead of beginning a new process inline.
+It is ideal to direct users toward an appropriate action, especially for addressing errors. To preserve clarity, limit Infoboxes to one link. If it's necessary to provide the user with an action, please direct them to the appropriate flow instead of beginning a new process inline.
 
 <Canvas>
   <Story id="mui-components-alerts-infobox--block-link" />

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Infobox/Infobox.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Infobox/Infobox.stories.tsx
@@ -88,22 +88,6 @@ Success.args = {
   title: "Approved for launch",
 };
 
-export const InlineLink = DefaultTemplate.bind({});
-InlineLink.args = {
-  children: (
-    <>
-      Your fuel mixture ratios need to be{" "}
-      <Link href="#" variant="monochrome">
-        reconfigured
-      </Link>
-      . Then, rerun all safety checks.
-    </>
-  ),
-  role: "alert",
-  severity: "error",
-  title: "Safety checks failed",
-};
-
 export const BlockLink = DefaultTemplate.bind({});
 BlockLink.args = {
   children: (


### PR DESCRIPTION
### Description

removes inline link example from Infobox
