### PR TITLE
Update MenuButton icon

### DIFF
--- a/packages/odyssey-react-mui/src/MenuButton.tsx
+++ b/packages/odyssey-react-mui/src/MenuButton.tsx
@@ -12,7 +12,7 @@
 
 import { Button, buttonVariantValues, MenuItem, useUniqueId } from "./";
 import { Divider, ListSubheader, Menu } from "@mui/material";
-import { ChevronDownIcon } from "./icons.generated";
+import { ChevronDownIcon, MoreIcon } from "./icons.generated";
 import { memo, type ReactElement, useCallback, useMemo, useState } from "react";
 
 import { MenuContext, MenuContextType } from "./MenuContext";
@@ -56,6 +56,10 @@ export type MenuButtonProps = {
    */
   id?: string;
   /**
+   * If the MenuButton is an overflow menu or standard menu.
+   */
+  isOverflow?: boolean;
+  /**
    * The tooltip text for the Button if it's icon-only
    */
   tooltipText?: string;
@@ -84,8 +88,9 @@ const MenuButton = ({
   buttonLabel = "",
   buttonVariant = "secondary",
   children,
-  endIcon = <ChevronDownIcon />,
+  endIcon: endIconProp,
   id: idOverride,
+  isOverflow,
   tooltipText,
 }: MenuButtonProps) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -113,6 +118,14 @@ const MenuButton = ({
       openMenu,
     }),
     [closeMenu, openMenu]
+  );
+
+  const endIcon = endIconProp ? (
+    endIconProp
+  ) : isOverflow ? (
+    <MoreIcon />
+  ) : (
+    <ChevronDownIcon />
   );
 
   return (

--- a/packages/odyssey-storybook/src/components/odyssey-mui/MenuButton/MenuButton.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/MenuButton/MenuButton.stories.tsx
@@ -25,7 +25,6 @@ import {
   GroupIcon,
   GlobeIcon,
   CalendarIcon,
-  MoreIcon,
 } from "@okta/odyssey-react-mui/icons";
 import icons from "../../../../.storybook/components/iconUtils";
 import { MuiThemeDecorator } from "../../../../.storybook/components";
@@ -118,6 +117,16 @@ const storybookMeta: Meta<MenuButtonProps> = {
         defaultValue: "",
       },
     },
+    isOverflow: {
+      control: "boolean",
+      description: "If the MenuButton is an overflow menu or standard menu.",
+      table: {
+        type: {
+          summary: "boolean",
+        },
+        defaultValue: "",
+      },
+    },
     tooltipText: {
       control: "text",
       description:
@@ -133,7 +142,6 @@ const storybookMeta: Meta<MenuButtonProps> = {
   args: {
     buttonLabel: "More actions",
     buttonVariant: "secondary",
-    endIcon: <MoreIcon />,
   },
   decorators: [MuiThemeDecorator],
   tags: ["autodocs"],
@@ -273,7 +281,6 @@ export const IconButton: StoryObj<MenuButtonProps> = {
       <MenuItem key="2">Edit configuration</MenuItem>,
       <MenuItem key="3">Launch</MenuItem>,
     ],
-    endIcon: <MoreIcon />,
     tooltipText: "Add confirmation",
   },
 };


### PR DESCRIPTION
Two changes here:
1. `MenuButton` icon now defaults to ChevronDown, not More
2. `MenuButton` gains a new `isOverflow` prop, which defaults the icon to `More` and not `ChevronDown`