### PR TITLE
fix(odyssey-react-mui): ensure headings pick up TypographyFamilyHeading

### DIFF
--- a/packages/odyssey-react-mui/src/Typography.tsx
+++ b/packages/odyssey-react-mui/src/Typography.tsx
@@ -102,7 +102,7 @@ const Typography = ({
       if (variant === "body") {
         return "p";
       } else if (variant === "subordinate" || variant === "support") {
-        return "h6";
+        return "p";
       } else {
         return variant;
       }

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -2271,8 +2271,6 @@ export const components = (
     },
     MuiTypography: {
       defaultProps: {
-        fontFamily:
-          "'Inter', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', 'Noto Sans Arabic', sans-serif",
         variantMapping: {
           h1: "h1",
           h2: "h2",


### PR DESCRIPTION
### Description

`Typography` variants no longer have their `fontFamily` overridden by a default prop. `support` and `subordinate` now render as `p` instead of `h6`.