### PR TITLE
fix(odyssey-storybook): stories were broken from incorrect template args

### DIFF
--- a/packages/odyssey-storybook/src/components/odyssey-mui/Infobox/Infobox.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Infobox/Infobox.stories.tsx
@@ -32,6 +32,8 @@ const storybookMeta: Meta<InfoboxProps> = {
   argTypes: {
     children: {
       control: "text",
+      defaultValue:
+        "You are currently logged in from Moonbase Alpha-6, located on Luna.",
     },
     role: {
       control: "radio",
@@ -57,11 +59,6 @@ const DefaultTemplate: Story<InfoboxProps> = (args) => {
       {args.children}
     </Infobox>
   );
-};
-
-DefaultTemplate.args = {
-  children:
-    "You are currently logged in from Moonbase Alpha-6, located on Luna.",
 };
 
 export const Info = DefaultTemplate.bind({});

--- a/packages/odyssey-storybook/src/components/odyssey-mui/MenuButton/MenuButton.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/MenuButton/MenuButton.stories.tsx
@@ -42,6 +42,7 @@ const storybookMeta: Meta<MenuButtonProps> = {
     },
     buttonLabel: {
       control: "text",
+      defaultValue: "More actions",
     },
     buttonEndIcon: {
       control: "text",
@@ -59,13 +60,8 @@ const DefaultTemplate: Story<MenuButtonProps> = (args) => {
   return <MenuButton {...args}>{args.children}</MenuButton>;
 };
 
-DefaultTemplate.args = {
-  buttonLabel: "More actions",
-};
-
 export const Simple = DefaultTemplate.bind({});
 Simple.args = {
-  buttonLabel: "More actions",
   children: [
     <MenuItem>View details</MenuItem>,
     <MenuItem>Edit configuration</MenuItem>,
@@ -99,7 +95,6 @@ ActionIcons.args = {
 
 export const ButtonVariant = DefaultTemplate.bind({});
 ButtonVariant.args = {
-  buttonLabel: "More actions",
   buttonVariant: "floating",
   children: [
     <MenuItem>View details</MenuItem>,
@@ -110,7 +105,6 @@ ButtonVariant.args = {
 
 export const Groupings = DefaultTemplate.bind({});
 Groupings.args = {
-  buttonLabel: "More actions",
   children: [
     <ListSubheader>Crew</ListSubheader>,
     <MenuItem>Assign captain</MenuItem>,

--- a/packages/odyssey-storybook/src/components/odyssey-mui/SearchField/SearchField.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/SearchField/SearchField.stories.tsx
@@ -27,6 +27,7 @@ const storybookMeta: Meta<SearchFieldProps> = {
   argTypes: {
     autoCompleteType: {
       control: "text",
+      defaultValue: "name",
     },
     hasInitialFocus: {
       control: "boolean",
@@ -39,6 +40,7 @@ const storybookMeta: Meta<SearchFieldProps> = {
     },
     label: {
       control: "text",
+      defaultValue: "Search",
     },
     onBlur: {
       control: "function",
@@ -51,6 +53,7 @@ const storybookMeta: Meta<SearchFieldProps> = {
     },
     placeholder: {
       control: "text",
+      defaultValue: "Search planets",
     },
     value: {
       control: "text",
@@ -65,13 +68,4 @@ const Template: Story<SearchFieldProps> = (args) => {
   return <SearchField {...args} />;
 };
 
-Template.args = {
-  autoCompleteType: "name",
-  label: "Destination",
-};
-
 export const Default = Template.bind({});
-Default.args = {
-  label: "Search",
-  placeholder: "Search planets",
-};

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Toast/Toast.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Toast/Toast.stories.tsx
@@ -44,10 +44,12 @@ const storybookMeta: Meta<ToastProps> = {
     },
     severity: {
       control: "radio",
+      defaultValue: "info",
       options: ["error", "info", "success", "warning"],
     },
     text: {
       control: "text",
+      defaultValue: "The mission to Sagittarius A is set for January 7.",
     },
   },
   decorators: [MuiThemeDecorator],
@@ -86,22 +88,8 @@ const DefaultTemplate: Story<ToastProps> = (args) => {
   );
 };
 
-DefaultTemplate.args = {
-  severity: "info",
-  text: "The mission to Sagittarius A is set for January 7.",
-};
-
 const StaticTemplate: Story<ToastProps> = (args) => {
   return <Toast {...args}></Toast>;
-};
-
-StaticTemplate.args = {
-  isVisible: true,
-};
-
-StaticTemplate.args = {
-  severity: "info",
-  text: "The mission to Sagittarius A is set for January 7.",
 };
 
 const MultipleTemplate: Story<ToastProps> = () => {
@@ -160,7 +148,7 @@ export const Info = DefaultTemplate.bind({});
 Info.args = {};
 
 export const InfoStatic = StaticTemplate.bind({});
-InfoStatic.args = {};
+InfoStatic.args = { isVisible: true };
 
 export const Error = DefaultTemplate.bind({});
 Error.args = {
@@ -171,6 +159,7 @@ Error.args = {
 
 export const ErrorStatic = StaticTemplate.bind({});
 ErrorStatic.args = {
+  isVisible: true,
   text: "Security breach in Hangar 18",
   role: "alert",
   severity: "error",
@@ -185,6 +174,7 @@ Warning.args = {
 
 export const WarningStatic = StaticTemplate.bind({});
 WarningStatic.args = {
+  isVisible: true,
   text: "Severe solar winds may delay local system flights",
   role: "status",
   severity: "warning",
@@ -199,6 +189,7 @@ Success.args = {
 
 export const SuccessStatic = StaticTemplate.bind({});
 SuccessStatic.args = {
+  isVisible: true,
   text: "Docking completed",
   role: "status",
   severity: "success",
@@ -214,6 +205,7 @@ Dismissible.args = {
 export const DismissibleStatic = StaticTemplate.bind({});
 DismissibleStatic.args = {
   isDismissable: true,
+  isVisible: true,
   linkText: "View report",
   linkUrl: "#",
 };


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
Removed `Template.args` and put those back as `defaultValues` on `storybookMeta`.

This fixes a number of stories that were broken in a recent update.