### PR TITLE
Simplify Dialog children type

### DIFF
--- a/packages/odyssey-react-mui/src/Dialog.tsx
+++ b/packages/odyssey-react-mui/src/Dialog.tsx
@@ -32,7 +32,7 @@ export type DialogProps = {
   callToActionPrimaryComponent?: ReactElement<typeof Button>;
   callToActionSecondaryComponent?: ReactElement<typeof Button>;
   callToActionTertiaryComponent?: ReactElement<typeof Button>;
-  children: ReactNode | Array<ReactNode>;
+  children: ReactNode;
   onClose: () => void;
   isOpen: boolean;
   title: string;


### PR DESCRIPTION
It previously accepted a `ReactNode` or an array of `ReactNode`s, but we only need the former.