### PR TITLE
Allow MenuButton to accept null children

### DIFF
--- a/packages/odyssey-react-mui/src/MenuButton.tsx
+++ b/packages/odyssey-react-mui/src/MenuButton.tsx
@@ -23,13 +23,16 @@ import {
 import { memo, type ReactElement, useCallback, useMemo, useState } from "react";
 
 import { MenuContext, MenuContextType } from "./MenuContext";
+import { NullElement } from "./NullElement";
 
 export type MenuButtonProps = {
   /**
    * The <MenuItem> components within the Menu.
    */
   children: Array<
-    ReactElement<typeof MenuItem | typeof Divider | typeof ListSubheader>
+    ReactElement<
+      typeof MenuItem | typeof Divider | typeof ListSubheader | NullElement
+    >
   >;
   /**
    * The label on the triggering Button

--- a/packages/odyssey-react-mui/src/NullElement.tsx
+++ b/packages/odyssey-react-mui/src/NullElement.tsx
@@ -1,0 +1,13 @@
+/*!
+ * Copyright (c) 2023-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+export type NullElement = false | null | undefined;

--- a/packages/odyssey-react-mui/src/index.ts
+++ b/packages/odyssey-react-mui/src/index.ts
@@ -118,6 +118,7 @@ export * from "./Link";
 export * from "./MenuButton";
 export * from "./MenuItem";
 export * from "./NativeSelect";
+export * from "./NullElement";
 export * from "./OdysseyCacheProvider";
 export * from "./OdysseyProvider";
 export * from "./OdysseyThemeProvider";


### PR DESCRIPTION
This PR creates a new `NullElement` type, and allows `MenuButton` to accept it as a child. This enables conditional rendering of children.