### PR TITLE
docs(odyssey-storybook): make datepicker starting date fixed

### DIFF
--- a/packages/odyssey-storybook/src/components/odyssey-labs/DatePicker/DatePicker.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/DatePicker/DatePicker.stories.tsx
@@ -46,7 +46,7 @@ export default storybookMeta;
 
 export const DatePickerStandard: StoryObj<DatePickerProps<unknown, unknown>> = {
   render: function C(props) {
-    const [value, setValue] = useState<unknown>(Date.now());
+    const [value, setValue] = useState<unknown>("09/05/1977");
     const datePickerProps = useMemo(
       () => ({
         ...props,


### PR DESCRIPTION
Variable default date was causing VRT to need an update every day