### PR TITLE
fix(odyssey-react-mui): add displayName to Tooltip component

### DIFF
--- a/packages/odyssey-react-mui/src/Tooltip.tsx
+++ b/packages/odyssey-react-mui/src/Tooltip.tsx
@@ -52,3 +52,5 @@ export const Tooltip = ({
     <MuiPropsChild>{children}</MuiPropsChild>
   </MuiTooltip>
 );
+
+Tooltip.displayName = "Tooltip";

--- a/packages/odyssey-react-mui/src/Tooltip.tsx
+++ b/packages/odyssey-react-mui/src/Tooltip.tsx
@@ -14,7 +14,7 @@ import { Tooltip as MuiTooltip } from "@mui/material";
 import type { TooltipProps as MuiTooltipProps } from "@mui/material";
 
 import { MuiPropsChild } from "./MuiPropsChild";
-import { ReactElement } from "react";
+import { ReactElement, memo } from "react";
 import { SeleniumProps } from "./SeleniumProps";
 
 export type TooltipProps = {
@@ -36,7 +36,7 @@ export type TooltipProps = {
   text: string;
 } & SeleniumProps;
 
-export const Tooltip = ({
+const Tooltip = ({
   ariaType,
   children,
   placement = "top",
@@ -53,4 +53,7 @@ export const Tooltip = ({
   </MuiTooltip>
 );
 
-Tooltip.displayName = "Tooltip";
+const MemoizedTooltip = memo(Tooltip);
+MemoizedTooltip.displayName = "Tooltip";
+
+export { MemoizedTooltip as Tooltip };


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->
Adds `displayName` to the `Tooltip` component so it displays correctly in Storybooks
[OKTA-659417](https://oktainc.atlassian.net/browse/OKTA-659417)

## Summary

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
