### PR TITLE
Remove MUI links in documentation

### DIFF
--- a/packages/odyssey-storybook/src/components/odyssey-labs/DatePicker/DatePicker.mdx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/DatePicker/DatePicker.mdx
@@ -17,8 +17,3 @@ Use our default DatePicker for choosing a date. For example, “10/17/2022".
 <Canvas>
   <Story id="labs-components-datepicker--date-picker-standard" />
 </Canvas>
-
-## References
-
-- <a href="https://mui.com/x/react-date-pickers/date-picker/">DatePicker API</a> -
-  Material UI X

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.mdx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.mdx
@@ -116,7 +116,6 @@ You should pair Disabled Buttons with a Tooltip if the user would benefit from a
 
 ## References
 
-- <a href="https://mui.com/material-ui/api/button/">Button API</a> - Material UI
 - <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button">
     Button
   </a> - MDN

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Link/Link.mdx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Link/Link.mdx
@@ -36,5 +36,4 @@ Set `target = "_blank"`.
 
 ## References
 
-- <a href="https://mui.com/material-ui/api/link/">Link API</a> - Material UI
 - [Google's Developer Documentation](https://developers.google.com/web/tools/lighthouse/audits/noopener) provides backgrounds on security and performance considerations when using external links

--- a/packages/odyssey-storybook/src/contributing/CustomTheme.mdx
+++ b/packages/odyssey-storybook/src/contributing/CustomTheme.mdx
@@ -27,9 +27,3 @@ Visually, the mui components under `OdysseyThemeProvider` with custom theme woul
 <Canvas>
   <Story id="customization-components--radio-group-story" />
 </Canvas>
-
-## References
-
-- <a href="https://mui.com/material-ui/customization/theme-components/">
-    Components Customization
-  </a> - Material UI


### PR DESCRIPTION
Removes the MUI links in the documentation, since people were getting confused.

I left a single reference in the [Custom Theming ](https://odyssey.okta.design/?path=/docs/guidelines-custom-theming--page) page, since the intention of that page is specifically to point to MUI's `ThemeOptions` documentation for anyone taking a deep dive into how Odyssey works under-the-hood.