### PR TITLE
OKTA-653386: gray color in default Status lamp variant

### DIFF
--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -688,7 +688,7 @@ export const components = ({
               height: ".64em",
               marginInlineEnd: odysseyTokens.Spacing2,
               borderRadius: "100%",
-              backgroundColor: "transparent",
+              backgroundColor: odysseyTokens.HueNeutral600,
               borderColor: odysseyTokens.TypographyColorBody,
               borderWidth: odysseyTokens.BorderWidthHeavy,
               borderStyle: odysseyTokens.BorderStyleMain,


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

[OKTA-653386](https://oktainc.atlassian.net/browse/OKTA-653386)

## Summary

Changed the background color of the default lamp Status from `transparent` to `gray` using design tokens. The pill variant was already correct.
[Odyssey design shows that the correct background color is gray](https://odyssey.okta.design/latest/components/status/design-rRsXKZjT#section-severity-4d)
<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

Before:
<img width="1022" alt="image" src="https://github.com/okta/odyssey/assets/140422233/229a800e-0c53-41fe-be66-ed94458102a5">

After:
<img width="1022" alt="image" src="https://github.com/okta/odyssey/assets/140422233/57d5205a-7ddf-482e-9156-bbcae6de3e62">

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
