### PR TITLE
Wrapped Tag and TagList

### DIFF
--- a/packages/odyssey-react-mui/src/Tag.tsx
+++ b/packages/odyssey-react-mui/src/Tag.tsx
@@ -14,16 +14,16 @@ import { Chip } from ".";
 import { memo } from "react";
 
 export type TagProps = {
-  isClickable?: boolean;
   isDisabled?: boolean;
+  isInteractive?: boolean;
   label: string;
   onDelete?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
 };
 
-const Tag = ({ isClickable, isDisabled, label, onDelete }: TagProps) => (
+const Tag = ({ isDisabled, isInteractive, label, onDelete }: TagProps) => (
   <Chip
     label={label}
-    clickable={isClickable}
+    clickable={isInteractive}
     component="li"
     disabled={isDisabled}
     onDelete={onDelete}

--- a/packages/odyssey-react-mui/src/Tag.tsx
+++ b/packages/odyssey-react-mui/src/Tag.tsx
@@ -10,28 +10,28 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Chip } from ".";
+import { Chip, ChipProps } from "@mui/material";
 import { memo, useContext } from "react";
 import { TagListContext } from "./TagListContext";
 
 export type TagProps = {
   isDisabled?: boolean;
   label: string;
-  onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
-  onDelete?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+  onClick?: ChipProps["onClick"];
+  onRemove?: ChipProps["onDelete"];
 };
 
-const Tag = ({ isDisabled, label, onClick, onDelete }: TagProps) => {
-  const { chipComponent } = useContext(TagListContext);
+const Tag = ({ isDisabled, label, onClick, onRemove }: TagProps) => {
+  const { chipElementType } = useContext(TagListContext);
 
   return (
     <Chip
       label={label}
       clickable={onClick ? true : false}
-      component={chipComponent}
+      component={chipElementType}
       disabled={isDisabled}
       onClick={onClick}
-      onDelete={onDelete}
+      onDelete={onRemove}
     />
   );
 };

--- a/packages/odyssey-react-mui/src/Tag.tsx
+++ b/packages/odyssey-react-mui/src/Tag.tsx
@@ -11,24 +11,37 @@
  */
 
 import { Chip } from ".";
-import { memo } from "react";
+import { memo, useContext } from "react";
+import { TagListContext } from "./TagListContext";
 
 export type TagProps = {
   isDisabled?: boolean;
   isInteractive?: boolean;
   label: string;
+  onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
   onDelete?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
 };
 
-const Tag = ({ isDisabled, isInteractive, label, onDelete }: TagProps) => (
-  <Chip
-    label={label}
-    clickable={isInteractive}
-    component="li"
-    disabled={isDisabled}
-    onDelete={onDelete}
-  />
-);
+const Tag = ({
+  isDisabled,
+  isInteractive,
+  label,
+  onClick,
+  onDelete,
+}: TagProps) => {
+  const { chipComponent } = useContext(TagListContext);
+
+  return (
+    <Chip
+      label={label}
+      clickable={isInteractive}
+      component={chipComponent}
+      disabled={isDisabled}
+      onClick={onClick}
+      onDelete={onDelete}
+    />
+  );
+};
 
 const MemoizedTag = memo(Tag);
 

--- a/packages/odyssey-react-mui/src/Tag.tsx
+++ b/packages/odyssey-react-mui/src/Tag.tsx
@@ -13,10 +13,9 @@
 import { Chip, ChipProps } from ".";
 import { memo } from "react";
 
-export interface TagProps extends ChipProps {
+export interface TagProps extends Omit<ChipProps, "clickable" | "disabled"> {
   isClickable?: boolean;
   isDisabled?: boolean;
-  label: string;
 }
 
 const Tag = ({ isClickable, isDisabled, label, ...rest }: TagProps) => (

--- a/packages/odyssey-react-mui/src/Tag.tsx
+++ b/packages/odyssey-react-mui/src/Tag.tsx
@@ -1,0 +1,28 @@
+/*!
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { Chip, ChipProps } from ".";
+import { memo } from "react";
+
+export interface TagProps extends ChipProps {
+  isClickable?: boolean;
+  isDisabled?: boolean;
+  label: string;
+}
+
+const Tag = ({ isClickable, isDisabled, label, ...rest }: TagProps) => (
+  <Chip label={label} clickable={isClickable} disabled={isDisabled} {...rest} />
+);
+
+const MemoizedTag = memo(Tag);
+
+export { MemoizedTag as Tag };

--- a/packages/odyssey-react-mui/src/Tag.tsx
+++ b/packages/odyssey-react-mui/src/Tag.tsx
@@ -16,25 +16,18 @@ import { TagListContext } from "./TagListContext";
 
 export type TagProps = {
   isDisabled?: boolean;
-  isInteractive?: boolean;
   label: string;
   onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
   onDelete?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
 };
 
-const Tag = ({
-  isDisabled,
-  isInteractive,
-  label,
-  onClick,
-  onDelete,
-}: TagProps) => {
+const Tag = ({ isDisabled, label, onClick, onDelete }: TagProps) => {
   const { chipComponent } = useContext(TagListContext);
 
   return (
     <Chip
       label={label}
-      clickable={isInteractive}
+      clickable={onClick ? true : false}
       component={chipComponent}
       disabled={isDisabled}
       onClick={onClick}

--- a/packages/odyssey-react-mui/src/Tag.tsx
+++ b/packages/odyssey-react-mui/src/Tag.tsx
@@ -10,16 +10,24 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Chip, ChipProps } from ".";
+import { Chip } from ".";
 import { memo } from "react";
 
-export interface TagProps extends Omit<ChipProps, "clickable" | "disabled"> {
+export type TagProps = {
   isClickable?: boolean;
   isDisabled?: boolean;
-}
+  label: string;
+  onDelete?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+};
 
-const Tag = ({ isClickable, isDisabled, label, ...rest }: TagProps) => (
-  <Chip label={label} clickable={isClickable} disabled={isDisabled} {...rest} />
+const Tag = ({ isClickable, isDisabled, label, onDelete }: TagProps) => (
+  <Chip
+    label={label}
+    clickable={isClickable}
+    component="li"
+    disabled={isDisabled}
+    onDelete={onDelete}
+  />
 );
 
 const MemoizedTag = memo(Tag);

--- a/packages/odyssey-react-mui/src/TagList.tsx
+++ b/packages/odyssey-react-mui/src/TagList.tsx
@@ -18,7 +18,7 @@ export type TagListProps = {
 };
 
 const TagList = ({ children }: TagListProps) => (
-  <Stack direction="row" spacing={2}>
+  <Stack component="ul" direction="row" spacing={2}>
     {children}
   </Stack>
 );

--- a/packages/odyssey-react-mui/src/TagList.tsx
+++ b/packages/odyssey-react-mui/src/TagList.tsx
@@ -1,0 +1,28 @@
+/*!
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { Stack, Tag } from ".";
+import { memo, ReactElement } from "react";
+
+export type TagListProps = {
+  children: ReactElement<typeof Tag> | Array<ReactElement<typeof Tag>>;
+};
+
+const TagList = ({ children }: TagListProps) => (
+  <Stack direction="row" spacing={2}>
+    {children}
+  </Stack>
+);
+
+const MemoizedTagList = memo(TagList);
+
+export { MemoizedTagList as TagList };

--- a/packages/odyssey-react-mui/src/TagList.tsx
+++ b/packages/odyssey-react-mui/src/TagList.tsx
@@ -10,18 +10,21 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Stack, Tag } from ".";
+import { Tag } from "./";
+import { Stack } from "@mui/material";
 import { memo, ReactElement, useMemo } from "react";
-import { ChipComponentType, TagListContext } from "./TagListContext";
+import { ChipElementType, TagListContext } from "./TagListContext";
 
 export type TagListProps = {
   children: ReactElement<typeof Tag> | Array<ReactElement<typeof Tag>>;
 };
 
 const TagList = ({ children }: TagListProps) => {
-  const providerValue = useMemo(
+  const providerValue = useMemo<{
+    chipElementType: ChipElementType;
+  }>(
     () => ({
-      chipComponent: "li" as ChipComponentType,
+      chipElementType: "li",
     }),
     []
   );

--- a/packages/odyssey-react-mui/src/TagList.tsx
+++ b/packages/odyssey-react-mui/src/TagList.tsx
@@ -11,17 +11,29 @@
  */
 
 import { Stack, Tag } from ".";
-import { memo, ReactElement } from "react";
+import { memo, ReactElement, useMemo } from "react";
+import { ChipComponentType, TagListContext } from "./TagListContext";
 
 export type TagListProps = {
   children: ReactElement<typeof Tag> | Array<ReactElement<typeof Tag>>;
 };
 
-const TagList = ({ children }: TagListProps) => (
-  <Stack component="ul" direction="row" spacing={2}>
-    {children}
-  </Stack>
-);
+const TagList = ({ children }: TagListProps) => {
+  const providerValue = useMemo(
+    () => ({
+      chipComponent: "li" as ChipComponentType,
+    }),
+    []
+  );
+
+  return (
+    <Stack component="ul" direction="row" spacing={2}>
+      <TagListContext.Provider value={providerValue}>
+        {children}
+      </TagListContext.Provider>
+    </Stack>
+  );
+};
 
 const MemoizedTagList = memo(TagList);
 

--- a/packages/odyssey-react-mui/src/TagListContext.tsx
+++ b/packages/odyssey-react-mui/src/TagListContext.tsx
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { createContext, ElementType } from "react";
+import { ChipProps } from "@mui/material";
+
+export type ChipComponentType = ElementType<ChipProps>;
+export const TagListContext = createContext({
+  chipComponent: "div" as ChipComponentType,
+});

--- a/packages/odyssey-react-mui/src/TagListContext.tsx
+++ b/packages/odyssey-react-mui/src/TagListContext.tsx
@@ -10,10 +10,14 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { createContext, ElementType } from "react";
-import { ChipProps } from "@mui/material";
+import { createContext } from "react";
 
-export type ChipComponentType = ElementType<ChipProps>;
-export const TagListContext = createContext({
-  chipComponent: "div" as ChipComponentType,
+export type ChipElementType = "li" | "div";
+
+export type TagListContextType = {
+  chipElementType: ChipElementType;
+};
+
+export const TagListContext = createContext<TagListContextType>({
+  chipElementType: "div",
 });

--- a/packages/odyssey-react-mui/src/index.ts
+++ b/packages/odyssey-react-mui/src/index.ts
@@ -140,6 +140,8 @@ export * from "./PasswordInput";
 export * from "./Radio";
 export * from "./RadioGroup";
 export * from "./Status";
+export * from "./Tag";
+export * from "./TagList";
 export * from "./TextField";
 export * from "./theme";
 export * from "./ThemeProvider";

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.mdx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.mdx
@@ -24,10 +24,10 @@ TagList UI is simple. It consists of typography and spacing within a neutral con
   <Story id="mui-components-tag--clickable" />
 </Canvas>
 
-### Deletable Tags
+### Removable Tags
 
 <Canvas>
-  <Story id="mui-components-tag--deletable" />
+  <Story id="mui-components-tag--removable" />
 </Canvas>
 
 ### Disabled Tags

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
@@ -11,14 +11,14 @@
  */
 
 import { Story } from "@storybook/react";
-import { Chip, Stack } from "@okta/odyssey-react-mui";
+import { Tag, TagList } from "@okta/odyssey-react-mui";
 import { MuiThemeDecorator } from "../../../../.storybook/components";
 
 import TagMdx from "./Tag.mdx";
 
 export default {
   title: `MUI Components/Tag`,
-  component: Chip,
+  component: Tag,
   parameters: {
     docs: {
       page: TagMdx,
@@ -59,30 +59,30 @@ const handleDelete = () => {
 
 const DefaultTemplate: Story = (args) => {
   return (
-    <Stack direction="row" spacing={2}>
-      <Chip
+    <TagList>
+      <Tag
         label={args.label}
-        clickable={args.clickable}
-        disabled={args.disabled}
+        isClickable={args.clickable}
+        isDisabled={args.disabled}
         onDelete={args.deletable && handleDelete}
       />
       {args.label2 && (
-        <Chip
+        <Tag
           label={args.label2}
-          clickable={args.clickable}
-          disabled={args.disabled}
+          isClickable={args.clickable}
+          isDisabled={args.disabled}
           onDelete={args.deletable && handleDelete}
         />
       )}
       {args.label3 && (
-        <Chip
+        <Tag
           label={args.label3}
-          clickable={args.clickable}
-          disabled={args.disabled}
+          isClickable={args.clickable}
+          isDisabled={args.disabled}
           onDelete={args.deletable && handleDelete}
         />
       )}
-    </Stack>
+    </TagList>
   );
 };
 

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
@@ -29,59 +29,44 @@ export default {
       control: "text",
       defaultValue: "Starship",
     },
-    label2: {
+    isInteractive: {
+      control: "boolean",
+      defaultValue: false,
+    },
+    isDisabled: {
+      control: "boolean",
+      defaultValue: false,
+    },
+    onDelete: {
       control: "text",
       defaultValue: null,
-    },
-    label3: {
-      control: "text",
-      defaultValue: null,
-    },
-    interactive: {
-      control: "boolean",
-      defaultValue: false,
-    },
-    disabled: {
-      control: "boolean",
-      defaultValue: false,
-    },
-    deletable: {
-      control: "boolean",
-      defaultValue: false,
     },
   },
   decorators: [MuiThemeDecorator],
 };
 
-const handleDelete = () => {
-  console.info("You clicked the delete icon.");
+const DefaultTemplate: Story = (args) => {
+  return (
+    <Tag
+      label={args.label}
+      isInteractive={args.isInteractive}
+      isDisabled={args.isDisabled}
+      onDelete={args.onDelete}
+    />
+  );
 };
 
-const DefaultTemplate: Story = (args) => {
+const ListTemplate: Story = (args) => {
   return (
     <TagList>
       <Tag
         label={args.label}
-        isInteractive={args.interactive}
-        isDisabled={args.disabled}
-        onDelete={args.deletable && handleDelete}
+        isInteractive={args.isInteractive}
+        isDisabled={args.isDisabled}
+        onDelete={args.onDelete}
       />
-      {args.label2 && (
-        <Tag
-          label={args.label2}
-          isInteractive={args.interactive}
-          isDisabled={args.disabled}
-          onDelete={args.deletable && handleDelete}
-        />
-      )}
-      {args.label3 && (
-        <Tag
-          label={args.label3}
-          isInteractive={args.interactive}
-          isDisabled={args.disabled}
-          onDelete={args.deletable && handleDelete}
-        />
-      )}
+      <Tag label="Another tag" />
+      <Tag label="A third tag" />
     </TagList>
   );
 };
@@ -89,23 +74,22 @@ const DefaultTemplate: Story = (args) => {
 export const Default = DefaultTemplate.bind({});
 Default.args = {};
 
-export const List = DefaultTemplate.bind({});
-List.args = {
-  label2: "Warp-capable",
-  label3: "Unmanned",
-};
+export const List = ListTemplate.bind({});
+List.args = {};
 
 export const Clickable = DefaultTemplate.bind({});
 Clickable.args = {
-  clickable: true,
+  isClickable: true,
 };
 
 export const Deletable = DefaultTemplate.bind({});
 Deletable.args = {
-  deletable: true,
+  onDelete: () => {
+    return true;
+  },
 };
 
 export const Disabled = DefaultTemplate.bind({});
 Disabled.args = {
-  disabled: true,
+  isDisabled: true,
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
@@ -10,8 +10,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Story } from "@storybook/react";
-import { Tag, TagList } from "@okta/odyssey-react-mui";
+import { Meta, Story } from "@storybook/react";
+import { Tag, TagList, TagProps } from "@okta/odyssey-react-mui";
 import { MuiThemeDecorator } from "../../../../.storybook/components";
 
 import TagMdx from "./Tag.mdx";
@@ -29,13 +29,13 @@ export default {
       control: "text",
       defaultValue: "Starship",
     },
-    isInteractive: {
-      control: "boolean",
-      defaultValue: false,
-    },
     isDisabled: {
       control: "boolean",
       defaultValue: false,
+    },
+    onClick: {
+      control: "text",
+      defaultValue: null,
     },
     onDelete: {
       control: "text",
@@ -43,26 +43,26 @@ export default {
     },
   },
   decorators: [MuiThemeDecorator],
-};
+} as Meta<TagProps>;
 
-const DefaultTemplate: Story = (args) => {
+const DefaultTemplate: Story<TagProps> = (args) => {
   return (
     <Tag
       label={args.label}
-      isInteractive={args.isInteractive}
       isDisabled={args.isDisabled}
+      onClick={args.onClick}
       onDelete={args.onDelete}
     />
   );
 };
 
-const ListTemplate: Story = (args) => {
+const ListTemplate: Story<TagProps> = (args) => {
   return (
     <TagList>
       <Tag
         label={args.label}
-        isInteractive={args.isInteractive}
         isDisabled={args.isDisabled}
+        onClick={args.onClick}
         onDelete={args.onDelete}
       />
       <Tag label="Another tag" />
@@ -79,7 +79,9 @@ List.args = {};
 
 export const Clickable = DefaultTemplate.bind({});
 Clickable.args = {
-  isClickable: true,
+  onClick: () => {
+    return true;
+  },
 };
 
 export const Deletable = DefaultTemplate.bind({});

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
@@ -37,7 +37,7 @@ export default {
       control: "text",
       defaultValue: null,
     },
-    clickable: {
+    interactive: {
       control: "boolean",
       defaultValue: false,
     },
@@ -62,14 +62,14 @@ const DefaultTemplate: Story = (args) => {
     <TagList>
       <Tag
         label={args.label}
-        isClickable={args.clickable}
+        isInteractive={args.interactive}
         isDisabled={args.disabled}
         onDelete={args.deletable && handleDelete}
       />
       {args.label2 && (
         <Tag
           label={args.label2}
-          isClickable={args.clickable}
+          isInteractive={args.interactive}
           isDisabled={args.disabled}
           onDelete={args.deletable && handleDelete}
         />
@@ -77,7 +77,7 @@ const DefaultTemplate: Story = (args) => {
       {args.label3 && (
         <Tag
           label={args.label3}
-          isClickable={args.clickable}
+          isInteractive={args.interactive}
           isDisabled={args.disabled}
           onDelete={args.deletable && handleDelete}
         />

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
@@ -11,15 +11,17 @@
  */
 
 import { Meta, Story } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
 import { Tag, TagList, TagProps } from "@okta/odyssey-react-mui";
 import { MuiThemeDecorator } from "../../../../.storybook/components";
 
 import TagMdx from "./Tag.mdx";
 
-export default {
+const storybookMeta: Meta<TagProps> = {
   title: `MUI Components/Tag`,
   component: Tag,
   parameters: {
+    actions: { argTypesRegex: null },
     docs: {
       page: TagMdx,
     },
@@ -34,37 +36,25 @@ export default {
       defaultValue: false,
     },
     onClick: {
-      control: "text",
-      defaultValue: null,
+      control: "function",
     },
-    onDelete: {
-      control: "text",
-      defaultValue: null,
+    onRemove: {
+      control: "function",
     },
   },
   decorators: [MuiThemeDecorator],
-} as Meta<TagProps>;
+};
+
+export default storybookMeta;
 
 const DefaultTemplate: Story<TagProps> = (args) => {
-  return (
-    <Tag
-      label={args.label}
-      isDisabled={args.isDisabled}
-      onClick={args.onClick}
-      onDelete={args.onDelete}
-    />
-  );
+  return <Tag {...args} />;
 };
 
 const ListTemplate: Story<TagProps> = (args) => {
   return (
     <TagList>
-      <Tag
-        label={args.label}
-        isDisabled={args.isDisabled}
-        onClick={args.onClick}
-        onDelete={args.onDelete}
-      />
+      <Tag {...args} />
       <Tag label="Another tag" />
       <Tag label="A third tag" />
     </TagList>
@@ -79,16 +69,12 @@ List.args = {};
 
 export const Clickable = DefaultTemplate.bind({});
 Clickable.args = {
-  onClick: () => {
-    return true;
-  },
+  onClick: action("clicked"),
 };
 
-export const Deletable = DefaultTemplate.bind({});
-Deletable.args = {
-  onDelete: () => {
-    return true;
-  },
+export const Removable = DefaultTemplate.bind({});
+Removable.args = {
+  onRemove: action("removed"),
 };
 
 export const Disabled = DefaultTemplate.bind({});

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Toast/Toast.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Toast/Toast.stories.tsx
@@ -73,7 +73,7 @@ const DefaultTemplate: Story = (args) => {
   return (
     <>
       <Button variant="primary" onClick={openToast}>
-        Open {args.severity} snackbar Open {args.severity} toast
+        Open {args.severity} toast
       </Button>
       <Stack spacing={2} sx={{ width: "100%" }}>
         <Snackbar


### PR DESCRIPTION
This is a simple wrapper over `Chip` and `Stack` to add better ergonomics around tags and taglists.

I changed MUI's default `disabled` prop to `isDisabled` to be consistent with our other components.