### PR TITLE
docs: add kitchen sink to Button

### DIFF
--- a/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
@@ -414,7 +414,7 @@ export const KitchenSink: StoryObj<ButtonProps> = {
       <Button variant="tertiary" text="Tertiary" />
       <Button variant="danger" text="Danger" />
       <Button variant="floating" text="Floating" />
-      <Button variant="primary" startIcon={<AddIcon />} />
+      <Button variant="primary" startIcon={<AddIcon />} ariaLabel="Add" />
     </Box>
   ),
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
@@ -26,6 +26,7 @@ import { userEvent, waitFor, within } from "@storybook/testing-library";
 import { expect } from "@storybook/jest";
 import { axeRun } from "../../../axe-util";
 import type { PlaywrightProps } from "../storybookTypes";
+import { Box } from "@mui/material";
 
 const storybookMeta: Meta<ButtonProps> = {
   title: "MUI Components/Button",
@@ -402,4 +403,18 @@ export const IconOnly: StoryObj<ButtonProps> = {
     text: undefined,
     tooltipText: "Add crew",
   },
+};
+
+export const KitchenSink: StoryObj<ButtonProps> = {
+  name: "Kitchen sink",
+  render: () => (
+    <Box sx={{ display: "flex", flexWrap: "wrap", rowGap: 2 }}>
+      <Button variant="primary" text="Primary" />
+      <Button variant="secondary" text="Secondary" />
+      <Button variant="tertiary" text="Tertiary" />
+      <Button variant="danger" text="Danger" />
+      <Button variant="floating" text="Floating" />
+      <Button variant="primary" startIcon={<AddIcon />} />
+    </Box>
+  ),
 };


### PR DESCRIPTION
For Supernova, we want to include a demo that shows all the variants of `<Button>` side-by-side. This provides a story which does that.