### PR TITLE
fix: change to DesignTokens type rather than the overrides in theme

### DIFF
--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -29,6 +29,7 @@ import { tableHeadClasses } from "@mui/material/TableHead";
 import { tableRowClasses } from "@mui/material/TableRow";
 import { tableSortLabelClasses } from "@mui/material/TableSortLabel";
 import { tooltipClasses } from "@mui/material/Tooltip";
+
 import {
   AlertTriangleFilledIcon,
   ArrowDownIcon,
@@ -40,10 +41,10 @@ import {
   InformationCircleFilledIcon,
   SubtractIcon,
 } from "../iconDictionary";
-import { DesignTokensOverride } from ".";
+import { DesignTokens } from "./theme";
 
 export const components = (
-  odysseyTokens: DesignTokensOverride
+  odysseyTokens: DesignTokens
 ): ThemeOptions["components"] => {
   return {
     MuiAlert: {

--- a/packages/odyssey-react-mui/src/theme/index.ts
+++ b/packages/odyssey-react-mui/src/theme/index.ts
@@ -10,9 +10,5 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import * as Tokens from "@okta/odyssey-design-tokens";
-
 export * from "./theme";
 export { useTheme } from "@mui/material/styles";
-
-export type DesignTokensOverride = Partial<typeof Tokens>;

--- a/packages/odyssey-react-mui/src/theme/mixins.ts
+++ b/packages/odyssey-react-mui/src/theme/mixins.ts
@@ -11,11 +11,10 @@
  */
 
 import type { ThemeOptions } from "@mui/material";
-import { DesignTokensOverride } from ".";
 
-export const mixins = (
-  odysseyTokens: DesignTokensOverride
-): ThemeOptions["mixins"] => {
+import { DesignTokens } from "./theme";
+
+export const mixins = (odysseyTokens: DesignTokens): ThemeOptions["mixins"] => {
   return {
     maxWidth: odysseyTokens.TypographyLineLengthMax,
     borderRadius: odysseyTokens.BorderRadiusMain,

--- a/packages/odyssey-react-mui/src/theme/palette.ts
+++ b/packages/odyssey-react-mui/src/theme/palette.ts
@@ -11,11 +11,11 @@
  */
 
 import type { ThemeOptions } from "@mui/material";
-import { DesignTokensOverride } from ".";
-import * as Tokens from "@okta/odyssey-design-tokens";
+
+import { DesignTokens } from "./theme";
 
 export const palette = (
-  odysseyTokens: DesignTokensOverride
+  odysseyTokens: DesignTokens
 ): ThemeOptions["palette"] => {
   return {
     mode: "light",
@@ -26,7 +26,7 @@ export const palette = (
     primary: {
       lighter: odysseyTokens.HueBlue50,
       light: odysseyTokens.HueBlue300,
-      main: odysseyTokens.HueBlue500 ?? Tokens.HueBlue500,
+      main: odysseyTokens.HueBlue500,
       dark: odysseyTokens.HueBlue900,
       contrastText: odysseyTokens.TypographyColorBodyInverse,
     },
@@ -39,28 +39,28 @@ export const palette = (
     error: {
       lighter: odysseyTokens.HueRed50,
       light: odysseyTokens.HueRed300,
-      main: odysseyTokens.HueRed500 ?? Tokens.HueRed500,
+      main: odysseyTokens.HueRed500,
       dark: odysseyTokens.HueRed900,
       contrastText: odysseyTokens.TypographyColorBodyInverse,
     },
     warning: {
       lighter: odysseyTokens.HueYellow50,
       light: odysseyTokens.HueYellow300,
-      main: odysseyTokens.HueYellow500 ?? Tokens.HueYellow500,
+      main: odysseyTokens.HueYellow500,
       dark: odysseyTokens.HueYellow900,
       contrastText: odysseyTokens.TypographyColorBody,
     },
     info: {
       lighter: odysseyTokens.HueBlue50,
       light: odysseyTokens.HueBlue300,
-      main: odysseyTokens.HueBlue500 ?? Tokens.HueBlue500,
+      main: odysseyTokens.HueBlue500,
       dark: odysseyTokens.HueBlue900,
       contrastText: odysseyTokens.TypographyColorBodyInverse,
     },
     success: {
       lighter: odysseyTokens.HueGreen50,
       light: odysseyTokens.HueGreen300,
-      main: odysseyTokens.HueGreen500 ?? Tokens.HueGreen500,
+      main: odysseyTokens.HueGreen500,
       dark: odysseyTokens.HueGreen900,
       contrastText: odysseyTokens.TypographyColorBodyInverse,
     },

--- a/packages/odyssey-react-mui/src/theme/shape.ts
+++ b/packages/odyssey-react-mui/src/theme/shape.ts
@@ -11,11 +11,10 @@
  */
 
 import type { ThemeOptions } from "@mui/material";
-import { DesignTokensOverride } from ".";
 
-export const shape = (
-  odysseyTokens: DesignTokensOverride
-): ThemeOptions["shape"] => {
+import { DesignTokens } from "./theme";
+
+export const shape = (odysseyTokens: DesignTokens): ThemeOptions["shape"] => {
   // Strip units from BorderRadiusBase to accommodate MUI's typing
   const NumericalBorderRadiusBase =
     typeof odysseyTokens.BorderRadiusMain === "string"

--- a/packages/odyssey-react-mui/src/theme/spacing.ts
+++ b/packages/odyssey-react-mui/src/theme/spacing.ts
@@ -11,22 +11,22 @@
  */
 
 import type { ThemeOptions } from "@mui/material";
-import { DesignTokensOverride } from ".";
-import * as Tokens from "@okta/odyssey-design-tokens";
+
+import type { DesignTokens } from "./theme";
 
 export const spacing = (
-  odysseyTokens: DesignTokensOverride
+  odysseyTokens: DesignTokens
 ): ThemeOptions["spacing"] => {
   return [
-    odysseyTokens.Spacing0 ?? Tokens.Spacing0,
-    odysseyTokens.Spacing1 ?? Tokens.Spacing1,
-    odysseyTokens.Spacing2 ?? Tokens.Spacing2,
-    odysseyTokens.Spacing3 ?? Tokens.Spacing3,
-    odysseyTokens.Spacing4 ?? Tokens.Spacing4,
-    odysseyTokens.Spacing5 ?? Tokens.Spacing5,
-    odysseyTokens.Spacing6 ?? Tokens.Spacing6,
-    odysseyTokens.Spacing7 ?? Tokens.Spacing7,
-    odysseyTokens.Spacing8 ?? Tokens.Spacing8,
-    odysseyTokens.Spacing9 ?? Tokens.Spacing9,
+    odysseyTokens.Spacing0,
+    odysseyTokens.Spacing1,
+    odysseyTokens.Spacing2,
+    odysseyTokens.Spacing3,
+    odysseyTokens.Spacing4,
+    odysseyTokens.Spacing5,
+    odysseyTokens.Spacing6,
+    odysseyTokens.Spacing7,
+    odysseyTokens.Spacing8,
+    odysseyTokens.Spacing9,
   ];
 };

--- a/packages/odyssey-react-mui/src/theme/theme.ts
+++ b/packages/odyssey-react-mui/src/theme/theme.ts
@@ -11,6 +11,7 @@
  */
 
 import { createTheme } from "@mui/material/styles";
+import * as Tokens from "@okta/odyssey-design-tokens";
 
 import { components } from "./components";
 import { mixins } from "./mixins";
@@ -22,10 +23,12 @@ import "./components.types";
 import "./mixins.types";
 import "./palette.types";
 import "./typography.types";
-import { DesignTokensOverride } from ".";
 
-export const createOdysseyMuiTheme = (odysseyTokens: DesignTokensOverride) => {
-  return createTheme({
+export type DesignTokens = typeof Tokens;
+export type DesignTokensOverride = Partial<typeof Tokens>;
+
+export const createOdysseyMuiTheme = (odysseyTokens: DesignTokens) =>
+  createTheme({
     components: components(odysseyTokens),
     mixins: mixins(odysseyTokens),
     palette: palette(odysseyTokens),
@@ -33,4 +36,3 @@ export const createOdysseyMuiTheme = (odysseyTokens: DesignTokensOverride) => {
     spacing: spacing(odysseyTokens),
     typography: typography(odysseyTokens),
   });
-};

--- a/packages/odyssey-react-mui/src/theme/typography.ts
+++ b/packages/odyssey-react-mui/src/theme/typography.ts
@@ -11,10 +11,11 @@
  */
 
 import type { ThemeOptions } from "@mui/material";
-import { DesignTokensOverride } from ".";
+
+import { DesignTokens } from "./theme";
 
 export const typography = (
-  odysseyTokens: DesignTokensOverride
+  odysseyTokens: DesignTokens
 ): ThemeOptions["typography"] => {
   return {
     htmlFontSize: 16,

--- a/packages/odyssey-storybook/.storybook/manager.ts
+++ b/packages/odyssey-storybook/.storybook/manager.ts
@@ -1,5 +1,5 @@
 import { addons } from "@storybook/addons";
-import theme from "./OdysseyTheme";
+import theme from "./odysseyStorybookTheme";
 
 addons.setConfig({
   theme,

--- a/packages/odyssey-storybook/.storybook/odysseyStorybookTheme.js
+++ b/packages/odyssey-storybook/.storybook/odysseyStorybookTheme.js
@@ -16,7 +16,7 @@ import {
 export default create({
   base: "light",
 
-  PalettePrimary: PalettePrimaryMain,
+  colorPrimary: PalettePrimaryMain,
   colorSecondary: PalettePrimaryDark,
 
   // UI


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
Our theme creation functions have the wrong design tokens type: `DesignTokensOverride` rather than the full `DesignTokens` requiring we setup null checks. We no longer need those.