### PR TITLE
fix: add missing onInput to Autocomplete

### DIFF
--- a/packages/odyssey-react-mui/src/Autocomplete.tsx
+++ b/packages/odyssey-react-mui/src/Autocomplete.tsx
@@ -62,6 +62,12 @@ export type AutocompleteProps<
     undefined,
     IsCustomValueAllowed
   >["onChange"];
+  onInputChange?: MuiAutocompleteProps<
+    OptionType,
+    HasMultipleChoices,
+    undefined,
+    IsCustomValueAllowed
+  >["onInputChange"];
   options: MuiAutocompleteProps<
     OptionType,
     HasMultipleChoices,
@@ -89,6 +95,7 @@ const Autocomplete = <
   hint,
   label,
   onChange,
+  onInputChange,
   options,
   value,
 }: AutocompleteProps<OptionType, HasMultipleChoices, IsCustomValueAllowed>) => {
@@ -119,6 +126,7 @@ const Autocomplete = <
       loading={isLoading}
       multiple={hasMultipleChoices}
       onChange={onChange}
+      onInputChange={onInputChange}
       options={options}
       readOnly={isReadOnly}
       renderInput={renderInput}


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
`Autocomplete` is missing the `onInput` prop required by other apps. This PR adds it.