### PR TITLE
Add StylisPlugins to OdysseyCacheProvider

### DIFF
--- a/packages/odyssey-react-mui/src/OdysseyCacheProvider.tsx
+++ b/packages/odyssey-react-mui/src/OdysseyCacheProvider.tsx
@@ -18,19 +18,21 @@ declare global {
 
 import createCache, { StylisPlugin } from "@emotion/cache";
 import { CacheProvider } from "@emotion/react";
-import { memo, ReactElement, useMemo } from "react";
+import { memo, ReactNode, useMemo } from "react";
 
 import { useUniqueAlphabeticalId } from "./useUniqueAlphabeticalId";
+
+export type OdysseyCacheProviderProps = {
+  children: ReactNode;
+  nonce?: string;
+  stylisPlugins?: StylisPlugin[];
+};
 
 const OdysseyCacheProvider = ({
   children,
   nonce,
   stylisPlugins,
-}: {
-  children: ReactElement;
-  nonce?: string;
-  stylisPlugins: StylisPlugin[];
-}) => {
+}: OdysseyCacheProviderProps) => {
   const uniqueAlphabeticalId = useUniqueAlphabeticalId();
 
   const emotionCache = useMemo(

--- a/packages/odyssey-react-mui/src/OdysseyCacheProvider.tsx
+++ b/packages/odyssey-react-mui/src/OdysseyCacheProvider.tsx
@@ -16,7 +16,7 @@ declare global {
   }
 }
 
-import createCache from "@emotion/cache";
+import createCache, { StylisPlugin } from "@emotion/cache";
 import { CacheProvider } from "@emotion/react";
 import { memo, ReactElement, useMemo } from "react";
 
@@ -25,9 +25,11 @@ import { useUniqueAlphabeticalId } from "./useUniqueAlphabeticalId";
 const OdysseyCacheProvider = ({
   children,
   nonce,
+  stylisPlugins,
 }: {
   children: ReactElement;
   nonce?: string;
+  stylisPlugins: StylisPlugin[];
 }) => {
   const uniqueAlphabeticalId = useUniqueAlphabeticalId();
 
@@ -36,8 +38,9 @@ const OdysseyCacheProvider = ({
       createCache({
         key: uniqueAlphabeticalId,
         nonce: nonce || window.cspNonce,
+        stylisPlugins,
       }),
-    [nonce, uniqueAlphabeticalId]
+    [nonce, stylisPlugins, uniqueAlphabeticalId]
   );
 
   return <CacheProvider value={emotionCache}>{children}</CacheProvider>;

--- a/packages/odyssey-react-mui/src/OdysseyProvider.tsx
+++ b/packages/odyssey-react-mui/src/OdysseyProvider.tsx
@@ -10,36 +10,37 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { memo, ReactElement } from "react";
+import { memo, ReactNode } from "react";
 
-import { ThemeOptions } from "@mui/material";
-import { DesignTokensOverride } from "../src/theme/index";
-import { OdysseyCacheProvider } from "./OdysseyCacheProvider";
-import { OdysseyThemeProvider } from "./OdysseyThemeProvider";
+import {
+  OdysseyCacheProvider,
+  OdysseyCacheProviderProps,
+} from "./OdysseyCacheProvider";
+import {
+  OdysseyThemeProvider,
+  OdysseyThemeProviderProps,
+} from "./OdysseyThemeProvider";
 import {
   OdysseyTranslationProvider,
-  TranslationOverrides,
+  OdysseyTranslationProviderProps,
 } from "./OdysseyTranslationProvider";
-import { SupportedLanguages } from "./OdysseyTranslationProvider.types";
 
-type OdysseyProviderProps = {
-  children: ReactElement;
-  designTokensOverride?: DesignTokensOverride;
-  languageCode?: SupportedLanguages;
-  nonce?: string;
-  themeOverride?: ThemeOptions;
-  translationOverrides?: TranslationOverrides;
-};
+export type OdysseyProviderProps = OdysseyCacheProviderProps &
+  OdysseyThemeProviderProps &
+  OdysseyTranslationProviderProps & {
+    children: ReactNode;
+  };
 
 const OdysseyProvider = ({
   children,
   designTokensOverride,
   languageCode,
   nonce,
+  stylisPlugins,
   themeOverride,
   translationOverrides,
 }: OdysseyProviderProps) => (
-  <OdysseyCacheProvider nonce={nonce}>
+  <OdysseyCacheProvider nonce={nonce} stylisPlugins={stylisPlugins}>
     <OdysseyThemeProvider
       themeOverride={themeOverride}
       designTokensOverride={designTokensOverride}

--- a/packages/odyssey-react-mui/src/OdysseyThemeProvider.tsx
+++ b/packages/odyssey-react-mui/src/OdysseyThemeProvider.tsx
@@ -14,22 +14,24 @@ import {
   createTheme,
   ThemeProvider as MuiThemeProvider,
 } from "@mui/material/styles";
-import { memo, ReactElement, useMemo } from "react";
+import { memo, ReactNode, useMemo } from "react";
 
 import { ThemeOptions } from "@mui/material";
 import { deepmerge } from "@mui/utils";
 import { createOdysseyMuiTheme, DesignTokensOverride } from "./theme";
 import * as Tokens from "@okta/odyssey-design-tokens";
 
+export type OdysseyThemeProviderProps = {
+  children: ReactNode;
+  designTokensOverride?: DesignTokensOverride;
+  themeOverride?: ThemeOptions;
+};
+
 const OdysseyThemeProvider = ({
   children,
   designTokensOverride,
   themeOverride,
-}: {
-  children: ReactElement;
-  designTokensOverride?: DesignTokensOverride;
-  themeOverride?: ThemeOptions;
-}) => {
+}: OdysseyThemeProviderProps) => {
   const odysseyTokens = { ...Tokens, ...designTokensOverride };
   const odysseyTheme = createOdysseyMuiTheme(odysseyTokens);
 

--- a/packages/odyssey-react-mui/src/OdysseyTranslationProvider.tsx
+++ b/packages/odyssey-react-mui/src/OdysseyTranslationProvider.tsx
@@ -21,12 +21,6 @@ export type TranslationOverrides = {
   [key in SupportedLanguages]?: Partial<(typeof resources)["en"]>;
 };
 
-type OdysseyTranslationProviderProps = {
-  children: ReactNode;
-  languageCode?: SupportedLanguages;
-  translationOverrides?: TranslationOverrides;
-};
-
 const mergeBundleOverrides = (
   languageCode: SupportedLanguages,
   translationOverrides: TranslationOverrides
@@ -37,6 +31,12 @@ const mergeBundleOverrides = (
     ...bundle,
     ...overrides,
   };
+};
+
+export type OdysseyTranslationProviderProps = {
+  children: ReactNode;
+  languageCode?: SupportedLanguages;
+  translationOverrides?: TranslationOverrides;
 };
 
 export const OdysseyTranslationProvider = ({


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
`OdysseyCacheProvider` didn't allow passing custom StylisPlugins to Emotion.

In adding this, I went ahead and refactored the types for `OdysseyProvider`. 2 birds; 1 stone.