### PR TITLE
Fix div-inside-of-p issue in field errors

### DIFF
--- a/packages/odyssey-react-mui/src/ScreenReaderText.tsx
+++ b/packages/odyssey-react-mui/src/ScreenReaderText.tsx
@@ -28,7 +28,9 @@ export type ScreenReaderTextProps = {
 const style = { ...visuallyHidden };
 
 const ScreenReaderText = ({ children }: ScreenReaderTextProps) => (
-  <Box sx={style}>{children}</Box>
+  <Box sx={style} component="span">
+    {children}
+  </Box>
 );
 
 const MemoizedScreenReaderText = memo(ScreenReaderText);


### PR DESCRIPTION
`ScreenReaderText` was rendering as a `<div>`, which is semantically incorrect inside of a `<p>`. Now it's a `<span>` and all is right with the world.