### PR TITLE
Change Checkbox onChange and validity

### DIFF
--- a/packages/odyssey-react-mui/src/Checkbox.tsx
+++ b/packages/odyssey-react-mui/src/Checkbox.tsx
@@ -18,6 +18,8 @@ import {
 import { ChangeEventHandler, memo, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
+export const checkboxValidityValues = ["valid", "invalid", "inherit"] as const;
+
 export type CheckboxProps = {
   /**
    * The ARIA label for the Checkbox
@@ -40,17 +42,9 @@ export type CheckboxProps = {
    */
   isIndeterminate?: boolean;
   /**
-   * Determines whether the Checkbox has an invalid value
-   */
-  isInvalid?: boolean;
-  /**
    * Determines whether the Checkbox is required
    */
   isRequired?: boolean;
-  /**
-   * Determines whether the Checkbox has a valid value
-   */
-  isValid?: boolean;
   /**
    * The label text for the Checkbox
    */
@@ -64,6 +58,10 @@ export type CheckboxProps = {
    */
   onChange?: ChangeEventHandler<EventTarget>;
   /**
+   * The checkbox validity, if different from its enclosing group. Defaults to "inherit".
+   */
+  validity?: (typeof checkboxValidityValues)[number];
+  /**
    * The value attribute of the Checkbox
    */
   value?: string;
@@ -75,12 +73,11 @@ const Checkbox = ({
   isChecked,
   isDisabled,
   isIndeterminate,
-  isInvalid,
   isRequired,
-  isValid,
   label: labelProp,
   name,
   onChange,
+  validity = "inherit",
   value,
 }: CheckboxProps) => {
   const { t } = useTranslation();
@@ -105,7 +102,13 @@ const Checkbox = ({
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledBy}
       checked={isChecked}
-      className={isInvalid ? "Mui-error" : isValid ? "Mui-valid" : ""}
+      className={
+        validity === "invalid"
+          ? "Mui-error"
+          : validity === "valid"
+          ? "Mui-valid"
+          : ""
+      }
       control={
         <MuiCheckbox indeterminate={isIndeterminate} required={isRequired} />
       }

--- a/packages/odyssey-react-mui/src/Checkbox.tsx
+++ b/packages/odyssey-react-mui/src/Checkbox.tsx
@@ -15,7 +15,7 @@ import {
   FormControlLabel,
   Typography,
 } from "@mui/material";
-import { ChangeEventHandler, memo, useMemo } from "react";
+import { ChangeEvent, memo, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 export const checkboxValidityValues = ["valid", "invalid", "inherit"] as const;
@@ -32,7 +32,7 @@ export type CheckboxProps = {
   /**
    * Determines whether the Checkbox is checked
    */
-  isChecked?: boolean;
+  isDefaultChecked?: boolean;
   /**
    * Determines whether the Checkbox is disabled
    */
@@ -56,7 +56,7 @@ export type CheckboxProps = {
   /**
    * The change event handler for the Checkbox
    */
-  onChange?: ChangeEventHandler<EventTarget>;
+  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   /**
    * The checkbox validity, if different from its enclosing group. Defaults to "inherit".
    */
@@ -70,17 +70,18 @@ export type CheckboxProps = {
 const Checkbox = ({
   ariaLabel,
   ariaLabelledBy,
-  isChecked,
+  isDefaultChecked = false,
   isDisabled,
   isIndeterminate,
   isRequired,
   label: labelProp,
   name,
-  onChange,
+  onChange: onChangeProp,
   validity = "inherit",
   value,
 }: CheckboxProps) => {
   const { t } = useTranslation();
+  const [isCheckedValue, setIsCheckedValue] = useState(isDefaultChecked);
 
   const label = useMemo(() => {
     if (isRequired) {
@@ -97,11 +98,19 @@ const Checkbox = ({
     }
   }, [isRequired, labelProp, t]);
 
+  const onChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>, checked: boolean) => {
+      setIsCheckedValue(checked);
+      onChangeProp?.(event);
+    },
+    [onChangeProp]
+  );
+
   return (
     <FormControlLabel
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledBy}
-      checked={isChecked}
+      checked={isCheckedValue}
       className={
         validity === "invalid"
           ? "Mui-error"

--- a/packages/odyssey-react-mui/src/Checkbox.tsx
+++ b/packages/odyssey-react-mui/src/Checkbox.tsx
@@ -12,10 +12,11 @@
 
 import {
   Checkbox as MuiCheckbox,
+  CheckboxProps as MuiCheckboxProps,
   FormControlLabel,
   Typography,
 } from "@mui/material";
-import { ChangeEvent, memo, useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 export const checkboxValidityValues = ["valid", "invalid", "inherit"] as const;
@@ -56,7 +57,7 @@ export type CheckboxProps = {
   /**
    * The change event handler for the Checkbox
    */
-  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+  onChange?: MuiCheckboxProps["onChange"];
   /**
    * The checkbox validity, if different from its enclosing group. Defaults to "inherit".
    */
@@ -99,9 +100,9 @@ const Checkbox = ({
   }, [isRequired, labelProp, t]);
 
   const onChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>, checked: boolean) => {
-      setIsCheckedValue(checked);
-      onChangeProp?.(event);
+    (event, checked) => {
+      setIsCheckedValue(event.target.checked);
+      onChangeProp?.(event, checked);
     },
     [onChangeProp]
   );

--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -205,7 +205,7 @@ const Select = forwardRef<HTMLSelectElement, SelectProps>(
       return (
         <MenuItem key={option.value} value={option.value}>
           {isMultiSelect && (
-            <Checkbox isChecked={selectedValue.includes(option.value)} />
+            <Checkbox isDefaultChecked={selectedValue.includes(option.value)} />
           )}
           {option.text}
         </MenuItem>

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -560,11 +560,11 @@ export const components = (
             },
           },
           ".Mui-error:not(.Mui-valid) > &": {
-            borderColor: odysseyTokens.BorderColorDangerMain,
+            borderColor: odysseyTokens.BorderColorDangerControl,
 
             "&.Mui-checked": {
               backgroundColor: odysseyTokens.PaletteDangerMain,
-              borderColor: odysseyTokens.BorderColorDangerMain,
+              borderColor: odysseyTokens.BorderColorDangerControl,
             },
 
             "&.Mui-focusVisible": {

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -560,11 +560,11 @@ export const components = (
             },
           },
           ".Mui-error:not(.Mui-valid) > &": {
-            borderColor: odysseyTokens.BorderColorDangerControl,
+            borderColor: odysseyTokens.BorderColorDangerMain,
 
             "&.Mui-checked": {
               backgroundColor: odysseyTokens.PaletteDangerMain,
-              borderColor: odysseyTokens.BorderColorDangerControl,
+              borderColor: odysseyTokens.BorderColorDangerMain,
             },
 
             "&.Mui-focusVisible": {

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Checkbox/Checkbox.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Checkbox/Checkbox.stories.tsx
@@ -10,7 +10,11 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Checkbox, CheckboxProps } from "@okta/odyssey-react-mui";
+import {
+  Checkbox,
+  CheckboxProps,
+  checkboxValidityValues,
+} from "@okta/odyssey-react-mui";
 import { Meta, StoryObj } from "@storybook/react";
 import { MuiThemeDecorator } from "../../../../.storybook/components";
 import { userEvent, within } from "@storybook/testing-library";
@@ -37,25 +41,6 @@ const storybookMeta: Meta<CheckboxProps> = {
       table: {
         type: {
           summary: "string",
-        },
-      },
-    },
-    isInvalid: {
-      control: "boolean",
-      description:
-        "If `true`, indicates that the checkbox has an invalid value",
-      table: {
-        type: {
-          summary: "boolean",
-        },
-      },
-    },
-    isValid: {
-      control: "boolean",
-      description: "If `true`, indicates that the checkbox has a valid value",
-      table: {
-        type: {
-          summary: "boolean",
         },
       },
     },
@@ -121,6 +106,20 @@ const storybookMeta: Meta<CheckboxProps> = {
           summary: "func",
         },
         defaultValue: "",
+      },
+    },
+    validity: {
+      options: checkboxValidityValues,
+      control: { type: "radio" },
+      description:
+        "The checkbox validity, if different from its enclosing group. Doesn't need to be set if the checkbox isn't a different validity from an enclosing `CheckboxGroup`.",
+      table: {
+        type: {
+          summary: checkboxValidityValues.join(" | "),
+        },
+        defaultValue: {
+          summary: "inherit",
+        },
       },
     },
     value: {

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Checkbox/Checkbox.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Checkbox/Checkbox.stories.tsx
@@ -185,9 +185,6 @@ export const Checked: StoryObj<CheckboxProps> = {
     label: "Pre-flight systems check complete",
     isDefaultChecked: true,
   },
-  play: async ({ canvasElement, step }) => {
-    checkTheBox({ canvasElement, step })("Checkbox Checked");
-  },
 };
 
 export const Disabled: StoryObj<CheckboxProps> = {
@@ -218,9 +215,6 @@ export const Indeterminate: StoryObj<CheckboxProps> = {
     label: "Pre-flight systems check complete",
     isIndeterminate: true,
     isDefaultChecked: true,
-  },
-  play: async ({ canvasElement, step }) => {
-    checkTheBox({ canvasElement, step })("Checkbox Indeterminate");
   },
 };
 

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Checkbox/Checkbox.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Checkbox/Checkbox.stories.tsx
@@ -44,9 +44,9 @@ const storybookMeta: Meta<CheckboxProps> = {
         },
       },
     },
-    isChecked: {
+    isDefaultChecked: {
       control: "boolean",
-      description: "If `true`, the checkbox is checked",
+      description: "If `true`, the checkbox starts checked",
       table: {
         type: {
           summary: "boolean",
@@ -183,7 +183,7 @@ export const Required: StoryObj<CheckboxProps> = {
 export const Checked: StoryObj<CheckboxProps> = {
   args: {
     label: "Pre-flight systems check complete",
-    isChecked: true,
+    isDefaultChecked: true,
   },
   play: async ({ canvasElement, step }) => {
     checkTheBox({ canvasElement, step })("Checkbox Checked");
@@ -217,7 +217,7 @@ export const Indeterminate: StoryObj<CheckboxProps> = {
   args: {
     label: "Pre-flight systems check complete",
     isIndeterminate: true,
-    isChecked: true,
+    isDefaultChecked: true,
   },
   play: async ({ canvasElement, step }) => {
     checkTheBox({ canvasElement, step })("Checkbox Indeterminate");
@@ -227,7 +227,7 @@ export const Indeterminate: StoryObj<CheckboxProps> = {
 export const Invalid: StoryObj<CheckboxProps> = {
   args: {
     label: "Pre-flight systems check complete",
-    isInvalid: true,
+    validity: "invalid",
   },
   play: async ({ canvasElement, step }) => {
     checkTheBox({ canvasElement, step })("Checkbox Disabled");

--- a/packages/odyssey-storybook/src/components/odyssey-mui/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -20,7 +20,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import { MuiThemeDecorator } from "../../../../.storybook/components";
 
 type CheckboxGroupStoryProps = CheckboxGroupProps & {
-  isChecked: Parameters<typeof Checkbox>[0]["isChecked"];
+  isDefaultChecked: Parameters<typeof Checkbox>[0]["isDefaultChecked"];
   isIndeterminate: Parameters<typeof Checkbox>[0]["isIndeterminate"];
 };
 
@@ -120,7 +120,7 @@ const GroupTemplate: StoryObj<CheckboxGroupProps> = {
   ),
   parameters: {
     controls: {
-      exclude: ["isChecked", "isIndeterminate"],
+      exclude: ["isDefaultChecked", "isIndeterminate"],
     },
   },
 };
@@ -133,7 +133,7 @@ export const Disabled: StoryObj<CheckboxGroupStoryProps> = {
   ...GroupTemplate,
   parameters: {
     controls: {
-      exclude: ["isChecked", "isIndeterminate"],
+      exclude: ["isDefaultChecked", "isIndeterminate"],
     },
   },
   args: {
@@ -145,7 +145,7 @@ export const Error: StoryObj<CheckboxGroupStoryProps> = {
   ...GroupTemplate,
   parameters: {
     controls: {
-      exclude: ["isChecked", "isIndeterminate"],
+      exclude: ["isDefaultChecked", "isIndeterminate"],
     },
     docs: {
       description: {
@@ -170,7 +170,7 @@ export const MixedError: StoryObj<CheckboxGroupStoryProps> = {
     >
       <Checkbox label="Alfred" name="alfred" value="alfred" validity="valid" />
       <Checkbox
-        isChecked
+        isDefaultChecked
         label="Barbara Gordon"
         name="barbara-gordon"
         value="barbara-gordon"
@@ -182,7 +182,7 @@ export const MixedError: StoryObj<CheckboxGroupStoryProps> = {
         validity="valid"
       />
       <Checkbox
-        isChecked
+        isDefaultChecked
         label="The Joker"
         name="the-joker"
         value="the-joker"
@@ -191,7 +191,7 @@ export const MixedError: StoryObj<CheckboxGroupStoryProps> = {
   ),
   parameters: {
     controls: {
-      exclude: ["isChecked", "isIndeterminate"],
+      exclude: ["isDefaultChecked", "isIndeterminate"],
     },
     docs: {
       description: {

--- a/packages/odyssey-storybook/src/components/odyssey-mui/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -168,7 +168,7 @@ export const MixedError: StoryObj<CheckboxGroupStoryProps> = {
       label="Who will you invite to your birthday?"
       isRequired={args.isRequired}
     >
-      <Checkbox label="Alfred" name="alfred" value="alfred" isValid />
+      <Checkbox label="Alfred" name="alfred" value="alfred" validity="valid" />
       <Checkbox
         isChecked
         label="Barbara Gordon"
@@ -179,7 +179,7 @@ export const MixedError: StoryObj<CheckboxGroupStoryProps> = {
         label="Hal Jordan"
         name="hal-jordan"
         value="hal-jordan"
-        isValid
+        validity="valid"
       />
       <Checkbox
         isChecked


### PR DESCRIPTION
1. Changes `Checkbox` `onChange` to make the component fully controlled. As part of this, `isChecked` has been replaced with `isDefaultChecked`, which matches the MUI standard.
2. Replaces `isValid` and `isInvalid` with a single `validity` prop.