### PR TITLE
fix: static tables to always have virtualization enabled

### DIFF
--- a/packages/odyssey-react-mui/src/labs/StaticTable.tsx
+++ b/packages/odyssey-react-mui/src/labs/StaticTable.tsx
@@ -95,7 +95,7 @@ const StaticTable = <TData extends DefaultMaterialReactTableData>({
       data={data}
       enableBottomToolbar={false}
       enablePagination={false}
-      enableRowVirtualization={data.length > 50}
+      enableRowVirtualization
       enableSorting={false}
       getRowId={getRowId}
       initialState={initialState}


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
`StaticTable` wouldn't work properly if the data amount changed after rendering. It either always needed virtualization or never needed it. It cannot be added after-the-fact based on the way the library works.

I've left it on always for now and can revisit exposing the option to consumers in the future with @jordankoschei-okta's new design changes.