### PR TITLE
Add disabling of show/hide icon feature in PasswordField

### DIFF
--- a/packages/odyssey-react-mui/src/PasswordField.tsx
+++ b/packages/odyssey-react-mui/src/PasswordField.tsx
@@ -41,6 +41,10 @@ export type PasswordFieldProps = {
    */
   hasInitialFocus?: boolean;
   /**
+   * If `true`, the show/hide icon is not shown to the user
+   */
+  hasShowPassword?: boolean;
+  /**
    * The helper text content.
    */
   hint?: string;
@@ -60,10 +64,6 @@ export type PasswordFieldProps = {
    * It prevents the user from changing the value of the field
    */
   isReadOnly?: boolean;
-  /**
-   * If `true`, the show/hide icon is not shown to the user
-   */
-  isShowPasswordIconDisabled?: boolean;
   /**
    * The label for the `input` element.
    */
@@ -104,7 +104,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
       id: idOverride,
       isDisabled = false,
       isOptional = false,
-      isShowPasswordIconDisabled = false,
+      hasShowPassword = true,
       isReadOnly,
       label,
       name: nameOverride,
@@ -135,7 +135,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
           autoFocus={hasInitialFocus}
           data-se={testId}
           endAdornment={
-            !isShowPasswordIconDisabled && (
+            hasShowPassword && (
               <InputAdornment position="end">
                 <IconButton
                   aria-label={
@@ -176,7 +176,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
         placeholder,
         isOptional,
         isReadOnly,
-        isShowPasswordIconDisabled,
+        hasShowPassword,
         ref,
         testId,
         value,

--- a/packages/odyssey-react-mui/src/PasswordField.tsx
+++ b/packages/odyssey-react-mui/src/PasswordField.tsx
@@ -151,6 +151,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             )
           }
           id={id}
+          inputProps={{ role: "textbox" }}
           name={nameOverride ?? id}
           onChange={onChange}
           onFocus={onFocus}

--- a/packages/odyssey-react-mui/src/PasswordField.tsx
+++ b/packages/odyssey-react-mui/src/PasswordField.tsx
@@ -61,6 +61,10 @@ export type PasswordFieldProps = {
    */
   isReadOnly?: boolean;
   /**
+   * If `true`, the show/hide icon is not shown to the user
+   */
+  isShowPasswordIconDisabled?: boolean;
+  /**
    * The label for the `input` element.
    */
   label: string;
@@ -100,6 +104,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
       id: idOverride,
       isDisabled = false,
       isOptional = false,
+      isShowPasswordIconDisabled = false,
       isReadOnly,
       label,
       name: nameOverride,
@@ -130,18 +135,20 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
           autoFocus={hasInitialFocus}
           data-se={testId}
           endAdornment={
-            <InputAdornment position="end">
-              <IconButton
-                aria-label={
-                  inputType === "password"
-                    ? t("passwordfield.icon.label.show")
-                    : t("passwordfield.icon.label.hide")
-                }
-                onClick={togglePasswordVisibility}
-              >
-                {inputType === "password" ? <ShowIcon /> : <HideIcon />}
-              </IconButton>
-            </InputAdornment>
+            !isShowPasswordIconDisabled && (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label={
+                    inputType === "password"
+                      ? t("passwordfield.icon.label.show")
+                      : t("passwordfield.icon.label.hide")
+                  }
+                  onClick={togglePasswordVisibility}
+                >
+                  {inputType === "password" ? <ShowIcon /> : <HideIcon />}
+                </IconButton>
+              </InputAdornment>
+            )
           }
           id={id}
           name={nameOverride ?? id}
@@ -169,6 +176,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
         placeholder,
         isOptional,
         isReadOnly,
+        isShowPasswordIconDisabled,
         ref,
         testId,
         value,

--- a/packages/odyssey-storybook/src/components/odyssey-mui/PasswordField/PasswordField.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/PasswordField/PasswordField.stories.tsx
@@ -66,7 +66,7 @@ const storybookMeta: Meta<PasswordFieldProps> = {
     isOptional: {
       control: "boolean",
     },
-    isShowPasswordIconDisabled: {
+    hasShowPassword: {
       control: "boolean",
     },
     value: {
@@ -77,7 +77,7 @@ const storybookMeta: Meta<PasswordFieldProps> = {
     autoCompleteType: "current-password",
     label: "Password",
     isOptional: false,
-    isShowPasswordIconDisabled: false,
+    hasShowPassword: true,
     id: "password-input",
   },
   decorators: [MuiThemeDecorator],

--- a/packages/odyssey-storybook/src/components/odyssey-mui/PasswordField/PasswordField.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/PasswordField/PasswordField.stories.tsx
@@ -11,7 +11,7 @@
  */
 
 import { Meta, StoryObj } from "@storybook/react";
-import { screen } from "@storybook/testing-library";
+import { within } from "@storybook/testing-library";
 import {
   PasswordField,
   PasswordFieldProps,
@@ -86,14 +86,15 @@ const storybookMeta: Meta<PasswordFieldProps> = {
 export default storybookMeta;
 
 export const Default: StoryObj<PasswordFieldProps> = {
-  play: async ({ args, canvasElement, step }) => {
+  play: async ({ canvasElement, step }) => {
     await step("toggle password", async () => {
-      const fieldElement = canvasElement.querySelector(
-        `#${args.id}`
-      ) as HTMLInputElement;
-      expect(fieldElement.type).toBe("password");
+      const canvas = within(canvasElement);
+      const fieldElement = canvas.getByRole("textbox", {
+        name: "Password",
+      });
+      expect(fieldElement).toHaveAttribute("type", "password");
 
-      const buttonElement = screen.getByRole("button", {
+      const buttonElement = canvas.getByRole("button", {
         name: odysseyTranslate("passwordfield.icon.label.show"),
       });
       if (buttonElement) {
@@ -101,14 +102,14 @@ export const Default: StoryObj<PasswordFieldProps> = {
         userEvent.click(buttonElement);
         userEvent.tab();
         await waitFor(() => {
-          expect(fieldElement.type).toBe("text");
+          expect(fieldElement).toHaveAttribute("type", "text");
           expect(buttonElement.ariaLabel).toBe(
             odysseyTranslate("passwordfield.icon.label.hide")
           );
         });
         userEvent.click(buttonElement);
         await waitFor(() => {
-          expect(fieldElement.type).toBe("password");
+          expect(fieldElement).toHaveAttribute("type", "password");
           expect(buttonElement.ariaLabel).toBe(
             odysseyTranslate("passwordfield.icon.label.show")
           );
@@ -125,14 +126,15 @@ export const NoShowPassword: StoryObj<PasswordFieldProps> = {
   args: {
     hasShowPassword: false,
   },
-  play: async ({ args, canvasElement, step }) => {
+  play: async ({ canvasElement, step }) => {
     await step("toggle password", async () => {
-      const fieldElement = canvasElement.querySelector(
-        `#${args.id}`
-      ) as HTMLInputElement;
-      expect(fieldElement.type).toBe("password");
+      const canvas = within(canvasElement);
+      const fieldElement = canvas.getByRole("textbox", {
+        name: "Password",
+      });
+      expect(fieldElement).toHaveAttribute("type", "password");
 
-      const buttonElement = screen.queryByRole("button", {
+      const buttonElement = canvas.queryByRole("button", {
         name: odysseyTranslate("passwordfield.icon.label.show"),
       });
       expect(buttonElement).toBe(null);

--- a/packages/odyssey-storybook/src/components/odyssey-mui/PasswordField/PasswordField.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/PasswordField/PasswordField.stories.tsx
@@ -75,9 +75,10 @@ const storybookMeta: Meta<PasswordFieldProps> = {
   },
   args: {
     autoCompleteType: "current-password",
-    label: "Password",
+    hasShowPassword: true,
     isOptional: false,
     id: "password-input",
+    label: "Password",
   },
   decorators: [MuiThemeDecorator],
 };
@@ -131,9 +132,9 @@ export const NoShowPassword: StoryObj<PasswordFieldProps> = {
       ) as HTMLInputElement;
       expect(fieldElement.type).toBe("password");
 
-      const buttonElement = canvasElement.querySelector(
-        '[aria-label="toggle password visibility"]'
-      );
+      const buttonElement = screen.queryByRole("button", {
+        name: odysseyTranslate("passwordfield.icon.label.show"),
+      });
       expect(buttonElement).toBe(null);
     });
   },

--- a/packages/odyssey-storybook/src/components/odyssey-mui/PasswordField/PasswordField.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/PasswordField/PasswordField.stories.tsx
@@ -77,7 +77,6 @@ const storybookMeta: Meta<PasswordFieldProps> = {
     autoCompleteType: "current-password",
     label: "Password",
     isOptional: false,
-    hasShowPassword: true,
     id: "password-input",
   },
   decorators: [MuiThemeDecorator],
@@ -117,6 +116,25 @@ export const Default: StoryObj<PasswordFieldProps> = {
       await waitFor(() => {
         axeRun("Password Field Default");
       });
+    });
+  },
+};
+
+export const NoShowPassword: StoryObj<PasswordFieldProps> = {
+  args: {
+    hasShowPassword: false,
+  },
+  play: async ({ args, canvasElement, step }) => {
+    await step("toggle password", async () => {
+      const fieldElement = canvasElement.querySelector(
+        `#${args.id}`
+      ) as HTMLInputElement;
+      expect(fieldElement.type).toBe("password");
+
+      const buttonElement = canvasElement.querySelector(
+        '[aria-label="toggle password visibility"]'
+      );
+      expect(buttonElement).toBe(null);
     });
   },
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/PasswordField/PasswordField.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/PasswordField/PasswordField.stories.tsx
@@ -66,6 +66,9 @@ const storybookMeta: Meta<PasswordFieldProps> = {
     isOptional: {
       control: "boolean",
     },
+    isShowPasswordIconDisabled: {
+      control: "boolean",
+    },
     value: {
       control: "text",
     },
@@ -74,6 +77,7 @@ const storybookMeta: Meta<PasswordFieldProps> = {
     autoCompleteType: "current-password",
     label: "Password",
     isOptional: false,
+    isShowPasswordIconDisabled: false,
     id: "password-input",
   },
   decorators: [MuiThemeDecorator],


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

[OKTA-646382](https://oktainc.atlassian.net/browse/OKTA-646382)

## Summary
1. As per a request from the sign-in-widget team, we have added a prop `hasPasswordIcon` which is default true, but can be overloaded to `false`. When it is `false`, there is no show password eye icon in the `PasswordField`.
2. Added a new StoryObj `NoShowPassword` where `hasPasswordIcon` is set to `false`

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  3. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

<img width="926" alt="Screenshot 2023-09-25 at 3 13 45 PM" src="https://github.com/okta/odyssey/assets/109781221/eb9b5d98-f872-417f-9ca2-c1ef558eefc7">

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
