### PR TITLE
fix: memoize the Link component

### DIFF
--- a/packages/odyssey-react-mui/src/Link.tsx
+++ b/packages/odyssey-react-mui/src/Link.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { forwardRef, ReactElement } from "react";
+import { forwardRef, memo, ReactElement } from "react";
 
 import {
   Link as MuiLink,
@@ -27,12 +27,13 @@ export type LinkProps = {
   variant?: MuiLinkProps["variant"];
 };
 
-export const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
-  const { icon, children, target, variant, href, rel } = props;
-  return (
-    <MuiLink ref={ref} variant={variant} target={target} href={href} rel={rel}>
+const Link = forwardRef<HTMLAnchorElement, LinkProps>(
+  ({ icon, children, target, variant, href, rel }, ref) => (
+    <MuiLink href={href} ref={ref} rel={rel} target={target} variant={variant}>
       {icon && <span className="Link-icon">{icon}</span>}
+
       {children}
+
       {target === "_blank" && (
         <span className="Link-indicator" role="presentation">
           <SvgIcon viewBox="0 0 16 16">
@@ -46,5 +47,11 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
         </span>
       )}
     </MuiLink>
-  );
-});
+  )
+);
+
+const MemoizedLink = memo(Link);
+
+MemoizedLink.displayName = "Link";
+
+export { MemoizedLink as Link };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Link/Link.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Link/Link.stories.tsx
@@ -26,10 +26,6 @@ export default {
     children: {
       control: "text",
     },
-    variant: {
-      options: ["default", "monochrome"],
-      control: { type: "radio" },
-    },
     icon: {
       control: "object",
     },
@@ -41,6 +37,10 @@ export default {
     },
     onClick: {
       action: true,
+    },
+    variant: {
+      control: { type: "radio" },
+      options: ["default", "monochrome"],
     },
   },
   decorators: [MuiThemeDecorator],


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
The `Link` component was missing memoization and didn't have the correct `displayName` when used in Storybook.

That's now fixed.

![image](https://github.com/okta/odyssey/assets/97464104/839af80c-e748-404b-8053-e1ed86ebe9a1)
