### PR TITLE
Adds `testId` prop to `odyssey-react-mui` components

### DIFF
--- a/packages/odyssey-react-mui/src/Autocomplete.tsx
+++ b/packages/odyssey-react-mui/src/Autocomplete.tsx
@@ -18,6 +18,7 @@ import {
 import { memo, useCallback } from "react";
 
 import { Field } from "./Field";
+import type { SeleniumProps } from "./SeleniumProps";
 
 export type AutocompleteProps<
   OptionType,
@@ -113,7 +114,7 @@ export type AutocompleteProps<
     undefined,
     IsCustomValueAllowed
   >["value"];
-};
+} & SeleniumProps;
 
 const Autocomplete = <
   OptionType,
@@ -131,6 +132,7 @@ const Autocomplete = <
   onInputChange,
   options,
   value,
+  testId,
 }: AutocompleteProps<OptionType, HasMultipleChoices, IsCustomValueAllowed>) => {
   const renderInput = useCallback(
     ({ InputLabelProps, InputProps, ...params }) => (
@@ -157,6 +159,7 @@ const Autocomplete = <
     <MuiAutocomplete
       // AutoComplete is wrapped in a div within MUI which does not get the disabled attr. So this aria-disabled gets set in the div
       aria-disabled={isDisabled}
+      data-se={testId}
       disableCloseOnSelect={hasMultipleChoices}
       disabled={isDisabled}
       freeSolo={isCustomValueAllowed}

--- a/packages/odyssey-react-mui/src/Banner.tsx
+++ b/packages/odyssey-react-mui/src/Banner.tsx
@@ -16,6 +16,8 @@ import { ScreenReaderText } from "./ScreenReaderText";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
 
+import type { SeleniumProps } from "./SeleniumProps";
+
 export const bannerRoleValues = ["status", "alert"] as const;
 export const bannerSeverityValues: AlertColor[] = [
   "success",
@@ -54,7 +56,7 @@ export type BannerProps = {
    * The text content of the alert
    */
   text: string;
-};
+} & SeleniumProps;
 
 const Banner = ({
   linkUrl,
@@ -63,11 +65,12 @@ const Banner = ({
   role,
   severity,
   text,
+  testId,
 }: BannerProps) => {
   const { t } = useTranslation();
 
   return (
-    <Alert onClose={onClose} role={role} severity={severity} variant="banner">
+    <Alert data-se={testId} onClose={onClose} role={role} severity={severity} variant="banner">
       <ScreenReaderText>{t(`severity.${severity}`)}:</ScreenReaderText>
       <AlertTitle>{text}</AlertTitle>
       {linkUrl && (

--- a/packages/odyssey-react-mui/src/Banner.tsx
+++ b/packages/odyssey-react-mui/src/Banner.tsx
@@ -70,7 +70,13 @@ const Banner = ({
   const { t } = useTranslation();
 
   return (
-    <Alert data-se={testId} onClose={onClose} role={role} severity={severity} variant="banner">
+    <Alert
+      data-se={testId}
+      onClose={onClose}
+      role={role}
+      severity={severity}
+      variant="banner"
+    >
       <ScreenReaderText>{t(`severity.${severity}`)}:</ScreenReaderText>
       <AlertTitle>{text}</AlertTitle>
       {linkUrl && (

--- a/packages/odyssey-react-mui/src/Box.tsx
+++ b/packages/odyssey-react-mui/src/Box.tsx
@@ -13,14 +13,14 @@
 import { Box as MuiBox, BoxProps as MuiBoxProps } from "@mui/material";
 import { ReactNode, forwardRef, memo } from "react";
 
-import type { TestProps } from "./testTypes";
+import type { SeleniumProps } from "./SeleniumProps";
 
 export type BoxProps = {
   children?: ReactNode;
   component?: MuiBoxProps["component"];
   id?: MuiBoxProps["id"];
   sx?: MuiBoxProps["sx"];
-} & TestProps;
+} & SeleniumProps;
 
 const Box = forwardRef<HTMLElement, BoxProps>(
   ({ children, component, id, sx, testId }, ref) => (

--- a/packages/odyssey-react-mui/src/Box.tsx
+++ b/packages/odyssey-react-mui/src/Box.tsx
@@ -13,21 +13,24 @@
 import { Box as MuiBox, BoxProps as MuiBoxProps } from "@mui/material";
 import { ReactNode, forwardRef, memo } from "react";
 
+import type { TestProps } from "./testTypes";
+
 export type BoxProps = {
   children?: ReactNode;
   component?: MuiBoxProps["component"];
   id?: MuiBoxProps["id"];
   sx?: MuiBoxProps["sx"];
-};
+} & TestProps;
 
 const Box = forwardRef<HTMLElement, BoxProps>(
-  ({ children, component, id, sx }, ref) => (
+  ({ children, component, id, sx, testId }, ref) => (
     <MuiBox
       ref={ref}
       children={children}
       component={component}
       id={id}
       sx={sx}
+      data-se={testId}
     />
   )
 );

--- a/packages/odyssey-react-mui/src/Box.tsx
+++ b/packages/odyssey-react-mui/src/Box.tsx
@@ -28,9 +28,9 @@ const Box = forwardRef<HTMLElement, BoxProps>(
       ref={ref}
       children={children}
       component={component}
+      data-se={testId}
       id={id}
       sx={sx}
-      data-se={testId}
     />
   )
 );

--- a/packages/odyssey-react-mui/src/Button.tsx
+++ b/packages/odyssey-react-mui/src/Button.tsx
@@ -16,6 +16,7 @@ import { memo, ReactElement, useCallback } from "react";
 
 import { MuiPropsContext, useMuiProps } from "./MuiPropsContext";
 import { Tooltip } from "./Tooltip";
+import type { SeleniumProps } from "./SeleniumProps";
 
 export const buttonSizeValues = ["small", "medium", "large"] as const;
 export const buttonTypeValues = ["button", "submit", "reset"] as const;
@@ -100,7 +101,7 @@ export type ButtonProps = {
       label?: "" | undefined;
       startIcon?: ReactElement;
     }
-);
+) & SeleniumProps;
 
 const Button = ({
   ariaDescribedBy,
@@ -114,6 +115,7 @@ const Button = ({
   onClick,
   size = "medium",
   startIcon,
+  testId,
   tooltipText,
   type = "button",
   variant,
@@ -127,6 +129,7 @@ const Button = ({
         aria-label={ariaLabel}
         aria-labelledby={ariaLabelledBy}
         aria-describedby={ariaDescribedBy}
+        data-se={testId}
         disabled={isDisabled}
         endIcon={endIcon}
         fullWidth={isFullWidth}
@@ -152,6 +155,7 @@ const Button = ({
       onClick,
       size,
       startIcon,
+      testId,
       type,
       variant,
     ]

--- a/packages/odyssey-react-mui/src/Button.tsx
+++ b/packages/odyssey-react-mui/src/Button.tsx
@@ -101,7 +101,8 @@ export type ButtonProps = {
       label?: "" | undefined;
       startIcon?: ReactElement;
     }
-) & SeleniumProps;
+) &
+  SeleniumProps;
 
 const Button = ({
   ariaDescribedBy,

--- a/packages/odyssey-react-mui/src/Callout.tsx
+++ b/packages/odyssey-react-mui/src/Callout.tsx
@@ -15,6 +15,8 @@ import { Alert, AlertTitle, Box } from "@mui/material";
 import { ScreenReaderText } from "./ScreenReaderText";
 import { useTranslation } from "react-i18next";
 
+import type { SeleniumProps } from "./SeleniumProps";
+
 export const calloutRoleValues = ["status", "alert"] as const;
 export const calloutSeverityValues = [
   "success",
@@ -42,13 +44,13 @@ export type CalloutProps = {
    * The title of the Callout
    */
   title?: string;
-};
+} & SeleniumProps;
 
-const Callout = ({ children, role, severity, title }: CalloutProps) => {
+const Callout = ({ children, role, severity, testId, title }: CalloutProps) => {
   const { t } = useTranslation();
 
   return (
-    <Alert role={role} severity={severity} variant="callout">
+    <Alert data-se={testId} role={role} severity={severity} variant="callout">
       <ScreenReaderText>{t(`severity.${severity}`)}: </ScreenReaderText>
       {title && <AlertTitle>{title}</AlertTitle>}
       <Box component="div">{children}</Box>

--- a/packages/odyssey-react-mui/src/Checkbox.tsx
+++ b/packages/odyssey-react-mui/src/Checkbox.tsx
@@ -19,6 +19,8 @@ import { Typography } from "./Typography";
 import { memo, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import type { SeleniumProps } from "./SeleniumProps";
+
 export const checkboxValidityValues = ["valid", "invalid", "inherit"] as const;
 
 export type CheckboxProps = {
@@ -66,7 +68,7 @@ export type CheckboxProps = {
    * The value attribute of the Checkbox
    */
   value?: string;
-};
+} & SeleniumProps;
 
 const Checkbox = ({
   ariaLabel,
@@ -78,6 +80,7 @@ const Checkbox = ({
   label: labelProp,
   name,
   onChange: onChangeProp,
+  testId,
   validity = "inherit",
   value,
 }: CheckboxProps) => {
@@ -122,6 +125,7 @@ const Checkbox = ({
       control={
         <MuiCheckbox indeterminate={isIndeterminate} required={isRequired} />
       }
+      data-se={testId}
       disabled={isDisabled}
       label={label}
       name={name}

--- a/packages/odyssey-react-mui/src/CheckboxGroup.tsx
+++ b/packages/odyssey-react-mui/src/CheckboxGroup.tsx
@@ -61,12 +61,12 @@ const CheckboxGroup = ({
   testId,
 }: CheckboxGroupProps) => {
   const renderFieldComponent = useCallback(
-    ({ ariaDescribedBy, id, dataSe }) => (
-      <MuiFormGroup aria-describedby={ariaDescribedBy} data-se={dataSe} id={id}>
+    ({ ariaDescribedBy, id }) => (
+      <MuiFormGroup aria-describedby={ariaDescribedBy} data-se={testId} id={id}>
         {children}
       </MuiFormGroup>
     ),
-    [children]
+    [children, testId]
   );
 
   return (
@@ -80,7 +80,6 @@ const CheckboxGroup = ({
       isOptional={!isRequired}
       label={label}
       renderFieldComponent={renderFieldComponent}
-      testId={testId}
     />
   );
 };

--- a/packages/odyssey-react-mui/src/CheckboxGroup.tsx
+++ b/packages/odyssey-react-mui/src/CheckboxGroup.tsx
@@ -61,8 +61,8 @@ const CheckboxGroup = ({
   testId,
 }: CheckboxGroupProps) => {
   const renderFieldComponent = useCallback(
-    ({ ariaDescribedBy, id }) => (
-      <MuiFormGroup aria-describedby={ariaDescribedBy} id={id}>
+    ({ ariaDescribedBy, id, dataSe }) => (
+      <MuiFormGroup aria-describedby={ariaDescribedBy} data-se={dataSe} id={id}>
         {children}
       </MuiFormGroup>
     ),

--- a/packages/odyssey-react-mui/src/CheckboxGroup.tsx
+++ b/packages/odyssey-react-mui/src/CheckboxGroup.tsx
@@ -15,6 +15,7 @@ import { memo, ReactElement, useCallback } from "react";
 
 import { Checkbox } from "./Checkbox";
 import { Field } from "./Field";
+import type { SeleniumProps } from "./SeleniumProps";
 
 export type CheckboxGroupProps = {
   /**
@@ -47,7 +48,7 @@ export type CheckboxGroupProps = {
    * The label text for the CheckboxGroup
    */
   label: string;
-};
+} & SeleniumProps;
 
 const CheckboxGroup = ({
   children,
@@ -57,6 +58,7 @@ const CheckboxGroup = ({
   isDisabled,
   isRequired = false,
   label,
+  testId,
 }: CheckboxGroupProps) => {
   const renderFieldComponent = useCallback(
     ({ ariaDescribedBy, id }) => (
@@ -78,6 +80,7 @@ const CheckboxGroup = ({
       isOptional={!isRequired}
       label={label}
       renderFieldComponent={renderFieldComponent}
+      testId={testId}
     />
   );
 };

--- a/packages/odyssey-react-mui/src/CircularProgress.tsx
+++ b/packages/odyssey-react-mui/src/CircularProgress.tsx
@@ -12,6 +12,8 @@
 
 import { CircularProgress as MuiCircularProgress } from "@mui/material";
 
+import type { SeleniumProps } from "./SeleniumProps";
+
 export type CircularProgressProps = {
   /**
    * The ARIA label for the progress spinner
@@ -22,13 +24,15 @@ export type CircularProgressProps = {
    * If undefined, the spinner will spin perpetually.
    */
   value?: number;
-};
+} & SeleniumProps;
 
 export const CircularProgress = ({
   ariaLabel,
+  testId,
   value,
 }: CircularProgressProps) => (
   <MuiCircularProgress
+    data-se={testId}
     value={value}
     variant={value ? "determinate" : "indeterminate"}
     aria-label={ariaLabel}

--- a/packages/odyssey-react-mui/src/Dialog.tsx
+++ b/packages/odyssey-react-mui/src/Dialog.tsx
@@ -28,6 +28,8 @@ import {
   ReactElement,
 } from "react";
 
+import type { SeleniumProps } from "./SeleniumProps";
+
 export type DialogProps = {
   /**
    * An optional Button object to be situated in the Dialog footer. Should almost always be of variant `primary`.
@@ -58,7 +60,7 @@ export type DialogProps = {
    */
   title: string;
   ariaLabel: string;
-};
+} & SeleniumProps;
 
 const Dialog = ({
   callToActionFirstComponent,
@@ -67,6 +69,7 @@ const Dialog = ({
   children,
   isOpen,
   onClose,
+  testId,
   title,
   ariaLabel,
 }: DialogProps) => {
@@ -103,7 +106,7 @@ const Dialog = ({
     );
 
   return (
-    <MuiDialog open={isOpen} onClose={onClose}>
+    <MuiDialog data-se={testId} open={isOpen} onClose={onClose}>
       <DialogTitle>
         {title}
         <Button

--- a/packages/odyssey-react-mui/src/Field.tsx
+++ b/packages/odyssey-react-mui/src/Field.tsx
@@ -23,7 +23,6 @@ import { Typography } from "./Typography";
 import { useFieldset } from "./FieldsetContext";
 import { useTranslation } from "react-i18next";
 import { useUniqueId } from "./useUniqueId";
-import type { SeleniumProps } from "./SeleniumProps";
 
 export const fieldTypeValues = ["single", "group"] as const;
 
@@ -84,7 +83,7 @@ export type FieldProps = {
     dataSe?: string;
     id: string;
   }) => ReactElement;
-} & SeleniumProps;
+};
 
 const Field = ({
   errorMessage,
@@ -97,7 +96,6 @@ const Field = ({
   isOptional = false,
   label,
   renderFieldComponent,
-  testId,
 }: FieldProps) => {
   const { t } = useTranslation();
 
@@ -149,7 +147,6 @@ const Field = ({
       {renderFieldComponent({
         ariaDescribedBy,
         id,
-        dataSe: testId,
       })}
 
       {errorMessage && <FieldError id={errorId} text={errorMessage} />}

--- a/packages/odyssey-react-mui/src/Field.tsx
+++ b/packages/odyssey-react-mui/src/Field.tsx
@@ -77,9 +77,11 @@ export type FieldProps = {
    */
   renderFieldComponent: ({
     ariaDescribedBy,
+    dataSe,
     id,
   }: {
     ariaDescribedBy?: string;
+    dataSe?: string;
     id: string;
   }) => ReactElement;
 } & SeleniumProps;
@@ -119,7 +121,6 @@ const Field = ({
   return (
     <MuiFormControl
       component={fieldType === "group" ? "fieldset" : "div"}
-      data-se={testId}
       disabled={isDisabled}
       error={Boolean(errorMessage)}
       role={isRadioGroup ? "radiogroup" : undefined}
@@ -148,6 +149,7 @@ const Field = ({
       {renderFieldComponent({
         ariaDescribedBy,
         id,
+        dataSe: testId,
       })}
 
       {errorMessage && <FieldError id={errorId} text={errorMessage} />}

--- a/packages/odyssey-react-mui/src/Field.tsx
+++ b/packages/odyssey-react-mui/src/Field.tsx
@@ -23,6 +23,7 @@ import { Typography } from "./Typography";
 import { useFieldset } from "./FieldsetContext";
 import { useTranslation } from "react-i18next";
 import { useUniqueId } from "./useUniqueId";
+import type { SeleniumProps } from "./SeleniumProps";
 
 export const fieldTypeValues = ["single", "group"] as const;
 
@@ -81,7 +82,7 @@ export type FieldProps = {
     ariaDescribedBy?: string;
     id: string;
   }) => ReactElement;
-};
+} & SeleniumProps;
 
 const Field = ({
   errorMessage,
@@ -94,6 +95,7 @@ const Field = ({
   isOptional = false,
   label,
   renderFieldComponent,
+  testId,
 }: FieldProps) => {
   const { t } = useTranslation();
 
@@ -117,6 +119,7 @@ const Field = ({
   return (
     <MuiFormControl
       component={fieldType === "group" ? "fieldset" : "div"}
+      data-se={testId}
       disabled={isDisabled}
       error={Boolean(errorMessage)}
       role={isRadioGroup ? "radiogroup" : undefined}

--- a/packages/odyssey-react-mui/src/FieldError.tsx
+++ b/packages/odyssey-react-mui/src/FieldError.tsx
@@ -16,16 +16,18 @@ import { FormHelperText } from "@mui/material";
 import { ScreenReaderText } from "./ScreenReaderText";
 import { useTranslation } from "react-i18next";
 
+import type { SeleniumProps } from "./SeleniumProps";
+
 export type FieldErrorProps = {
   id?: string;
   text: string;
-};
+} & SeleniumProps;
 
-const FieldError = ({ id, text }: FieldErrorProps) => {
+const FieldError = ({ id, testId, text }: FieldErrorProps) => {
   const { t } = useTranslation();
 
   return (
-    <FormHelperText error id={id}>
+    <FormHelperText data-se={testId} error id={id}>
       <ScreenReaderText>{`${t(
         "fielderror.screenreader.text"
       )}:`}</ScreenReaderText>

--- a/packages/odyssey-react-mui/src/FieldHint.tsx
+++ b/packages/odyssey-react-mui/src/FieldHint.tsx
@@ -14,13 +14,15 @@ import { memo } from "react";
 
 import { FormHelperText } from "@mui/material";
 
+import type { SeleniumProps } from "./SeleniumProps";
+
 export type FieldHintProps = {
   id?: string;
   text: string;
-};
+} & SeleniumProps;
 
-const FieldHint = ({ id, text }: FieldHintProps) => {
-  return <FormHelperText id={id}>{text}</FormHelperText>;
+const FieldHint = ({ id, testId, text }: FieldHintProps) => {
+  return <FormHelperText data-se={testId} id={id}>{text}</FormHelperText>;
 };
 
 const MemoizedFieldHint = memo(FieldHint);

--- a/packages/odyssey-react-mui/src/FieldHint.tsx
+++ b/packages/odyssey-react-mui/src/FieldHint.tsx
@@ -22,7 +22,11 @@ export type FieldHintProps = {
 } & SeleniumProps;
 
 const FieldHint = ({ id, testId, text }: FieldHintProps) => {
-  return <FormHelperText data-se={testId} id={id}>{text}</FormHelperText>;
+  return (
+    <FormHelperText data-se={testId} id={id}>
+      {text}
+    </FormHelperText>
+  );
 };
 
 const MemoizedFieldHint = memo(FieldHint);

--- a/packages/odyssey-react-mui/src/FieldLabel.tsx
+++ b/packages/odyssey-react-mui/src/FieldLabel.tsx
@@ -16,6 +16,7 @@ import { memo, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { ScreenReaderText } from "./ScreenReaderText";
 import { Subordinate } from "./Typography";
+import type { SeleniumProps } from "./SeleniumProps";
 
 export type FieldLabelProps = {
   hasVisibleLabel: boolean;
@@ -23,27 +24,28 @@ export type FieldLabelProps = {
   inputId: string;
   isOptional: boolean;
   text: string;
-};
+} & SeleniumProps;
 
 const FieldLabel = ({
   hasVisibleLabel,
   id,
   inputId,
   isOptional,
+  testId,
   text,
 }: FieldLabelProps) => {
   const { t } = useTranslation();
 
   const inputLabel = useMemo(
     () => (
-      <MuiInputLabel htmlFor={inputId} id={id}>
+      <MuiInputLabel data-se={testId} htmlFor={inputId} id={id}>
         <span>{text}</span>
         {isOptional && (
           <Subordinate>{t("fieldlabel.optional.text")}</Subordinate>
         )}
       </MuiInputLabel>
     ),
-    [id, inputId, isOptional, text, t]
+    [id, inputId, isOptional, testId, text, t]
   );
 
   return hasVisibleLabel ? (

--- a/packages/odyssey-react-mui/src/Fieldset.tsx
+++ b/packages/odyssey-react-mui/src/Fieldset.tsx
@@ -18,6 +18,7 @@ import { FieldsetContext } from "./FieldsetContext";
 import { Legend, Support } from "./Typography";
 import { useOdysseyDesignTokens } from "./OdysseyDesignTokensContext";
 import { useUniqueId } from "./useUniqueId";
+import type { SeleniumProps } from "./SeleniumProps";
 
 export type FieldsetProps = {
   /**
@@ -48,7 +49,7 @@ export type FieldsetProps = {
    * The name associated with the group.
    */
   name?: string;
-};
+} & SeleniumProps;
 
 const Fieldset = ({
   alert,
@@ -58,6 +59,7 @@ const Fieldset = ({
   isDisabled = false,
   legend,
   name,
+  testId,
 }: FieldsetProps) => {
   const odysseyDesignTokens = useOdysseyDesignTokens();
   const id = useUniqueId(idOverride);
@@ -72,6 +74,7 @@ const Fieldset = ({
   return (
     <Box
       component="fieldset"
+      data-se={testId}
       disabled={isDisabled}
       name={name}
       id={id}

--- a/packages/odyssey-react-mui/src/Form.tsx
+++ b/packages/odyssey-react-mui/src/Form.tsx
@@ -17,6 +17,7 @@ import { Button } from "./Button";
 import { Callout } from "./Callout";
 import { Heading4, Support } from "./Typography";
 import { useUniqueId } from "./useUniqueId";
+import type { SeleniumProps } from "./SeleniumProps";
 
 export const formEncodingTypeValues = [
   "application/x-www-form-urlencoded",
@@ -84,7 +85,7 @@ export type FormProps = {
    * The title of the Form
    */
   title?: string;
-};
+} & SeleniumProps;
 
 const Form = ({
   alert,
@@ -98,20 +99,22 @@ const Form = ({
   name,
   noValidate = false,
   target,
+  testId,
   title,
 }: FormProps) => {
   const id = useUniqueId(idOverride);
 
   return (
     <Box
-      component="form"
       autoComplete={autoCompleteType}
-      name={name}
+      component="form"
+      data-se={testId}
       encType={encodingType}
+      id={id}
       method={method}
+      name={name}
       noValidate={noValidate}
       target={target}
-      id={id}
       sx={{
         maxWidth: (theme) => theme.mixins.maxWidth,
         margin: (theme) => theme.spacing(0),

--- a/packages/odyssey-react-mui/src/Link.tsx
+++ b/packages/odyssey-react-mui/src/Link.tsx
@@ -12,6 +12,7 @@
 
 import { memo, ReactElement } from "react";
 import { ExternalLinkIcon } from "./icons.generated";
+import type { SeleniumProps } from "./SeleniumProps";
 
 import { Link as MuiLink } from "@mui/material";
 
@@ -47,10 +48,10 @@ export type LinkProps = {
    * The visual presentation of the Link (default or monochrome)
    */
   variant?: (typeof linkVariantValues)[number];
-};
+} & SeleniumProps;
 
-const Link = ({ children, href, icon, target, rel, variant }: LinkProps) => (
-  <MuiLink href={href} rel={rel} target={target} variant={variant}>
+const Link = ({ children, href, icon, rel, target, testId, variant }: LinkProps) => (
+  <MuiLink data-se={testId} href={href} rel={rel} target={target} variant={variant}>
     {icon && <span className="Link-icon">{icon}</span>}
 
     {children}

--- a/packages/odyssey-react-mui/src/Link.tsx
+++ b/packages/odyssey-react-mui/src/Link.tsx
@@ -50,8 +50,22 @@ export type LinkProps = {
   variant?: (typeof linkVariantValues)[number];
 } & SeleniumProps;
 
-const Link = ({ children, href, icon, rel, target, testId, variant }: LinkProps) => (
-  <MuiLink data-se={testId} href={href} rel={rel} target={target} variant={variant}>
+const Link = ({
+  children,
+  href,
+  icon,
+  rel,
+  target,
+  testId,
+  variant,
+}: LinkProps) => (
+  <MuiLink
+    data-se={testId}
+    href={href}
+    rel={rel}
+    target={target}
+    variant={variant}
+  >
     {icon && <span className="Link-icon">{icon}</span>}
 
     {children}

--- a/packages/odyssey-react-mui/src/MenuButton.tsx
+++ b/packages/odyssey-react-mui/src/MenuButton.tsx
@@ -143,7 +143,7 @@ const MenuButton = ({
   );
 
   return (
-    <div data-se={testId}>
+    <div>
       <Button
         aria-controls={isOpen ? `${uniqueId}-menu` : undefined}
         aria-expanded={isOpen ? "true" : undefined}
@@ -151,6 +151,7 @@ const MenuButton = ({
         ariaDescribedBy={ariaDescribedBy}
         ariaLabel={ariaLabel}
         ariaLabelledBy={ariaLabelledBy}
+        data-se={testId}
         endIcon={endIcon}
         id={`${uniqueId}-button`}
         label={buttonLabel}

--- a/packages/odyssey-react-mui/src/MenuButton.tsx
+++ b/packages/odyssey-react-mui/src/MenuButton.tsx
@@ -90,7 +90,8 @@ export type MenuButtonProps = {
       ariaLabelledBy: string;
       buttonLabel?: undefined | "";
     }
-) & SeleniumProps;
+) &
+  SeleniumProps;
 
 const MenuButton = ({
   ariaLabel,

--- a/packages/odyssey-react-mui/src/MenuButton.tsx
+++ b/packages/odyssey-react-mui/src/MenuButton.tsx
@@ -23,6 +23,7 @@ import { memo, type ReactElement, useCallback, useMemo, useState } from "react";
 
 import { MenuContext, MenuContextType } from "./MenuContext";
 import { NullElement } from "./NullElement";
+import type { SeleniumProps } from "./SeleniumProps";
 
 export type MenuButtonProps = {
   /**
@@ -89,7 +90,7 @@ export type MenuButtonProps = {
       ariaLabelledBy: string;
       buttonLabel?: undefined | "";
     }
-);
+) & SeleniumProps;
 
 const MenuButton = ({
   ariaLabel,
@@ -102,6 +103,7 @@ const MenuButton = ({
   id: idOverride,
   isOverflow,
   size,
+  testId,
   tooltipText,
 }: MenuButtonProps) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -140,7 +142,7 @@ const MenuButton = ({
   );
 
   return (
-    <div>
+    <div data-se={testId}>
       <Button
         aria-controls={isOpen ? `${uniqueId}-menu` : undefined}
         aria-expanded={isOpen ? "true" : undefined}

--- a/packages/odyssey-react-mui/src/MenuItem.tsx
+++ b/packages/odyssey-react-mui/src/MenuItem.tsx
@@ -18,6 +18,7 @@ import { menuItemClasses } from "@mui/material/MenuItem";
 import { memo, useCallback, useContext, type ReactNode } from "react";
 
 import { MenuContext } from "./MenuContext";
+import type { SeleniumProps } from "./SeleniumProps";
 
 export type MenuItemProps = {
   /**
@@ -50,7 +51,7 @@ export type MenuItemProps = {
    * - "destructive": A variant indicating a destructive action.
    */
   variant?: "default" | "destructive";
-};
+} & SeleniumProps;
 
 const MenuItem = ({
   children,
@@ -58,6 +59,7 @@ const MenuItem = ({
   isSelected,
   isDisabled,
   onClick: onClickProp,
+  testId,
   value,
   variant = "default",
 }: MenuItemProps) => {
@@ -75,15 +77,16 @@ const MenuItem = ({
     <MuiMenuItem
       /* eslint-disable-next-line jsx-a11y/no-autofocus */
       autoFocus={hasInitialFocus}
-      selected={isSelected}
-      disabled={isDisabled}
-      value={value}
-      onClick={onClick}
       className={
         variant === "destructive"
           ? `${menuItemClasses.root}-destructive`
           : undefined
       }
+      data-se={testId}
+      disabled={isDisabled}
+      onClick={onClick}
+      selected={isSelected}
+      value={value}
     >
       {children}
     </MuiMenuItem>

--- a/packages/odyssey-react-mui/src/NativeSelect.tsx
+++ b/packages/odyssey-react-mui/src/NativeSelect.tsx
@@ -15,6 +15,8 @@ import { Select as MuiSelect } from "@mui/material";
 import { SelectProps as MuiSelectProps } from "@mui/material";
 import { Field } from "./Field";
 
+import type { SeleniumProps } from "./SeleniumProps";
+
 export type NativeSelectOption = {
   text: string;
   value?: string;
@@ -74,7 +76,7 @@ export type NativeSelectProps = {
    * The value or values selected in the NativeSelect
    */
   value?: string | string[];
-};
+} & SeleniumProps;
 
 const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
   (
@@ -90,6 +92,7 @@ const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
       onBlur,
       onChange,
       onFocus,
+      testId,
       value,
       children,
     },
@@ -135,6 +138,7 @@ const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
         isOptional={isOptional}
         label={label}
         renderFieldComponent={renderFieldComponent}
+        testId={testId}
       />
     );
   }

--- a/packages/odyssey-react-mui/src/NativeSelect.tsx
+++ b/packages/odyssey-react-mui/src/NativeSelect.tsx
@@ -101,6 +101,7 @@ const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
     const renderFieldComponent = useCallback(
       () => (
         <MuiSelect
+          data-se={testId}
           defaultValue={defaultValue}
           id={idOverride}
           name={idOverride}
@@ -115,6 +116,7 @@ const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
         />
       ),
       [
+        children,
         defaultValue,
         idOverride,
         isMultiSelect,
@@ -122,7 +124,7 @@ const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
         onChange,
         onFocus,
         ref,
-        children,
+        testId,
         value,
       ]
     );
@@ -138,7 +140,6 @@ const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
         isOptional={isOptional}
         label={label}
         renderFieldComponent={renderFieldComponent}
-        testId={testId}
       />
     );
   }

--- a/packages/odyssey-react-mui/src/PasswordField.tsx
+++ b/packages/odyssey-react-mui/src/PasswordField.tsx
@@ -121,6 +121,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
           autoComplete={autoCompleteType}
           /* eslint-disable-next-line jsx-a11y/no-autofocus */
           autoFocus={hasInitialFocus}
+          data-se={testId}
           endAdornment={
             <InputAdornment position="end">
               <IconButton
@@ -156,6 +157,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
         isOptional,
         isReadOnly,
         ref,
+        testId,
         value,
       ]
     );
@@ -171,7 +173,6 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
         isOptional={isOptional}
         label={label}
         renderFieldComponent={renderFieldComponent}
-        testId={testId}
       />
     );
   }

--- a/packages/odyssey-react-mui/src/PasswordField.tsx
+++ b/packages/odyssey-react-mui/src/PasswordField.tsx
@@ -22,6 +22,7 @@ import {
 
 import { ShowIcon, HideIcon } from "./icons.generated";
 import { Field } from "./Field";
+import type { SeleniumProps } from "./SeleniumProps";
 
 export type PasswordFieldProps = {
   /**
@@ -82,7 +83,7 @@ export type PasswordFieldProps = {
    * The value of the `input` element, required for a controlled component.
    */
   value?: string;
-};
+} & SeleniumProps;
 
 const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
   (
@@ -100,6 +101,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
       onFocus,
       onBlur,
       placeholder,
+      testId,
       value,
     },
     ref
@@ -169,6 +171,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
         isOptional={isOptional}
         label={label}
         renderFieldComponent={renderFieldComponent}
+        testId={testId}
       />
     );
   }

--- a/packages/odyssey-react-mui/src/Radio.tsx
+++ b/packages/odyssey-react-mui/src/Radio.tsx
@@ -15,6 +15,8 @@ import { memo } from "react";
 
 import { FormControlLabel } from "@mui/material";
 
+import type { SeleniumProps } from "./SeleniumProps";
+
 export type RadioProps = {
   /**
    * If `true`, the Radio is selected
@@ -40,7 +42,7 @@ export type RadioProps = {
    * The value attribute of the Radio
    */
   value: string;
-};
+} & SeleniumProps;
 
 const Radio = ({
   isChecked,
@@ -48,12 +50,14 @@ const Radio = ({
   isInvalid,
   label,
   name,
+  testId,
   value,
 }: RadioProps) => (
   <FormControlLabel
     checked={isChecked}
     className={isInvalid ? "Mui-error" : ""}
     control={<MuiRadio />}
+    data-se={testId}
     disabled={isDisabled}
     label={label}
     name={name}

--- a/packages/odyssey-react-mui/src/RadioGroup.tsx
+++ b/packages/odyssey-react-mui/src/RadioGroup.tsx
@@ -15,6 +15,7 @@ import { ChangeEventHandler, memo, ReactElement, useCallback } from "react";
 
 import { Radio, RadioProps } from "./Radio";
 import { Field } from "./Field";
+import type { SeleniumProps } from "./SeleniumProps";
 
 export type RadioGroupProps = {
   /**
@@ -53,7 +54,7 @@ export type RadioGroupProps = {
    * The `value` on the selected Radio
    */
   value?: RadioProps["value"];
-};
+} & SeleniumProps;
 
 const RadioGroup = ({
   children,
@@ -64,6 +65,7 @@ const RadioGroup = ({
   isDisabled,
   label,
   onChange,
+  testId,
   value,
 }: RadioGroupProps) => {
   const renderFieldComponent = useCallback(
@@ -92,6 +94,7 @@ const RadioGroup = ({
       isDisabled={isDisabled}
       label={label}
       renderFieldComponent={renderFieldComponent}
+      testId={testId}
     />
   );
 };

--- a/packages/odyssey-react-mui/src/RadioGroup.tsx
+++ b/packages/odyssey-react-mui/src/RadioGroup.tsx
@@ -72,6 +72,7 @@ const RadioGroup = ({
     ({ ariaDescribedBy, id }) => (
       <MuiRadioGroup
         aria-describedby={ariaDescribedBy}
+        data-se={testId}
         defaultValue={defaultValue}
         id={id}
         name={id}
@@ -81,7 +82,7 @@ const RadioGroup = ({
         {children}
       </MuiRadioGroup>
     ),
-    [children, defaultValue, onChange, value]
+    [children, defaultValue, onChange, testId, value]
   );
 
   return (
@@ -94,7 +95,6 @@ const RadioGroup = ({
       isDisabled={isDisabled}
       label={label}
       renderFieldComponent={renderFieldComponent}
-      testId={testId}
     />
   );
 };

--- a/packages/odyssey-react-mui/src/SearchField.tsx
+++ b/packages/odyssey-react-mui/src/SearchField.tsx
@@ -121,6 +121,7 @@ const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
           autoComplete={autoCompleteType}
           /* eslint-disable-next-line jsx-a11y/no-autofocus */
           autoFocus={hasInitialFocus}
+          data-se={testId}
           endAdornment={
             uncontrolledValue && (
               <InputAdornment position="end">
@@ -163,6 +164,7 @@ const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
         onBlur,
         placeholder,
         ref,
+        testId,
         controlledValue,
         uncontrolledValue,
       ]
@@ -177,7 +179,6 @@ const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
         isOptional={true}
         label={label}
         renderFieldComponent={renderFieldComponent}
-        testId={testId}
       />
     );
   }

--- a/packages/odyssey-react-mui/src/SearchField.tsx
+++ b/packages/odyssey-react-mui/src/SearchField.tsx
@@ -23,6 +23,7 @@ import {
 
 import { CloseCircleFilledIcon, SearchIcon } from "./icons.generated";
 import { Field } from "./Field";
+import type { SeleniumProps } from "./SeleniumProps";
 
 export type SearchFieldProps = {
   /**
@@ -71,7 +72,7 @@ export type SearchFieldProps = {
    * The value of the `input` element, required for a controlled component.
    */
   value?: string;
-};
+} & SeleniumProps;
 
 const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
   (
@@ -86,6 +87,7 @@ const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
       onBlur,
       onClear: onClearProp,
       placeholder,
+      testId,
       value: controlledValue,
     },
     ref
@@ -175,6 +177,7 @@ const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
         isOptional={true}
         label={label}
         renderFieldComponent={renderFieldComponent}
+        testId={testId}
       />
     );
   }

--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -218,6 +218,7 @@ const Select = forwardRef<HTMLSelectElement, SelectProps>(
       () => (
         <MuiSelect
           children={children}
+          data-se={testId}
           id={idOverride}
           multiple={isMultiSelect}
           name={idOverride}
@@ -240,6 +241,7 @@ const Select = forwardRef<HTMLSelectElement, SelectProps>(
         children,
         renderValue,
         selectedValue,
+        testId,
         label,
       ]
     );
@@ -255,7 +257,6 @@ const Select = forwardRef<HTMLSelectElement, SelectProps>(
         isOptional={isOptional}
         label={label}
         renderFieldComponent={renderFieldComponent}
-        testId={testId}
       />
     );
   }

--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -22,6 +22,7 @@ import {
 } from "@mui/material";
 import { SelectProps as MuiSelectProps } from "@mui/material";
 import { Field } from "./Field";
+import type { SeleniumProps } from "./SeleniumProps";
 
 export type SelectOption = {
   text: string;
@@ -78,7 +79,7 @@ export type SelectProps = {
    * The value or values selected in the Select
    */
   value?: string | string[];
-};
+} & SeleniumProps;
 
 /**
  * Options in Odyssey <Select> are passed as an array, which can contain any combination
@@ -109,6 +110,7 @@ const Select = forwardRef<HTMLSelectElement, SelectProps>(
       onChange: onChangeProp,
       onFocus,
       value,
+      testId,
       options,
     },
     ref
@@ -253,6 +255,7 @@ const Select = forwardRef<HTMLSelectElement, SelectProps>(
         isOptional={isOptional}
         label={label}
         renderFieldComponent={renderFieldComponent}
+        testId={testId}
       />
     );
   }

--- a/packages/odyssey-react-mui/src/SeleniumProps.ts
+++ b/packages/odyssey-react-mui/src/SeleniumProps.ts
@@ -10,9 +10,11 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-export type TestProps = {
+export type SeleniumProps = {
   /**
-   * @deprecated Use semantic selectors instead.
+   * This prop puts a `data` attribute on an HTML element in this component with the value provided.
+   * 
+   * @deprecated **WARNING:** You should be using Semantic Selectors instead of this property. This is a temporary measure for backwards compatibility with existing Selenium tests.
    */
   testId?: string;
 };

--- a/packages/odyssey-react-mui/src/SeleniumProps.ts
+++ b/packages/odyssey-react-mui/src/SeleniumProps.ts
@@ -13,7 +13,7 @@
 export type SeleniumProps = {
   /**
    * This prop puts a `data` attribute on an HTML element in this component with the value provided.
-   * 
+   *
    * @deprecated **WARNING:** You should be using Semantic Selectors instead of this property. This is a temporary measure for backwards compatibility with existing Selenium tests.
    */
   testId?: string;

--- a/packages/odyssey-react-mui/src/Status.tsx
+++ b/packages/odyssey-react-mui/src/Status.tsx
@@ -13,6 +13,7 @@
 import { Chip } from "@mui/material";
 
 import { useMuiProps } from "./MuiPropsContext";
+import type { SeleniumProps } from "./SeleniumProps";
 
 export const statusSeverityValues = [
   "default",
@@ -35,12 +36,12 @@ export type StatusProps = {
    * The style of the Status indicator
    */
   variant?: (typeof statusVariantValues)[number];
-};
+} & SeleniumProps;
 
-export const Status = ({ severity, label, variant = "lamp" }: StatusProps) => {
+export const Status = ({ label, severity, testId, variant = "lamp" }: StatusProps) => {
   const muiProps = useMuiProps();
 
   return (
-    <Chip {...muiProps} label={label} color={severity} variant={variant} />
+    <Chip {...muiProps} color={severity} data-se={testId} label={label} variant={variant} />
   );
 };

--- a/packages/odyssey-react-mui/src/Status.tsx
+++ b/packages/odyssey-react-mui/src/Status.tsx
@@ -38,10 +38,21 @@ export type StatusProps = {
   variant?: (typeof statusVariantValues)[number];
 } & SeleniumProps;
 
-export const Status = ({ label, severity, testId, variant = "lamp" }: StatusProps) => {
+export const Status = ({
+  label,
+  severity,
+  testId,
+  variant = "lamp",
+}: StatusProps) => {
   const muiProps = useMuiProps();
 
   return (
-    <Chip {...muiProps} color={severity} data-se={testId} label={label} variant={variant} />
+    <Chip
+      {...muiProps}
+      color={severity}
+      data-se={testId}
+      label={label}
+      variant={variant}
+    />
   );
 };

--- a/packages/odyssey-react-mui/src/Tabs.tsx
+++ b/packages/odyssey-react-mui/src/Tabs.tsx
@@ -67,9 +67,9 @@ export type TabsProps = {
    * Identifier for the selected tab.
    */
   value?: string;
-} & SeleniumProps;
+};
 
-const Tabs = ({ ariaLabel, initialValue, tabs, testId, value }: TabsProps) => {
+const Tabs = ({ ariaLabel, initialValue, tabs, value }: TabsProps) => {
   const [tabState, setTabState] = useState(initialValue ?? value ?? "0");
 
   const onChange = useCallback(
@@ -87,7 +87,7 @@ const Tabs = ({ ariaLabel, initialValue, tabs, testId, value }: TabsProps) => {
 
   return (
     <MuiTabContext value={tabState}>
-      <MuiTabList data-se={testId} onChange={onChange} aria-label={ariaLabel}>
+      <MuiTabList onChange={onChange} aria-label={ariaLabel}>
         {tabs.map((tab, index) => (
           <MuiTab
             data-se={tab.testId}
@@ -101,7 +101,6 @@ const Tabs = ({ ariaLabel, initialValue, tabs, testId, value }: TabsProps) => {
       </MuiTabList>
       {tabs.map((tab, index) => (
         <MuiTabPanel
-          data-se={tab.testId}
           value={tab.value ? tab.value : index.toString()}
           key={tab.value ? tab.value : index.toString()}
         >

--- a/packages/odyssey-react-mui/src/Tabs.tsx
+++ b/packages/odyssey-react-mui/src/Tabs.tsx
@@ -24,6 +24,7 @@ import {
   TabPanel as MuiTabPanel,
   TabContext as MuiTabContext,
 } from "@mui/lab";
+import { SeleniumProps } from "./SeleniumProps";
 
 export type TabItemProps = {
   /**
@@ -46,7 +47,7 @@ export type TabItemProps = {
    * The value associated with the TabItem
    */
   value?: string;
-};
+} & SeleniumProps;
 
 export type TabsProps = {
   /**
@@ -66,9 +67,9 @@ export type TabsProps = {
    * Identifier for the selected tab.
    */
   value?: string;
-};
+} & SeleniumProps;
 
-const Tabs = ({ ariaLabel, initialValue, tabs, value }: TabsProps) => {
+const Tabs = ({ ariaLabel, initialValue, tabs, testId, value }: TabsProps) => {
   const [tabState, setTabState] = useState(initialValue ?? value ?? "0");
 
   const onChange = useCallback(
@@ -86,9 +87,10 @@ const Tabs = ({ ariaLabel, initialValue, tabs, value }: TabsProps) => {
 
   return (
     <MuiTabContext value={tabState}>
-      <MuiTabList onChange={onChange} aria-label={ariaLabel}>
+      <MuiTabList data-se={testId} onChange={onChange} aria-label={ariaLabel}>
         {tabs.map((tab, index) => (
           <MuiTab
+            data-se={tab.testId}
             disabled={tab.isDisabled}
             icon={tab.startIcon}
             label={tab.label}
@@ -99,6 +101,7 @@ const Tabs = ({ ariaLabel, initialValue, tabs, value }: TabsProps) => {
       </MuiTabList>
       {tabs.map((tab, index) => (
         <MuiTabPanel
+          data-se={tab.testId}
           value={tab.value ? tab.value : index.toString()}
           key={tab.value ? tab.value : index.toString()}
         >

--- a/packages/odyssey-react-mui/src/Tag.tsx
+++ b/packages/odyssey-react-mui/src/Tag.tsx
@@ -33,7 +33,14 @@ export type TagProps = {
   onRemove?: MuiChipProps["onDelete"];
 } & SeleniumProps;
 
-const Tag = ({ icon, isDisabled, label, onClick, onRemove, testId }: TagProps) => {
+const Tag = ({
+  icon,
+  isDisabled,
+  label,
+  onClick,
+  onRemove,
+  testId,
+}: TagProps) => {
   const { chipElementType } = useContext(TagListContext);
 
   const renderTag = useCallback(

--- a/packages/odyssey-react-mui/src/Tag.tsx
+++ b/packages/odyssey-react-mui/src/Tag.tsx
@@ -14,6 +14,7 @@ import { Chip as MuiChip, ChipProps as MuiChipProps } from "@mui/material";
 import { memo, ReactElement, useCallback, useContext } from "react";
 import { TagListContext } from "./TagListContext";
 import { MuiPropsContext } from "./MuiPropsContext";
+import { SeleniumProps } from "./SeleniumProps";
 
 export type TagProps = {
   icon?: ReactElement;
@@ -30,9 +31,9 @@ export type TagProps = {
    * Callback fired when the remove button of the Tag is clicked
    */
   onRemove?: MuiChipProps["onDelete"];
-};
+} & SeleniumProps;
 
-const Tag = ({ icon, isDisabled, label, onClick, onRemove }: TagProps) => {
+const Tag = ({ icon, isDisabled, label, onClick, onRemove, testId }: TagProps) => {
   const { chipElementType } = useContext(TagListContext);
 
   const renderTag = useCallback(
@@ -42,6 +43,7 @@ const Tag = ({ icon, isDisabled, label, onClick, onRemove }: TagProps) => {
         aria-disabled={isDisabled}
         clickable={onClick ? true : false}
         component={chipElementType}
+        data-se={testId}
         disabled={isDisabled}
         icon={icon}
         label={label}
@@ -49,7 +51,7 @@ const Tag = ({ icon, isDisabled, label, onClick, onRemove }: TagProps) => {
         onDelete={onRemove}
       />
     ),
-    [chipElementType, icon, isDisabled, label, onClick, onRemove]
+    [chipElementType, icon, isDisabled, label, onClick, onRemove, testId]
   );
 
   return <MuiPropsContext.Consumer>{renderTag}</MuiPropsContext.Consumer>;

--- a/packages/odyssey-react-mui/src/TagList.tsx
+++ b/packages/odyssey-react-mui/src/TagList.tsx
@@ -14,15 +14,16 @@ import { Tag } from "./Tag";
 import { Stack } from "@mui/material";
 import { memo, ReactElement, useMemo } from "react";
 import { ChipElementType, TagListContext } from "./TagListContext";
+import { SeleniumProps } from "./SeleniumProps";
 
 export type TagListProps = {
   /**
    * The Tag or array of Tags within the TagList
    */
   children: ReactElement<typeof Tag> | Array<ReactElement<typeof Tag>>;
-};
+} & SeleniumProps;
 
-const TagList = ({ children }: TagListProps) => {
+const TagList = ({ children, testId }: TagListProps) => {
   const providerValue = useMemo<{
     chipElementType: ChipElementType;
   }>(
@@ -35,6 +36,7 @@ const TagList = ({ children }: TagListProps) => {
   return (
     <Stack
       component="ul"
+      data-se={testId}
       direction="row"
       spacing={2}
       useFlexGap

--- a/packages/odyssey-react-mui/src/TextField.tsx
+++ b/packages/odyssey-react-mui/src/TextField.tsx
@@ -22,6 +22,7 @@ import {
 } from "react";
 
 import { Field } from "./Field";
+import { SeleniumProps } from "./SeleniumProps";
 
 export const textFieldTypeValues = [
   "email",
@@ -106,7 +107,7 @@ export type TextFieldProps = {
    * The value of the `input` element, required for a controlled component.
    */
   value?: string;
-};
+} & SeleniumProps;
 
 const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
   (
@@ -127,6 +128,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       onFocus,
       placeholder,
       startAdornment,
+      testId,
       type = "text",
       value,
     },
@@ -190,6 +192,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         isOptional={isOptional}
         label={label}
         renderFieldComponent={renderFieldComponent}
+        testId={testId}
       />
     );
   }

--- a/packages/odyssey-react-mui/src/TextField.tsx
+++ b/packages/odyssey-react-mui/src/TextField.tsx
@@ -141,6 +141,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
           autoComplete={autoCompleteType}
           /* eslint-disable-next-line jsx-a11y/no-autofocus */
           autoFocus={hasInitialFocus}
+          data-se={testId}
           endAdornment={
             endAdornment && (
               <InputAdornment position="end">{endAdornment}</InputAdornment>
@@ -176,6 +177,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         isReadOnly,
         ref,
         startAdornment,
+        testId,
         type,
         value,
       ]
@@ -192,7 +194,6 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         isOptional={isOptional}
         label={label}
         renderFieldComponent={renderFieldComponent}
-        testId={testId}
       />
     );
   }

--- a/packages/odyssey-react-mui/src/Toast.tsx
+++ b/packages/odyssey-react-mui/src/Toast.tsx
@@ -17,6 +17,7 @@ import { Link } from "./Link";
 import { CloseIcon } from "./icons.generated";
 import { Button } from "./Button";
 import { useTranslation } from "react-i18next";
+import { SeleniumProps } from "./SeleniumProps";
 
 export const toastRoleValues = ["status", "alert"] as const;
 export const toastSeverityValues = [
@@ -69,7 +70,7 @@ export type ToastProps = {
    * The text content of the Toast
    */
   text: string;
-};
+} & SeleniumProps;
 
 const ClickAwayListenerProps = { onClickAway: () => false };
 
@@ -82,6 +83,7 @@ const Toast = ({
   onHide: onHideProp,
   role,
   severity,
+  testId,
   text,
 }: ToastProps) => {
   const { t } = useTranslation();
@@ -119,6 +121,7 @@ const Toast = ({
             />
           )
         }
+        data-se={testId}
         role={role}
         severity={severity}
         variant="toast"

--- a/packages/odyssey-react-mui/src/Tooltip.tsx
+++ b/packages/odyssey-react-mui/src/Tooltip.tsx
@@ -15,6 +15,7 @@ import type { TooltipProps as MuiTooltipProps } from "@mui/material";
 
 import { MuiPropsChild } from "./MuiPropsChild";
 import { ReactElement } from "react";
+import { SeleniumProps } from "./SeleniumProps";
 
 export type TooltipProps = {
   /**
@@ -33,15 +34,17 @@ export type TooltipProps = {
    * The text to display in the Tooltip
    */
   text: string;
-};
+} & SeleniumProps;
 
 export const Tooltip = ({
   ariaType,
   children,
   placement = "top",
+  testId,
   text,
 }: TooltipProps) => (
   <MuiTooltip
+    data-se={testId}
     describeChild={ariaType === "description"}
     placement={placement}
     title={text}

--- a/packages/odyssey-react-mui/src/Typography.tsx
+++ b/packages/odyssey-react-mui/src/Typography.tsx
@@ -15,6 +15,7 @@ import {
   TypographyProps as MuiTypographyProps,
 } from "@mui/material";
 import { ElementType, ReactNode, memo, useMemo } from "react";
+import { SeleniumProps } from "./SeleniumProps";
 
 export type TypographyVariantValue =
   | "h1"
@@ -85,7 +86,7 @@ export type TypographyProps = {
    * The variant of Typography to render.
    */
   variant?: keyof typeof typographyVariantMapping;
-};
+} & SeleniumProps;
 
 const Typography = ({
   ariaDescribedBy,
@@ -95,6 +96,7 @@ const Typography = ({
   classes,
   color,
   component: componentProp,
+  testId,
   variant = "body",
 }: TypographyProps) => {
   const component = useMemo(() => {
@@ -119,6 +121,7 @@ const Typography = ({
       classes={classes}
       color={color}
       component={component}
+      data-se={testId}
       variant={typographyVariantMapping[variant]}
     />
   );
@@ -135,6 +138,7 @@ const Heading1 = ({
   classes,
   color,
   component,
+  testId,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -144,6 +148,7 @@ const Heading1 = ({
     classes={classes}
     color={color}
     component={component}
+    data-se={testId}
     variant="h1"
   />
 );
@@ -159,6 +164,7 @@ const Heading2 = ({
   classes,
   color,
   component,
+  testId,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -168,6 +174,7 @@ const Heading2 = ({
     classes={classes}
     color={color}
     component={component}
+    data-se={testId}
     variant="h2"
   />
 );
@@ -183,6 +190,7 @@ const Heading3 = ({
   classes,
   color,
   component,
+  testId,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -192,6 +200,7 @@ const Heading3 = ({
     classes={classes}
     color={color}
     component={component}
+    data-se={testId}
     variant="h3"
   />
 );
@@ -207,6 +216,7 @@ const Heading4 = ({
   classes,
   color,
   component,
+  testId,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -216,6 +226,7 @@ const Heading4 = ({
     classes={classes}
     color={color}
     component={component}
+    data-se={testId}
     variant="h4"
   />
 );
@@ -231,6 +242,7 @@ const Heading5 = ({
   classes,
   color,
   component,
+  testId,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -240,6 +252,7 @@ const Heading5 = ({
     classes={classes}
     color={color}
     component={component}
+    data-se={testId}
     variant="h5"
   />
 );
@@ -255,6 +268,7 @@ const Heading6 = ({
   classes,
   color,
   component,
+  testId,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -264,6 +278,7 @@ const Heading6 = ({
     classes={classes}
     color={color}
     component={component}
+    data-se={testId}
     variant="h6"
   />
 );
@@ -279,6 +294,7 @@ const Paragraph = ({
   classes,
   color,
   component,
+  testId,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -288,6 +304,7 @@ const Paragraph = ({
     classes={classes}
     color={color}
     component={component}
+    data-se={testId}
     variant="body"
   />
 );
@@ -303,6 +320,7 @@ const Subordinate = ({
   classes,
   color,
   component,
+  testId,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -312,6 +330,7 @@ const Subordinate = ({
     classes={classes}
     color={color}
     component={component}
+    data-se={testId}
     variant="subordinate"
   />
 );
@@ -327,6 +346,7 @@ const Support = ({
   classes,
   color,
   component,
+  testId,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -336,6 +356,7 @@ const Support = ({
     classes={classes}
     color={color}
     component={component}
+    data-se={testId}
     variant="support"
   />
 );
@@ -351,6 +372,7 @@ const Legend = ({
   classes,
   color,
   component,
+  testId,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -360,6 +382,7 @@ const Legend = ({
     classes={classes}
     color={color}
     component={component}
+    data-se={testId}
     variant="legend"
   />
 );

--- a/packages/odyssey-react-mui/src/testTypes.ts
+++ b/packages/odyssey-react-mui/src/testTypes.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright (c) 2023-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+export type TestProps = {
+  /**
+   * @deprecated Use semantic selectors instead.
+   */
+  testId?: string;
+};


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Adds `testId` property to most components in `@okta/odyssey-react-mui`. This property is passed to the DOM as `data-se` for each component.

`testId` is intentionally added as `@deprecated` because it is needed for backward compatibility with existing test infrastructure, but reliance on this is discouraged in favor of using semantic selectors. The plan will be to phase out this property in the next major release of Odyssey.
