### PR TITLE
fix: moves @emotion/styled and @emotion/react to dependencies

### DIFF
--- a/packages/odyssey-react-mui/README.md
+++ b/packages/odyssey-react-mui/README.md
@@ -18,7 +18,7 @@ This project follows semantic versioning conventions:
 Install the package and peer dependencies:
 
 ```sh
-yarn add @okta/odyssey-react-mui @emotion/react
+yarn add @okta/odyssey-react-mui
 ```
 
 Include fonts:

--- a/packages/odyssey-react-mui/package.json
+++ b/packages/odyssey-react-mui/package.json
@@ -62,6 +62,8 @@
   },
   "dependencies": {
     "@emotion/cache": "^11.10.5",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.11.0",
     "@mui/lab": "^5.0.0-alpha.117",
     "@mui/material": "^5.12.3",
@@ -78,8 +80,6 @@
   "devDependencies": {
     "@babel/cli": "^7.22.9",
     "@babel/core": "^7.22.9",
-    "@emotion/react": "^11.11.1",
-    "@emotion/styled": "^11.11.0",
     "@okta/browserslist-config-odyssey": "workspace:*",
     "@okta/odyssey-babel-preset": "workspace:*",
     "@okta/odyssey-icons": "workspace:*",
@@ -114,8 +114,6 @@
     "yargs": "^17.7.2"
   },
   "peerDependencies": {
-    "@emotion/react": "^11",
-    "@emotion/styled": "^11",
     "react": ">=17 <19",
     "react-dom": ">=17 <19"
   }

--- a/packages/odyssey-react-mui/src/labs/README.md
+++ b/packages/odyssey-react-mui/src/labs/README.md
@@ -20,10 +20,10 @@ This project follows semantic versioning conventions:
 
 ## Getting Started
 
-Install the package and peer dependencies:
+To use Odyssey Labs, import as:
 
 ```sh
-yarn add @okta/odyssey-react-mui @okta/odyssey-react-labs @emotion/react
+import from "@okta/odyssey-react-mui/labs"
 ```
 
 ## Components

--- a/yarn.lock
+++ b/yarn.lock
@@ -5746,8 +5746,6 @@ __metadata:
     word-wrap: ~1.2.5
     yargs: ^17.7.2
   peerDependencies:
-    "@emotion/react": ^11
-    "@emotion/styled": ^11
     react: ">=17 <19"
     react-dom: ">=17 <19"
   languageName: unknown


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
`@emotion/styled` and `@emotion/react` were in `devDependencies`. We need to move them to `dependencies` to make it easier to install Odyssey.

#### Resolves
- [OKTA-639400](https://oktainc.atlassian.net/browse/OKTA-639400)
- [OKTA-641085](https://oktainc.atlassian.net/browse/OKTA-641085)