### PR TITLE
Switch isRequired to isOptional

### DIFF
--- a/packages/odyssey-react-mui/src/Field.tsx
+++ b/packages/odyssey-react-mui/src/Field.tsx
@@ -39,9 +39,9 @@ export type FieldProps = {
    */
   isDisabled?: boolean;
   /**
-   * If `true`, the `input` element is required.
+   * If `true`, the `input` element is not required.
    */
-  isRequired?: boolean;
+  isOptional?: boolean;
   /**
    * The label for the `input` element.
    */
@@ -69,7 +69,7 @@ const Field = ({
   hint,
   id: idOverride,
   isDisabled = false,
-  isRequired = true,
+  isOptional = false,
   label,
   optionalLabel,
   renderFieldComponent,
@@ -90,7 +90,7 @@ const Field = ({
         hasVisibleLabel={hasVisibleLabel}
         id={labelId}
         inputId={id}
-        isRequired={isRequired}
+        isOptional={isOptional}
         optionalText={optionalLabel}
         text={label}
       />

--- a/packages/odyssey-react-mui/src/FieldLabel.tsx
+++ b/packages/odyssey-react-mui/src/FieldLabel.tsx
@@ -20,7 +20,7 @@ export type FieldLabelProps = {
   hasVisibleLabel: boolean;
   id: string;
   inputId: string;
-  isRequired: boolean;
+  isOptional: boolean;
   optionalText?: string;
   text: string;
 };
@@ -29,7 +29,7 @@ const FieldLabel = ({
   hasVisibleLabel,
   id,
   inputId,
-  isRequired,
+  isOptional,
   optionalText,
   text,
 }: FieldLabelProps) => {
@@ -37,12 +37,12 @@ const FieldLabel = ({
     () => (
       <InputLabel htmlFor={inputId} id={id}>
         {text}
-        {!isRequired && (
+        {isOptional && (
           <Typography variant="subtitle1">{optionalText}</Typography>
         )}
       </InputLabel>
     ),
-    [id, inputId, isRequired, optionalText, text]
+    [id, inputId, isOptional, optionalText, text]
   );
 
   return hasVisibleLabel ? (

--- a/packages/odyssey-react-mui/src/PasswordField.tsx
+++ b/packages/odyssey-react-mui/src/PasswordField.tsx
@@ -51,13 +51,13 @@ export type PasswordFieldProps = {
    */
   isDisabled?: boolean;
   /**
+   * If `true`, the `input` element is not required.
+   */
+  isOptional?: boolean;
+  /**
    * It prevents the user from changing the value of the field
    */
   isReadOnly?: boolean;
-  /**
-   * If `true`, the `input` element is required.
-   */
-  isRequired?: boolean;
   /**
    * The label for the `input` element.
    */
@@ -93,6 +93,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
       hint,
       id: idOverride,
       isDisabled = false,
+      isOptional = false,
       isReadOnly,
       label,
       onChange,
@@ -137,6 +138,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
           placeholder={placeholder}
           readOnly={isReadOnly}
           ref={ref}
+          required={!isOptional}
           type={inputType}
           value={value}
         />
@@ -150,6 +152,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
         onFocus,
         onBlur,
         placeholder,
+        isOptional,
         isReadOnly,
         ref,
         value,
@@ -163,6 +166,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
         hint={hint}
         id={idOverride}
         isDisabled={isDisabled}
+        isOptional={isOptional}
         label={label}
         renderFieldComponent={renderFieldComponent}
       />

--- a/packages/odyssey-react-mui/src/SearchField.tsx
+++ b/packages/odyssey-react-mui/src/SearchField.tsx
@@ -124,7 +124,7 @@ const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
         hasVisibleLabel={false}
         id={idOverride}
         isDisabled={isDisabled}
-        isRequired={false}
+        isOptional={true}
         label={label}
         renderFieldComponent={renderFieldComponent}
       />

--- a/packages/odyssey-react-mui/src/TextField.tsx
+++ b/packages/odyssey-react-mui/src/TextField.tsx
@@ -59,13 +59,13 @@ export type TextFieldProps = {
    */
   isMultiline?: boolean;
   /**
+   * If `true`, the `input` element is not required.
+   */
+  isOptional?: boolean;
+  /**
    * It prevents the user from changing the value of the field
    */
   isReadOnly?: boolean;
-  /**
-   * If `true`, the `input` element is required.
-   */
-  isRequired?: boolean;
   /**
    * The label for the `input` element.
    */
@@ -83,7 +83,7 @@ export type TextFieldProps = {
    */
   onFocus?: FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
   /**
-   * The label for the `input` element if the it's not optional
+   * The label for the `input` element if it's optional
    */
   optionalLabel?: string;
   /**
@@ -115,8 +115,8 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       id: idOverride,
       isDisabled = false,
       isMultiline = false,
+      isOptional = false,
       isReadOnly,
-      isRequired = true,
       label,
       onBlur,
       onChange,
@@ -175,7 +175,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         hint={hint}
         id={idOverride}
         isDisabled={isDisabled}
-        isRequired={isRequired}
+        isOptional={isOptional}
         label={label}
         optionalLabel={optionalLabel}
         renderFieldComponent={renderFieldComponent}

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -40,6 +40,7 @@ import {
   InformationCircleFilledIcon,
   SubtractIcon,
 } from "../iconDictionary";
+import { theme } from "./theme";
 
 export const components: ThemeOptions["components"] = {
   MuiAlert: {
@@ -1318,6 +1319,9 @@ export const components: ThemeOptions["components"] = {
             transform: "none",
           }),
         }),
+        "& > .MuiTypography-root": {
+          lineHeight: `${theme.typography.ui.lineHeight}rem`,
+        },
       }),
     },
   },

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -40,7 +40,6 @@ import {
   InformationCircleFilledIcon,
   SubtractIcon,
 } from "../iconDictionary";
-import { theme } from "./theme";
 
 export const components: ThemeOptions["components"] = {
   MuiAlert: {

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -1320,7 +1320,7 @@ export const components: ThemeOptions["components"] = {
           }),
         }),
         "& > .MuiTypography-root": {
-          lineHeight: `${theme.typography.ui.lineHeight}rem`,
+          lineHeight: "unset",
         },
       }),
     },

--- a/packages/odyssey-storybook/src/components/odyssey-mui/PasswordField/PasswordField.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/PasswordField/PasswordField.stories.tsx
@@ -66,9 +66,9 @@ const storybookMeta: ComponentMeta<typeof PasswordField> = {
       control: "boolean",
       defaultValue: false,
     },
-    isRequired: {
+    isOptional: {
       control: "boolean",
-      defaultValue: true,
+      defaultValue: false,
     },
     value: {
       control: "text",

--- a/packages/odyssey-storybook/src/components/odyssey-mui/TextField/TextField.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/TextField/TextField.stories.tsx
@@ -66,6 +66,10 @@ const storybookMeta: ComponentMeta<typeof TextField> = {
     onFocus: {
       control: "function",
     },
+    isOptional: {
+      control: "boolean",
+      defaultValue: false,
+    },
     optionalLabel: {
       control: "text",
       defaultValue: "Optional",
@@ -76,10 +80,6 @@ const storybookMeta: ComponentMeta<typeof TextField> = {
     isReadOnly: {
       control: "boolean",
       defaultValue: false,
-    },
-    isRequired: {
-      control: "boolean",
-      defaultValue: true,
     },
     startAdornment: {
       control: "text",
@@ -115,7 +115,7 @@ Disabled.args = {
 
 export const Optional = Template.bind({});
 Optional.args = {
-  isRequired: false,
+  isOptional: true,
 };
 
 export const ReadOnly = Template.bind({});


### PR DESCRIPTION
This PR improves the optional/required handling on form fields. I made the following changes:

1. **`isRequired` is now `isOptional` on all form fields that include it**. This includes all types of `TextField`, as well as `PasswordField`. It does not include `SearchField`, since that component doesn't include `required`/`optional` functionality. I made this change throughout the stack for consistency (`Textfield` -> `Field` -> `FieldLabel`, etc)
2. **Updated the `lineHeight` on the optional label.** The line height was 1.14 pixels off, making the input "jump" by a pixel when the optionalLabel was visible. I updated it to the proper value to ensure that it remains positioned properly without bumping anything improperly.