### PR TITLE
OKTA-651827: make tabs controlled

### DIFF
--- a/packages/odyssey-react-mui/src/Tabs.tsx
+++ b/packages/odyssey-react-mui/src/Tabs.tsx
@@ -10,9 +10,10 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import React, {
+import {
   ReactElement,
   ReactNode,
+  SyntheticEvent,
   memo,
   useCallback,
   useEffect,
@@ -67,16 +68,29 @@ export type TabsProps = {
    * Identifier for the selected tab.
    */
   value?: string;
+  /**
+   * Callback fired when the active tab is changed.
+   */
+  onChange?: (event: SyntheticEvent, value: string) => void;
 };
 
-const Tabs = ({ ariaLabel, initialValue, tabs, value }: TabsProps) => {
+const Tabs = ({
+  ariaLabel,
+  initialValue,
+  tabs,
+  value,
+  onChange,
+}: TabsProps) => {
   const [tabState, setTabState] = useState(initialValue ?? value ?? "0");
 
-  const onChange = useCallback(
-    (_event: React.SyntheticEvent, newState: string) => {
-      setTabState(newState);
+  const handleChange = useCallback(
+    (_event: SyntheticEvent, value: string) => {
+      setTabState(value);
+      if (onChange) {
+        onChange(_event, value);
+      }
     },
-    []
+    [onChange]
   );
 
   useEffect(() => {
@@ -87,7 +101,7 @@ const Tabs = ({ ariaLabel, initialValue, tabs, value }: TabsProps) => {
 
   return (
     <MuiTabContext value={tabState}>
-      <MuiTabList onChange={onChange} aria-label={ariaLabel}>
+      <MuiTabList onChange={handleChange} aria-label={ariaLabel}>
         {tabs.map((tab, index) => (
           <MuiTab
             data-se={tab.testId}

--- a/packages/odyssey-react-mui/src/Tabs.tsx
+++ b/packages/odyssey-react-mui/src/Tabs.tsx
@@ -11,20 +11,20 @@
  */
 
 import {
+  TabContext as MuiTabContext,
+  TabList as MuiTabList,
+  TabListProps as MuiTabListProps,
+  TabPanel as MuiTabPanel,
+} from "@mui/lab";
+import { Tab as MuiTab } from "@mui/material";
+import {
   ReactElement,
   ReactNode,
-  SyntheticEvent,
   memo,
   useCallback,
   useEffect,
   useState,
 } from "react";
-import { Tab as MuiTab } from "@mui/material";
-import {
-  TabList as MuiTabList,
-  TabPanel as MuiTabPanel,
-  TabContext as MuiTabContext,
-} from "@mui/lab";
 import { SeleniumProps } from "./SeleniumProps";
 
 export type TabItemProps = {
@@ -71,7 +71,7 @@ export type TabsProps = {
   /**
    * Callback fired when the active tab is changed.
    */
-  onChange?: (event: SyntheticEvent, value: string) => void;
+  onChange?: MuiTabListProps["onChange"];
 };
 
 const Tabs = ({
@@ -79,18 +79,16 @@ const Tabs = ({
   initialValue,
   tabs,
   value,
-  onChange,
+  onChange: onChangeProp,
 }: TabsProps) => {
   const [tabState, setTabState] = useState(initialValue ?? value ?? "0");
 
-  const handleChange = useCallback(
-    (event: SyntheticEvent, value: string) => {
+  const onChange = useCallback<NonNullable<MuiTabListProps["onChange"]>>(
+    (event, value: string) => {
       setTabState(value);
-      if (onChange) {
-        onChange(event, value);
-      }
+      onChangeProp?.(event, value);
     },
-    [onChange]
+    [onChangeProp]
   );
 
   useEffect(() => {
@@ -101,7 +99,7 @@ const Tabs = ({
 
   return (
     <MuiTabContext value={tabState}>
-      <MuiTabList onChange={handleChange} aria-label={ariaLabel}>
+      <MuiTabList onChange={onChange} aria-label={ariaLabel}>
         {tabs.map((tab, index) => (
           <MuiTab
             data-se={tab.testId}

--- a/packages/odyssey-react-mui/src/Tabs.tsx
+++ b/packages/odyssey-react-mui/src/Tabs.tsx
@@ -84,10 +84,10 @@ const Tabs = ({
   const [tabState, setTabState] = useState(initialValue ?? value ?? "0");
 
   const handleChange = useCallback(
-    (_event: SyntheticEvent, value: string) => {
+    (event: SyntheticEvent, value: string) => {
       setTabState(value);
       if (onChange) {
-        onChange(_event, value);
+        onChange(event, value);
       }
     },
     [onChange]

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
@@ -89,7 +89,6 @@ const storybookMeta: Meta<TabsProps & TabItemProps> = {
         type: {
           summary: "func",
         },
-        defaultValue: "",
       },
     },
   },
@@ -220,7 +219,6 @@ export const Controlled: StoryObj<TabItemProps> = {
           tabs={tabs}
           onChange={onChange}
         />
-        <br />
         <Typography>{`Current tab is ${value}`}</Typography>
         <Button
           label="Navigate to Galaxies externally"

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
@@ -10,9 +10,16 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
-import { TabItemProps, TabsProps, Tabs } from "@okta/odyssey-react-mui";
+import {
+  Button,
+  TabItemProps,
+  Tabs,
+  TabsProps,
+  Typography,
+} from "@okta/odyssey-react-mui";
 import { BugIcon } from "@okta/odyssey-react-mui/icons";
 import { MuiThemeDecorator } from "../../../../.storybook/components";
 import { userEvent, waitFor, within } from "@storybook/testing-library";
@@ -73,6 +80,16 @@ const storybookMeta: Meta<TabsProps & TabItemProps> = {
         type: {
           summary: "string",
         },
+      },
+    },
+    onChange: {
+      control: null,
+      description: "Callback fired when the active tab is changed",
+      table: {
+        type: {
+          summary: "func",
+        },
+        defaultValue: "",
       },
     },
   },
@@ -166,5 +183,54 @@ export const Icons: StoryObj<TabItemProps> = {
   },
   play: async ({ canvasElement, step }) => {
     selectTab({ canvasElement, step })("Tab Icon", "Xenomorphs");
+  },
+};
+
+export const Controlled: StoryObj<TabItemProps> = {
+  render: function C() {
+    const [value, setValue] = useState("planets");
+
+    const onChange = (_e: unknown, value: string) => {
+      setValue(value);
+    };
+
+    const tabs: TabItemProps[] = [
+      {
+        label: "Planets",
+        value: "planets",
+        children: "Information about Planets",
+      },
+      {
+        label: "Moons",
+        value: "moons",
+        children: "Information about Moons",
+      },
+      {
+        label: "Galaxies",
+        value: "galaxies",
+        children: "Information about Galaxies",
+      },
+    ];
+
+    return (
+      <>
+        <Tabs
+          value={value}
+          ariaLabel="controlled tabs example"
+          tabs={tabs}
+          onChange={onChange}
+        />
+        <br />
+        <Typography>{`Current tab is ${value}`}</Typography>
+        <Button
+          label="Navigate to Galaxies externally"
+          variant="primary"
+          onClick={() => {
+            setValue("galaxies");
+          }}
+          size="small"
+        />
+      </>
+    );
   },
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
@@ -13,7 +13,13 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 
-import { Button, TabItemProps, Tabs, TabsProps } from "@okta/odyssey-react-mui";
+import {
+  Box,
+  Button,
+  TabItemProps,
+  Tabs,
+  TabsProps,
+} from "@okta/odyssey-react-mui";
 import { BugIcon } from "@okta/odyssey-react-mui/icons";
 import { expect } from "@storybook/jest";
 import { userEvent, waitFor, within } from "@storybook/testing-library";
@@ -213,14 +219,16 @@ export const Controlled: StoryObj<TabItemProps> = {
           tabs={tabs}
           onChange={onChange}
         />
-        <Button
-          label="Navigate to Galaxies"
-          variant="primary"
-          onClick={() => {
-            setValue("galaxies");
-          }}
-          size="small"
-        />
+        <Box sx={{ marginTop: 4 }}>
+          <Button
+            label="Navigate to Galaxies"
+            variant="primary"
+            onClick={() => {
+              setValue("galaxies");
+            }}
+            size="small"
+          />
+        </Box>
       </>
     );
   },

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
@@ -10,23 +10,17 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
 
-import {
-  Button,
-  TabItemProps,
-  Tabs,
-  TabsProps,
-  Typography,
-} from "@okta/odyssey-react-mui";
+import { Button, TabItemProps, Tabs, TabsProps } from "@okta/odyssey-react-mui";
 import { BugIcon } from "@okta/odyssey-react-mui/icons";
-import { MuiThemeDecorator } from "../../../../.storybook/components";
-import { userEvent, waitFor, within } from "@storybook/testing-library";
 import { expect } from "@storybook/jest";
+import { userEvent, waitFor, within } from "@storybook/testing-library";
+import { MuiThemeDecorator } from "../../../../.storybook/components";
+import icons from "../../../../.storybook/components/iconUtils";
 import { axeRun } from "../../../axe-util";
 import type { PlaywrightProps } from "../storybookTypes";
-import icons from "../../../../.storybook/components/iconUtils";
 
 const storybookMeta: Meta<TabsProps & TabItemProps> = {
   title: "MUI Components/Tabs",
@@ -219,9 +213,8 @@ export const Controlled: StoryObj<TabItemProps> = {
           tabs={tabs}
           onChange={onChange}
         />
-        <Typography>{`Current tab is ${value}`}</Typography>
         <Button
-          label="Navigate to Galaxies externally"
+          label="Navigate to Galaxies"
           variant="primary"
           onClick={() => {
             setValue("galaxies");

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
@@ -189,7 +189,7 @@ export const Controlled: StoryObj<TabItemProps> = {
   render: function C() {
     const [value, setValue] = useState("planets");
 
-    const onChange = (_e: unknown, value: string) => {
+    const onChange: TabsProps["onChange"] = (_e: unknown, value: string) => {
       setValue(value);
     };
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

[OKTA-651827](https://oktainc.atlassian.net/browse/OKTA-651827)

## Summary

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->
This allows an `onChange` prop to the `Tabs` component, to allow control, which gets called if it's defined, when the selected tab changes.

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<img width="1026" alt="image" src="https://github.com/okta/odyssey/assets/140422233/9b3edf7a-4e28-48e8-a65f-02b9f4a4acb7">

<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
