### PR TITLE
fix: concurrency in Applitools being too high

### DIFF
--- a/packages/odyssey-storybook/applitools.config.js
+++ b/packages/odyssey-storybook/applitools.config.js
@@ -26,5 +26,5 @@ module.exports = {
   matchLevel: "Strict",
   parentBranchName,
   showStorybookOutput: true,
-  testConcurrency: 20,
+  testConcurrency: 10,
 };


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

https://oktainc.atlassian.net/browse/OKTA-651614

## Summary

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->
Applitools had too high of a concurrency for our plan. This has been taken down to only 10 threads to reduce the workload.

## Testing & Screenshots

- [X] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
N/A