### PR TITLE
Add missing autoFocus from TextField

### DIFF
--- a/packages/odyssey-react-mui/src/TextField.tsx
+++ b/packages/odyssey-react-mui/src/TextField.tsx
@@ -43,6 +43,10 @@ import {
 
 export type TextFieldProps = {
   /**
+   * If `true`, the component will receive focus automatically.
+   */
+  autoFocus?: boolean;
+  /**
    * This prop helps users to fill forms faster, especially on mobile devices.
    * The name can be confusing, as it's more like an autofill.
    * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
@@ -126,6 +130,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
   (
     {
       autoCompleteType,
+      autoFocus,
       endAdornment,
       errorMessage,
       hint,
@@ -187,6 +192,8 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         {hint && <FormHelperText id={hintId}>{hint}</FormHelperText>}
         <InputBase
           autoComplete={autoCompleteType}
+          /* eslint-disable-next-line jsx-a11y/no-autofocus */
+          autoFocus={autoFocus}
           endAdornment={
             inputType === "password" ? (
               <InputAdornment position="end">

--- a/packages/odyssey-storybook/src/components/odyssey-mui/TextField/TextField.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/TextField/TextField.stories.tsx
@@ -29,6 +29,10 @@ const storybookMeta: ComponentMeta<typeof TextField> = {
       control: "text",
       defaultValue: "name",
     },
+    autoFocus: {
+      control: "boolean",
+      defaultValue: false,
+    },
     isDisabled: {
       control: "boolean",
       defaultValue: false,


### PR DESCRIPTION
`<TextField>` is supposed to have the ability to auto-focus on page load, to match the expected (and spec'd) functionality. This PR addresses this missed requirement.

One caveat is that **autofocusing can create accessibility issues** and should be used very judiciously. To circumvent the linter error this throws by default, I've added `/* eslint-disable-next-line jsx-a11y/no-autofocus */` in the code to disable it _in just this one instance_. We'll provide a warning in our documentation to reduce the chances of users abusing this functionality.