### PR TITLE
Remove default branch in i18n config

### DIFF
--- a/packages/odyssey-react-mui/i18n.config.json
+++ b/packages/odyssey-react-mui/i18n.config.json
@@ -1,5 +1,4 @@
 {
-  "defaultBranch": "develop",
   "resourceFile": "odyssey-react-mui.properties",
   "resourceFilePath": "packages/odyssey-react-mui/src/properties",
   "translationsFilePath": "packages/odyssey-react-mui/src/properties/translations",


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Summary: Remove default branch in i18n config
Reason: 
In this [PR](https://github.com/atko-eng/okta-ui/pull/6537), we are getting the default branch name from the output of command `git remote show origin`.
In odyssey, it will be "develop" (`HEAD branch: develop`). So we do not need to define the `defaultBranch` in config file.