### PR TITLE
fix: remove ":" from ScreenReaderText in Callout

### DIFF
--- a/packages/odyssey-react-mui/src/Callout.tsx
+++ b/packages/odyssey-react-mui/src/Callout.tsx
@@ -51,7 +51,7 @@ const Callout = ({ children, role, severity, testId, title }: CalloutProps) => {
 
   return (
     <Alert data-se={testId} role={role} severity={severity} variant="callout">
-      <ScreenReaderText>{t(`severity.${severity}`)}: </ScreenReaderText>
+      <ScreenReaderText>{t(`severity.${severity}`)}</ScreenReaderText>
       {title && <AlertTitle>{title}</AlertTitle>}
       <Box component="div">{children}</Box>
     </Alert>


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

OKTA-653209

## Summary

I removed the hardcoded ":" in from ScreenReaderText element in `Callout` that was non-compliant with our translated strings approach. The change is only noticeable in the source code and to screen readers as they read label value of an icon in a `Callout`  


## Testing & Screenshots

I tested the output before and after via screen reader and there is no difference in what is voiced. The text output in english changes from "info:, <callout message text>" to "info, <callout message text>" so I don't believe we'll need to adjust the translated values.