### PR TITLE
fix(odyssey-react-mui): fix Button, Floating, Disabled bg color

### DIFF
--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -257,7 +257,7 @@ export const components: ThemeOptions["components"] = {
             borderColor: "transparent",
           },
           "&:disabled": {
-            backgroundColor: "rgba(235, 235, 237, 0.6)",
+            backgroundColor: "transparent",
             color: theme.palette.text.secondary,
             borderColor: "transparent",
           },


### PR DESCRIPTION
### Description

Changed our floating `:disabled` color to `transparent`.

<img width="109" alt="Screenshot 2023-03-28 at 1 56 51 PM" src="https://user-images.githubusercontent.com/36284167/228366324-f791ec2a-b1de-4a39-bb96-6cc5ee0a578a.png">