### PR TITLE
Prevent dismiss button from overlapping Banner text

### DIFF
--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -129,7 +129,7 @@ export const components = (
             borderRadius: 0,
 
             ...(ownerState.onClose !== undefined && {
-              paddingInlineEnd: odysseyTokens.Spacing6,
+              paddingInline: odysseyTokens.Spacing6,
             }),
           }),
           ...(ownerState.variant === "infobox" && {

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -127,6 +127,10 @@ export const components = (
             justifyContent: "center",
             alignItems: "center",
             borderRadius: 0,
+
+            ...(ownerState.onClose !== undefined && {
+              paddingInlineEnd: odysseyTokens.Spacing6,
+            }),
           }),
           ...(ownerState.variant === "infobox" && {
             borderRadius: odysseyTokens.BorderRadiusMain,


### PR DESCRIPTION
In certain cases, the `<Banner>` dismiss button could overlap the banner content. This PR applies some additional end padding on dismissable banners, ensuring the content avoids any awkward overlaps.