### PR TITLE
fix: adds branches back to Applitools

### DIFF
--- a/packages/odyssey-storybook/applitools.config.js
+++ b/packages/odyssey-storybook/applitools.config.js
@@ -13,27 +13,16 @@
 const branchName = process.env.GITHUB_HEAD_REF;
 const parentBranchName = process.env.GITHUB_BASE_REF;
 
-console.log({ branchName });
-console.log({ parentBranchName });
-
 module.exports = {
-  // NOTE: the docs for this exitcode config are incorrect as of this
-  // writing. An explicit `false` value here allows a failed VRT run to
-  // exit non zero and our larger CI build to pass as we intend.
-  // Validating VRT results is then handled through a separate applitools
-  // github integration.
-  exitcode: true,
-
   accessibilityValidation: {
     level: "AA",
     guidelinesVersion: "WCAG_2_1",
   },
-  baselineBranchName: parentBranchName,
   branchName,
   browser: [{ width: 1024, height: 768, name: "chrome" }],
+  exitcode: true,
   matchLevel: "Strict",
   parentBranchName,
-  showLogs: true,
   showStorybookOutput: true,
   testConcurrency: 20,
 };

--- a/packages/odyssey-storybook/applitools.config.js
+++ b/packages/odyssey-storybook/applitools.config.js
@@ -13,6 +13,9 @@
 const branchName = process.env.GITHUB_HEAD_REF;
 const parentBranchName = process.env.GITHUB_BASE_REF;
 
+console.log({ branchName });
+console.log({ parentBranchName });
+
 module.exports = {
   // NOTE: the docs for this exitcode config are incorrect as of this
   // writing. An explicit `false` value here allows a failed VRT run to
@@ -25,11 +28,12 @@ module.exports = {
     level: "AA",
     guidelinesVersion: "WCAG_2_1",
   },
-  branchName,
   baselineBranchName: parentBranchName,
-  parentBranchName,
+  branchName,
   browser: [{ width: 1024, height: 768, name: "chrome" }],
   matchLevel: "Strict",
+  parentBranchName,
+  showLogs: true,
   showStorybookOutput: true,
   testConcurrency: 20,
 };

--- a/packages/odyssey-storybook/applitools.config.js
+++ b/packages/odyssey-storybook/applitools.config.js
@@ -12,12 +12,14 @@
 
 const branchName = process.env.GITHUB_HEAD_REF;
 const parentBranchName = process.env.GITHUB_BASE_REF;
+const shortCommitHash = process.env.GITHUB_SHA.slice(0, 7);
 
 module.exports = {
   accessibilityValidation: {
     level: "AA",
     guidelinesVersion: "WCAG_2_1",
   },
+  batchName: branchName?.concat(" ", shortCommitHash),
   branchName,
   browser: [{ width: 1024, height: 768, name: "chrome" }],
   exitcode: true,

--- a/packages/odyssey-storybook/applitools.config.js
+++ b/packages/odyssey-storybook/applitools.config.js
@@ -10,7 +10,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-const VRT_IGNORE = "Toast.Provider Callout.Form Callout.Table".split(" ");
+const branchName = process.env.GITHUB_HEAD_REF;
+const parentBranchName = process.env.GITHUB_BASE_REF;
 
 module.exports = {
   // NOTE: the docs for this exitcode config are incorrect as of this
@@ -20,16 +21,15 @@ module.exports = {
   // github integration.
   exitcode: true,
 
-  matchLevel: "Strict",
-  showStorybookOutput: true,
-  testConcurrency: 20,
-  browser: [{ width: 1024, height: 768, name: "chrome" }],
   accessibilityValidation: {
     level: "AA",
     guidelinesVersion: "WCAG_2_1",
   },
-  include({ name }) {
-    if (VRT_IGNORE.includes(name)) return false;
-    return true;
-  },
+  branchName,
+  baselineBranchName: parentBranchName,
+  parentBranchName,
+  browser: [{ width: 1024, height: 768, name: "chrome" }],
+  matchLevel: "Strict",
+  showStorybookOutput: true,
+  testConcurrency: 20,
 };

--- a/packages/odyssey-storybook/applitools.xbrowser.config.js
+++ b/packages/odyssey-storybook/applitools.xbrowser.config.js
@@ -15,8 +15,8 @@ const config = require("./applitools.config");
 module.exports = Object.assign(config, {
   batch: {
     name: "okta/odyssey: x-browser",
-    sequenceName: "x-browser",
     notifyOnCompletion: true,
+    sequenceName: "x-browser",
   },
   browser: [
     { width: 1024, height: 768, name: "edgechromium" },


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
Applitools was lacking branches. This PR adds branches to the Applitools config, so they'll function again now that GitHub integration with Applitools is no longer possible.