### PR TITLE
Default Button text to empty string

### DIFF
--- a/packages/odyssey-react-mui/src/Button.tsx
+++ b/packages/odyssey-react-mui/src/Button.tsx
@@ -92,7 +92,7 @@ const Button = ({
   onClick,
   size = "medium",
   startIcon,
-  text,
+  text = "",
   tooltipText,
   variant,
 }: ButtonProps) => {

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
@@ -399,7 +399,7 @@ export const IconOnly: StoryObj<ButtonProps> = {
   args: {
     startIcon: <AddIcon />,
     ariaLabel: "Add crew",
-    text: "",
+    text: undefined,
     tooltipText: "Add crew",
   },
 };


### PR DESCRIPTION
Icon-only `<Button>`s were adding too much horizontal padding unless the component was explicitly passed `text=""`. In other words: **If the button text was undefined, icon-only buttons looked bad.**

This is an issue we inherited from MUI, so the simplest fix is to simply default the `text` prop to an empty string if it's not explicitly defined.