### PR TITLE
Fix broken Toast stories

### DIFF
--- a/packages/odyssey-storybook/src/components/odyssey-mui/Toast/Toast.mdx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Toast/Toast.mdx
@@ -25,7 +25,7 @@ Each Toast is made up of up to three parts: Severity, Title, and Message.
 </dl>
 
 <Canvas>
-  <Story of={ToastStories.InfoStatic} />
+  <Story of={ToastStories.Info} />
 </Canvas>
 
 `Toast` handles the visual appearance and show/hide logic, but not positioning. To have a `Toast` positioned correctly, it must be wrapped inside
@@ -45,7 +45,7 @@ If multiple Toasts are triggered in a short time, they will stack in order of ap
 ### Dismissible
 
 <Canvas>
-  <Story of={ToastStories.DismissibleStatic} />
+  <Story of={ToastStories.Dismissible} />
 </Canvas>
 
 ## Severity
@@ -57,7 +57,7 @@ Use Info Toasts to surface neutral information to users.
 This is the default variant for this component.
 
 <Canvas>
-  <Story of={ToastStories.InfoStatic} />
+  <Story of={ToastStories.Info} />
 </Canvas>
 
 ### Success
@@ -65,7 +65,7 @@ This is the default variant for this component.
 Use Success Toasts to inform users of successful or completed processes.
 
 <Canvas>
-  <Story of={ToastStories.SuccessStatic} />
+  <Story of={ToastStories.Success} />
 </Canvas>
 
 ### Warning
@@ -75,7 +75,7 @@ Use Warning Toasts to inform users of tasks or processes that may need their att
 When using the Warning variant, ensure the user does not need more context than you can give in the space available.
 
 <Canvas>
-  <Story of={ToastStories.WarningStatic} />
+  <Story of={ToastStories.Warning} />
 </Canvas>
 
 ### Error
@@ -87,7 +87,7 @@ When using a Error Toast, be sure that the error is also logged elsewhere, so a 
 Do not use Error Toasts for in-page errors such as invalid form fields. Instead, use static messaging the user can refer to while addressing their error.
 
 <Canvas>
-  <Story of={ToastStories.ErrorStatic} />
+  <Story of={ToastStories.Error} />
 </Canvas>
 
 ### Multiple Toasts

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Toast/Toast.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Toast/Toast.stories.tsx
@@ -56,6 +56,7 @@ export default meta;
 
 const Single: StoryObj<ToastProps> = {
   args: {
+    autoHideDuration: -1,
     isVisible: true,
   },
   render: function C(args) {

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Toast/Toast.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Toast/Toast.stories.tsx
@@ -12,7 +12,7 @@
 
 import { Meta, StoryObj } from "@storybook/react";
 import { Button, Toast, ToastProps, ToastStack } from "@okta/odyssey-react-mui";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 
 import { MuiThemeDecorator } from "../../../../.storybook/components";
 
@@ -56,32 +56,22 @@ export default meta;
 
 const Single: StoryObj<ToastProps> = {
   args: {
-    isVisible: false,
+    isVisible: true,
   },
   render: function C(args) {
     const [isVisible, setIsVisible] = useState(args.isVisible);
-    const openToast = useCallback(() => setIsVisible(true), []);
     return (
-      <>
-        <Button
-          variant="primary"
-          onClick={openToast}
-          text={`Open ${args.severity} toast`}
-        />
-        <ToastStack>
-          <Toast
-            autoHideDuration={args.autoHideDuration}
-            isDismissable={args.isDismissable}
-            linkText={args.linkText}
-            linkUrl={args.linkUrl}
-            isVisible={isVisible}
-            onHide={() => setIsVisible(false)}
-            role={args.role}
-            severity={args.severity}
-            text={args.text}
-          />
-        </ToastStack>
-      </>
+      <Toast
+        autoHideDuration={args.autoHideDuration}
+        isDismissable={args.isDismissable}
+        linkText={args.linkText}
+        linkUrl={args.linkUrl}
+        isVisible={isVisible}
+        onHide={() => setIsVisible(false)}
+        role={args.role}
+        severity={args.severity}
+        text={args.text}
+      />
     );
   },
 };
@@ -96,14 +86,6 @@ const Static: StoryObj<ToastProps> = {
 };
 
 export const Info: StoryObj<ToastProps> = {
-  ...Single,
-  args: {
-    text: "Testing",
-    severity: "info",
-  },
-};
-
-export const InfoStatic: StoryObj<ToastProps> = {
   ...Static,
   args: {
     isVisible: true,
@@ -112,16 +94,7 @@ export const InfoStatic: StoryObj<ToastProps> = {
   },
 };
 
-export const Error = {
-  ...Single,
-  args: {
-    text: "Security breach in Hangar 18",
-    role: "alert",
-    severity: "error",
-  },
-};
-
-export const ErrorStatic: StoryObj<ToastProps> = {
+export const Error: StoryObj<ToastProps> = {
   ...Static,
   args: {
     isVisible: true,
@@ -132,15 +105,6 @@ export const ErrorStatic: StoryObj<ToastProps> = {
 };
 
 export const Warning: StoryObj<ToastProps> = {
-  ...Single,
-  args: {
-    text: "Severe solar winds may delay local system flights",
-    role: "status",
-    severity: "warning",
-  },
-};
-
-export const WarningStatic: StoryObj<ToastProps> = {
   ...Static,
   args: {
     isVisible: true,
@@ -151,15 +115,6 @@ export const WarningStatic: StoryObj<ToastProps> = {
 };
 
 export const Success: StoryObj<ToastProps> = {
-  ...Single,
-  args: {
-    text: "Docking completed",
-    role: "status",
-    severity: "success",
-  },
-};
-
-export const SuccessStatic: StoryObj<ToastProps> = {
   ...Static,
   args: {
     isVisible: true,
@@ -170,15 +125,6 @@ export const SuccessStatic: StoryObj<ToastProps> = {
 };
 
 export const Dismissible: StoryObj<ToastProps> = {
-  ...Single,
-  args: {
-    isDismissable: true,
-    linkText: "View report",
-    linkUrl: "#",
-  },
-};
-
-export const DismissibleStatic: StoryObj<ToastProps> = {
   ...Static,
   args: {
     isVisible: true,


### PR DESCRIPTION
After the refactor to the latest Storybook, the `<Toast>` stories were broken — it turns out they simply had a redundant `ToastStack` wrapping them.

I removed that `ToastStack` and eliminated some unnecessary stories for clarity.