### PR TITLE
OKTA-649454: Add missing prop errorMessage to autocomplete

### DIFF
--- a/packages/odyssey-react-mui/src/Autocomplete.tsx
+++ b/packages/odyssey-react-mui/src/Autocomplete.tsx
@@ -43,6 +43,10 @@ export type AutocompleteProps<
    */
   hint?: string;
   /**
+   * The id attribute of the Select
+   */
+  id?: string;
+  /**
    * Allows the input of custom values
    */
   isCustomValueAllowed?: MuiAutocompleteProps<
@@ -87,6 +91,19 @@ export type AutocompleteProps<
    */
   label: string;
   /**
+   * The name of the `input` element. Defaults to the `id` if not set.
+   */
+  name?: string;
+  /**
+   * Callback fired when the autocomplete loses focus
+   */
+  onBlur?: MuiAutocompleteProps<
+    OptionType,
+    HasMultipleChoices,
+    undefined,
+    IsCustomValueAllowed
+  >["onBlur"];
+  /**
    * Callback fired when the value of the autocomplete input changes
    */
   onChange?: MuiAutocompleteProps<
@@ -104,6 +121,15 @@ export type AutocompleteProps<
     undefined,
     IsCustomValueAllowed
   >["onInputChange"];
+  /**
+   * Callback fired when the Select gains focus
+   */
+  onFocus?: MuiAutocompleteProps<
+    OptionType,
+    HasMultipleChoices,
+    undefined,
+    IsCustomValueAllowed
+  >["onFocus"];
   /**
    * The options for the Autocomplete input
    */
@@ -131,6 +157,7 @@ const Autocomplete = <
 >({
   errorMessage,
   hasMultipleChoices,
+  id: idOverride,
   isCustomValueAllowed,
   isDisabled,
   isLoading,
@@ -138,8 +165,11 @@ const Autocomplete = <
   isReadOnly,
   hint,
   label,
+  name: nameOverride,
+  onBlur,
   onChange,
   onInputChange,
+  onFocus,
   options,
   value,
   testId,
@@ -160,12 +190,13 @@ const Autocomplete = <
             {...InputProps}
             aria-describedby={ariaDescribedBy}
             id={id}
+            name={nameOverride ?? id}
             required={!isOptional}
           />
         )}
       />
     ),
