### PR TITLE
feat(odyssey-react-mui): wrapped typography component with context

### DIFF
--- a/packages/odyssey-react-mui/src/Typography.tsx
+++ b/packages/odyssey-react-mui/src/Typography.tsx
@@ -14,8 +14,9 @@ import {
   Typography as MuiTypography,
   TypographyProps as MuiTypographyProps,
 } from "@mui/material";
-import { ElementType, ReactNode, memo, useMemo } from "react";
+import { ElementType, ReactNode, memo, useCallback, useMemo } from "react";
 import { SeleniumProps } from "./SeleniumProps";
+import { MuiPropsContext } from "./MuiPropsContext";
 
 export type TypographyVariantValue =
   | "h1"
@@ -107,17 +108,34 @@ const Typography = ({
     return componentProp;
   }, [componentProp, variant]);
 
+  const renderTypography = useCallback(
+    (muiProps) => (
+      <MuiTypography
+        {...muiProps}
+        aria-describedby={ariaDescribedBy}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        children={children}
+        color={color}
+        component={component}
+        data-se={testId}
+        variant={typographyVariantMapping[variant]}
+      />
+    ),
+    [
+      ariaDescribedBy,
+      ariaLabel,
+      ariaLabelledBy,
+      children,
+      color,
+      component,
+      testId,
+      variant,
+    ]
+  );
+
   return (
-    <MuiTypography
-      aria-describedby={ariaDescribedBy}
-      aria-label={ariaLabel}
-      aria-labelledby={ariaLabelledBy}
-      children={children}
-      color={color}
-      component={component}
-      data-se={testId}
-      variant={typographyVariantMapping[variant]}
-    />
+    <MuiPropsContext.Consumer>{renderTypography}</MuiPropsContext.Consumer>
   );
 };
 

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tooltip/Tooltip.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tooltip/Tooltip.stories.tsx
@@ -13,6 +13,7 @@
 import { Meta, StoryObj } from "@storybook/react";
 import {
   Button,
+  Paragraph,
   Status,
   Tag,
   Tooltip,
@@ -144,6 +145,16 @@ export const IconButton: StoryObj<TooltipProps> = {
     ariaType: "label",
     placement: "top",
     text: "Download logs",
+  },
+};
+
+export const ParagraphWrapper: StoryObj<TooltipProps> = {
+  ...Template,
+  args: {
+    children: <Paragraph children="This is body copy." variant="body" />,
+    ariaType: "label",
+    placement: "top",
+    text: "This is a tooltip on body copy.",
   },
 };
 


### PR DESCRIPTION
Wrapped the Typography component with context so that other components, like Tooltip, can create a `ref` to it and wrap it.

[OKTA-658896](https://oktainc.atlassian.net/browse/OKTA-658896)

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
