### PR TITLE
fix: onGlobalFilterChange should fire when string removed

### DIFF
--- a/packages/odyssey-react-mui/src/labs/PaginatedTable.tsx
+++ b/packages/odyssey-react-mui/src/labs/PaginatedTable.tsx
@@ -82,7 +82,7 @@ const PaginatedTable = <TData extends DefaultMaterialReactTableData>({
   const [globalFilter, setGlobalFilter] = useState<string>();
 
   useEffect(() => {
-    if (globalFilter) {
+    if (globalFilter !== undefined) {
       onGlobalFilterChange?.(globalFilter);
     }
   }, [globalFilter, onGlobalFilterChange]);

--- a/packages/odyssey-react-mui/src/labs/StaticTable.tsx
+++ b/packages/odyssey-react-mui/src/labs/StaticTable.tsx
@@ -65,7 +65,7 @@ const StaticTable = <TData extends DefaultMaterialReactTableData>({
   const [globalFilter, setGlobalFilter] = useState<string>();
 
   useEffect(() => {
-    if (globalFilter) {
+    if (globalFilter !== undefined) {
       onGlobalFilterChange?.(globalFilter);
     }
   }, [globalFilter, onGlobalFilterChange]);


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
`onGlobalFilterChange` should fire when string removed, but it was gating by falsey values rather than `undefined`.