### PR TITLE
fix(odyssey-react-mui): update Tab styles to match Figma

### DIFF
--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -2080,11 +2080,8 @@ export const components = ({
           fontFamily: odysseyTokens.TypographyFamilyHeading,
           lineHeight: odysseyTokens.TypographyLineHeightUi,
           overflow: "visible",
-
-          ...(ownerState.textColor === "inherit" && {
-            color: odysseyTokens.HueNeutral600,
-            opacity: 1,
-          }),
+          color: odysseyTokens.HueNeutral600,
+          opacity: 1,
 
           ...(ownerState.selected == true && {
             color: odysseyTokens.TypographyColorAction,

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -2075,7 +2075,8 @@ export const components = ({
           maxWidth: `calc(${odysseyTokens.TypographyLineLengthMax} / 2)`,
           minWidth: "unset",
           minHeight: "unset",
-          padding: `${odysseyTokens.Spacing4} 0`,
+          padding: `${odysseyTokens.Spacing4} ${odysseyTokens.Spacing1}`,
+          fontSize: odysseyTokens.TypographySizeHeading6,
           fontFamily: odysseyTokens.TypographyFamilyHeading,
           lineHeight: odysseyTokens.TypographyLineHeightUi,
           overflow: "visible",
@@ -2087,7 +2088,7 @@ export const components = ({
 
           ...(ownerState.selected == true && {
             color: odysseyTokens.TypographyColorAction,
-            fontWeight: odysseyTokens.TypographyWeightBodyBold,
+            fontWeight: odysseyTokens.TypographyWeightHeading,
           }),
 
           ...(ownerState.disabled && {

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -2082,7 +2082,7 @@ export const components = ({
           overflow: "visible",
 
           ...(ownerState.textColor === "inherit" && {
-            color: "inherit",
+            color: odysseyTokens.HueNeutral600,
             opacity: 1,
           }),
 


### PR DESCRIPTION
[OKTA-658452](https://oktainc.atlassian.net/browse/OKTA-658452)

## Summary

Visual updates to match the [Figma component](https://www.figma.com/file/zh7A9gjaDlI50Hctdvd1OB/Odyssey-Components?type=design&node-id=83-485)

* Left and right padding added (`4px`) to `Tab` label 
* `font-size` updated from ~`13px` (`body`) to ~`16px` (`heading 6`)
* `font-weight` changed from `600` (`bodyBold`) to `500` (`heading`)
* default `color` changed from `inherit` to `Neutral 600`

## Testing & Screenshots

- [ x] I have confirmed this change with my designer and the Odyssey Design Team.

![Tabs](https://github.com/okta/odyssey/assets/147574410/d06805ef-af35-49b5-8fe6-dd21cfe7a1b4)

