### PR TITLE
fix(odyssey-react-mui): pass variant and target props to Link

### DIFF
--- a/packages/odyssey-react-mui/src/Link.tsx
+++ b/packages/odyssey-react-mui/src/Link.tsx
@@ -28,9 +28,9 @@ export type LinkProps = {
 };
 
 export const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
-  const { icon, children, target } = props;
+  const { icon, children, target, variant } = props;
   return (
-    <MuiLink ref={ref}>
+    <MuiLink ref={ref} variant={variant} target={target}>
       {icon && <span className="Link-icon">{icon}</span>}
       {children}
       {target === "_blank" && (

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -1338,6 +1338,7 @@ export const components: ThemeOptions["components"] = {
       root: ({ theme }) => ({
         color: theme.palette.primary.main,
         textDecoration: "underline",
+        cursor: "pointer",
 
         "&:hover": {
           color: theme.palette.primary.dark,


### PR DESCRIPTION
### Description

Fix: passes `variant` and `target` to `Link`