### PR TITLE
refactor: make default Tooltip placement top

### DIFF
--- a/packages/odyssey-react-mui/src/Tooltip.tsx
+++ b/packages/odyssey-react-mui/src/Tooltip.tsx
@@ -27,7 +27,7 @@ export const Tooltip = ({
   ariaType,
   children,
   text,
-  placement,
+  placement = "top",
 }: TooltipProps) => (
   <MuiTooltip
     describeChild={ariaType === "description"}

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tooltip/Tooltip.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tooltip/Tooltip.stories.tsx
@@ -48,7 +48,10 @@ const storybookMeta: Meta<TooltipProps> = {
     },
     placement: {
       options: ["top", "right", "bottom", "left"],
-      control: { type: "radio" },
+      control: {
+        type: "radio",
+        defaultValue: "top",
+      },
     },
   },
   args: {


### PR DESCRIPTION
Make the Tooltip default to `placement` `top` to be consistent with our design.