### PR TITLE
fix: update github workflows to point to `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - master
-      - develop
+      - main
       - "release/**"
 jobs:
   ci:

--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -11,7 +11,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
         with:
-          ref: develop
+          ref: main
       - name: setup node
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/x-browser-vrt.yml
+++ b/.github/workflows/x-browser-vrt.yml
@@ -12,7 +12,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
         with:
-          ref: develop
+          ref: main
           fetch-depth: 3
 
       - name: setup node


### PR DESCRIPTION
# Description

Uses `main` instead of `develop` or `master` for CI.