-    [errorMessage, hint, isOptional, label]
+    [errorMessage, hint, isOptional, label, nameOverride]
   );
 
   return (
@@ -177,10 +208,13 @@ const Autocomplete = <
       disabled={isDisabled}
       freeSolo={isCustomValueAllowed}
       filterSelectedOptions={true}
+      id={idOverride}
       loading={isLoading}
       multiple={hasMultipleChoices}
+      onBlur={onBlur}
       onChange={onChange}
       onInputChange={onInputChange}
+      onFocus={onFocus}
       options={options}
       readOnly={isReadOnly}
       renderInput={renderInput}

--- a/packages/odyssey-react-mui/src/Autocomplete.tsx
+++ b/packages/odyssey-react-mui/src/Autocomplete.tsx
@@ -26,6 +26,10 @@ export type AutocompleteProps<
   IsCustomValueAllowed extends boolean | undefined
 > = {
   /**
+   * The error message for the Select
+   */
+  errorMessage?: string;
+  /**
    * Enables multiple choice selection
    */
   hasMultipleChoices?: MuiAutocompleteProps<
@@ -125,6 +129,7 @@ const Autocomplete = <
   HasMultipleChoices extends boolean | undefined,
   IsCustomValueAllowed extends boolean | undefined
 >({
+  errorMessage,
   hasMultipleChoices,
   isCustomValueAllowed,
   isDisabled,
@@ -142,6 +147,7 @@ const Autocomplete = <
   const renderInput = useCallback(
     ({ InputLabelProps, InputProps, ...params }) => (
       <Field
+        errorMessage={errorMessage}
         fieldType="single"
         hasVisibleLabel
         id={InputLabelProps.htmlFor}
@@ -159,7 +165,7 @@ const Autocomplete = <
         )}
       />
     ),
-    [hint, isOptional, label]
+    [errorMessage, hint, isOptional, label]
   );
 
   return (

--- a/packages/odyssey-react-mui/src/Autocomplete.tsx
+++ b/packages/odyssey-react-mui/src/Autocomplete.tsx
@@ -95,7 +95,7 @@ export type AutocompleteProps<
    */
   name?: string;
   /**
-   * Callback fired when the autocomplete loses focus
+   * Callback fired when the autocomplete loses focus.
    */
   onBlur?: MuiAutocompleteProps<
     OptionType,
@@ -104,7 +104,7 @@ export type AutocompleteProps<
     IsCustomValueAllowed
   >["onBlur"];
   /**
-   * Callback fired when the value of the autocomplete input changes
+   * Callback fired when a selection is made.
    */
   onChange?: MuiAutocompleteProps<
     OptionType,
@@ -113,7 +113,7 @@ export type AutocompleteProps<
     IsCustomValueAllowed
   >["onChange"];
   /**
-   * Callback fired when the input value of the autocomplete input changes
+   * Callback fired when the textbox receives typed characters.
    */
   onInputChange?: MuiAutocompleteProps<
     OptionType,
@@ -122,7 +122,7 @@ export type AutocompleteProps<
     IsCustomValueAllowed
   >["onInputChange"];
   /**
-   * Callback fired when the Select gains focus
+   * Callback fired when the autocomplete gains focus.
    */
   onFocus?: MuiAutocompleteProps<
     OptionType,

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
@@ -152,7 +152,8 @@ const storybookMeta: Meta<typeof Autocomplete> = {
     },
     onBlur: {
       control: null,
-      description: "Callback fired when the autocomplete component loses focus",
+      description:
+        "Callback fired when the autocomplete component loses focus.",
       table: {
         type: {
           summary: "func",
@@ -162,8 +163,7 @@ const storybookMeta: Meta<typeof Autocomplete> = {
     },
     onChange: {
       control: null,
-      description:
-        "Callback fired when the value of the autocomplete input changes",
+      description: "Callback fired when a selection is made.",
       table: {
         type: {
           summary: "func",
@@ -173,8 +173,7 @@ const storybookMeta: Meta<typeof Autocomplete> = {
     },
     onInputChange: {
       control: null,
-      description:
-        "Callback fired when the input value of the autocomplete input changes",
+      description: "Callback fired when the textbox receives typed characters.",
       table: {
         type: {
           summary: "func",
@@ -184,7 +183,8 @@ const storybookMeta: Meta<typeof Autocomplete> = {
     },
     onFocus: {
       control: null,
-      description: "Callback fired when the select component gains focus",
+      description:
+        "Callback fired when the autocomplete component gains focus.",
       table: {
         type: {
           summary: "func",

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
@@ -50,6 +50,15 @@ const storybookMeta: Meta<typeof Autocomplete> = {
   title: "MUI Components/Forms/Autocomplete",
   component: Autocomplete,
   argTypes: {
+    errorMessage: {
+      control: "text",
+      description: "The error message for the select component",
+      table: {
+        type: {
+          summary: "string",
+        },
+      },
+    },
     hasMultipleChoices: {
       control: "boolean",
       description: "Enables multiple choice selection",
@@ -89,6 +98,15 @@ const storybookMeta: Meta<typeof Autocomplete> = {
     isLoading: {
       control: "boolean",
       description: "Displays a loading indicator",
+      table: {
+        type: {
+          summary: "boolean",
+        },
+      },
+    },
+    isOptional: {
+      control: "boolean",
+      description: "If `true`, the select component is optional",
       table: {
         type: {
           summary: "boolean",
@@ -301,6 +319,12 @@ export const MultipleReadOnly: StoryObj<AutocompleteType> = {
     hasMultipleChoices: true,
     isReadOnly: true,
     value: [{ label: "Tycho Station" }],
+  },
+};
+
+export const Optional: StoryObj<AutocompleteType> = {
+  args: {
+    isOptional: true,
   },
 };
 

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
@@ -77,6 +77,15 @@ const storybookMeta: Meta<typeof Autocomplete> = {
         },
       },
     },
+    id: {
+      control: "text",
+      description: "The id attribute of the autocomplete component",
+      table: {
+        type: {
+          summary: "string",
+        },
+      },
+    },
     isCustomValueAllowed: {
       control: "boolean",
       description: "Allows the input of custom values",
@@ -131,6 +140,26 @@ const storybookMeta: Meta<typeof Autocomplete> = {
         },
       },
     },
+    name: {
+      control: "text",
+      description:
+        "The name of the select component. Defaults to the `id` if not set.",
+      table: {
+        type: {
+          summary: "string",
+        },
+      },
+    },
+    onBlur: {
+      control: null,
+      description: "Callback fired when the autocomplete component loses focus",
+      table: {
+        type: {
+          summary: "func",
+        },
+        defaultValue: "",
+      },
+    },
     onChange: {
       control: null,
       description:
@@ -146,6 +175,16 @@ const storybookMeta: Meta<typeof Autocomplete> = {
       control: null,
       description:
         "Callback fired when the input value of the autocomplete input changes",
+      table: {
+        type: {
+          summary: "func",
+        },
+        defaultValue: "",
+      },
+    },
+    onFocus: {
+      control: null,
+      description: "Callback fired when the select component gains focus",
       table: {
         type: {
           summary: "func",

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
@@ -214,6 +214,17 @@ export const Disabled: StoryObj<AutocompleteType> = {
   },
 };
 
+export const Error: StoryObj<AutocompleteType> = {
+  args: {
+    errorMessage: "Select your destination.",
+  },
+  play: async ({ step }) => {
+    await step("Check for a11y errors on Select Error", async () => {
+      await waitFor(() => axeRun("Select Error"));
+    });
+  },
+};
+
 export const IsCustomValueAllowed: StoryObj<AutocompleteType> = {
   parameters: {
     docs: {

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
@@ -213,8 +213,9 @@ const storybookMeta: Meta<typeof Autocomplete> = {
     },
   },
   args: {
-    label: "Destination",
     hint: "Select your destination in the Sol system.",
+    id: "testId",
+    label: "Destination",
     options: stations,
   },
   decorators: [MuiThemeDecorator],
@@ -260,6 +261,10 @@ export const Default: StoryObj<AutocompleteType> = {
       userEvent.click(clearButton);
       expect(comboBoxElement.value).toBe("");
       userEvent.tab();
+    });
+    step("Check id and name", () => {
+      expect(comboBoxElement.getAttribute("id")).toBe("testId");
+      expect(comboBoxElement.getAttribute("name")).toBe("testId");
     });
   },
 };
@@ -317,6 +322,7 @@ export const Loading: StoryObj<AutocompleteType> = {
 export const Multiple: StoryObj<AutocompleteType> = {
   args: {
     hasMultipleChoices: true,
+    name: "testName",
   },
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
@@ -341,6 +347,10 @@ export const Multiple: StoryObj<AutocompleteType> = {
         expect(comboBoxElement.value).toBe("");
         userEvent.tab();
       });
+    });
+    step("Check id and name", () => {
+      expect(comboBoxElement.getAttribute("id")).toBe("testId");
+      expect(comboBoxElement.getAttribute("name")).toBe("testName");
     });
   },
 };


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

[OKTA-649454](https://oktainc.atlassian.net/browse/OKTA-649454)

## Summary

1. Added `errorMessage` prop and Storybook object with example
2. Added `isOptional` prop to Storybook (was there before but not in stories)
3. Added `onBlur` and `onFocus` props
4. Added `id` and `name` props

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  5. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots
errorMessage
![Screenshot 2023-09-28 at 11 23 37 AM](https://github.com/okta/odyssey/assets/109781221/97faee0c-61a4-480b-b9cd-5bb374b56111)

isOptional
![Screenshot 2023-09-28 at 11 24 18 AM](https://github.com/okta/odyssey/assets/109781221/53d9cb98-e9d1-4ea3-be1e-5322d6c9a96e)

onBlur/onFocus
https://github.com/okta/odyssey/assets/109781221/cf8cbbdc-a453-4d09-bf0b-9212a55a6a29

id/name
https://github.com/okta/odyssey/assets/109781221/897b8943-1290-4159-9d75-d5a8bd9f8eb6



- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
