### PR TITLE
Prevent Eye from disappearing when the user makes a password visible

### DIFF
--- a/packages/odyssey-react-mui/src/TextField.tsx
+++ b/packages/odyssey-react-mui/src/TextField.tsx
@@ -188,7 +188,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         <InputBase
           autoComplete={autoCompleteType}
           endAdornment={
-            inputType === "password" ? (
+            type === "password" ? (
               <InputAdornment position="end">
                 <IconButton
                   aria-label="toggle password visibility"


### PR DESCRIPTION
Previously, when the user toggled the `Eye` icon in a `TextField` of `type='password'`, the Eye would disappear.

It turns out the presence of the Eye was dependent on the `currentType` of the component, not the `type`. I swapped out that variable and now it works properly.