### PR TITLE
fix(odyssey-react-mui): ensure pointer events are disabled

### DIFF
--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -386,11 +386,6 @@ export const components: ThemeOptions["components"] = {
           outlineOffset: "1px",
         },
 
-        "&:disabled": {
-          cursor: "not-allowed",
-          pointerEvents: "inherit", // in order to have cursor: not-allowed, must change pointer-events from "none"
-        },
-
         [`.${buttonClasses.startIcon}, .${buttonClasses.endIcon}`]: {
           "& > *:nth-of-type(1)": {
             fontSize: `${theme.typography.ui.lineHeight}em`,


### PR DESCRIPTION
### Description

Removes `cursor` styling for disabled Buttons and returns `pointer-events` to default state.