### PR TITLE
Fix Select `onChange` type being `unknown`

### DIFF
--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -43,6 +43,10 @@ export type SelectProps<
    */
   errorMessage?: string;
   /**
+   * If `true`, the Select allows multiple selections
+   */
+  hasMultipleChoices?: HasMultipleChoices;
+  /**
    * The hint text for the Select
    */
   hint?: string;
@@ -55,8 +59,9 @@ export type SelectProps<
    */
   isDisabled?: boolean;
   /**
-   * If `true`, the Select allows multiple selections
+   * @deprecated Use `hasMultipleChoices` instead.
    */
+  /** **Deprecated:** use `hasMultipleChoices` */
   isMultiSelect?: HasMultipleChoices;
   /**
    * If `true`, the Select is optional
@@ -112,6 +117,7 @@ const Select = <
   HasMultipleChoices extends boolean
 >({
   errorMessage,
+  hasMultipleChoices: hasMultipleChoicesProp,
   hint,
   id: idOverride,
   isDisabled = false,
@@ -122,9 +128,9 @@ const Select = <
   onBlur,
   onChange: onChangeProp,
   onFocus,
-  value,
-  testId,
   options,
+  testId,
+  value,
 }: SelectProps<Value, HasMultipleChoices>) => {
   const hasMultipleChoices = useMemo(
     () =>
@@ -133,6 +139,13 @@ const Select = <
         : hasMultipleChoicesProp,
     [hasMultipleChoicesProp, isMultiSelect]
   );
+
+  const formattedValueForMultiSelect =
+    value === undefined
+      ? isMultiSelect
+        ? ([] as string[] as Value)
+        : ("" as string as Value)
+      : value;
 
   const formattedValueForMultiSelect = isMultiSelect
     ? ([] as string[] as Value)
@@ -147,7 +160,7 @@ const Select = <
       const valueFromEvent = event.target.value;
 
       if (typeof valueFromEvent === "string") {
-        if (isMultiSelect) {
+        if (hasMultipleChoices) {
           setSelectedValue(valueFromEvent.split(",") as Value);
         } else {
           setSelectedValue(valueFromEvent as Value);
@@ -158,7 +171,7 @@ const Select = <
 
       onChangeProp?.(event, child);
     },
-    [isMultiSelect, onChangeProp, setSelectedValue]
+    [hasMultipleChoices, onChangeProp, setSelectedValue]
   );
 
   // Normalize the options array to accommodate the various
@@ -222,7 +235,7 @@ const Select = <
 
         return (
           <MenuItem key={option.value} value={option.value}>
-            {isMultiSelect && (
+            {hasMultipleChoices && (
               <MuiCheckbox checked={selectedValue.includes(option.value)} />
             )}
             {option.text}
@@ -234,30 +247,30 @@ const Select = <
           </MenuItem>
         );
       }),
-    [isMultiSelect, normalizedOptions, selectedValue]
+    [hasMultipleChoices, normalizedOptions, selectedValue]
   );
 
   const renderFieldComponent = useCallback(
     ({ ariaDescribedBy, errorMessageElementId, id, labelElementId }) => (
       <MuiSelect
+        aria-describedby={ariaDescribedBy}
+        aria-errormessage={errorMessageElementId}
         children={children}
         data-se={testId}
         id={id}
-        aria-errormessage={errorMessageElementId}
-        aria-describedby={ariaDescribedBy}
         labelId={labelElementId}
-        multiple={isMultiSelect}
+        multiple={hasMultipleChoices}
         name={nameOverride ?? id}
         onBlur={onBlur}
         onChange={onChange}
         onFocus={onFocus}
-        renderValue={isMultiSelect ? renderValue : undefined}
+        renderValue={hasMultipleChoices ? renderValue : undefined}
         value={selectedValue}
       />
     ),
     [
       children,
-      isMultiSelect,
+      hasMultipleChoices,
       nameOverride,
       onBlur,
       onChange,

--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -140,13 +140,6 @@ const Select = <
     [hasMultipleChoicesProp, isMultiSelect]
   );
 
-  const formattedValueForMultiSelect =
-    value === undefined
-      ? isMultiSelect
-        ? ([] as string[] as Value)
-        : ("" as string as Value)
-      : value;
-
   const formattedValueForMultiSelect = isMultiSelect
     ? ([] as string[] as Value)
     : ("" as string as Value);

--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -94,7 +94,7 @@ export type SelectProps<
   /**
    * The value or values selected in the Select
    */
-  value: Value;
+  value?: Value;
 } & SeleniumProps;
 
 /**

--- a/packages/odyssey-react-mui/src/index.ts
+++ b/packages/odyssey-react-mui/src/index.ts
@@ -66,6 +66,7 @@ export * from "./Callout";
 export * from "./Checkbox";
 export * from "./CheckboxGroup";
 export * from "./CircularProgress";
+export * from "./createShadowDom";
 export * from "./createUniqueId";
 export * from "./Dialog";
 export * from "./Fieldset";

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Select/Select.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Select/Select.stories.tsx
@@ -17,7 +17,7 @@ import { userEvent, waitFor, screen } from "@storybook/testing-library";
 import { axeRun } from "../../../axe-util";
 import { expect } from "@storybook/jest";
 
-const optionsArray: SelectProps["options"] = [
+const optionsArray: SelectProps<string | string[], boolean>["options"] = [
   "Earth",
   "Mars",
   "Ceres",
@@ -27,7 +27,7 @@ const optionsArray: SelectProps["options"] = [
   "Ganymede",
 ];
 
-const optionsObject: SelectProps["options"] = [
+const optionsObject: SelectProps<string | string[], boolean>["options"] = [
   {
     text: "Earth",
     value: "earth",
@@ -58,7 +58,7 @@ const optionsObject: SelectProps["options"] = [
   },
 ];
 
-const optionsGrouped: SelectProps["options"] = [
+const optionsGrouped: SelectProps<string | string[], boolean>["options"] = [
   {
     text: "Sol System",
     type: "heading",
@@ -102,7 +102,7 @@ const optionsGrouped: SelectProps["options"] = [
   "New Terra",
 ];
 
-const storybookMeta: Meta<SelectProps> = {
+const storybookMeta: Meta<SelectProps<string | string[], boolean>> = {
   title: "MUI Components/Forms/Select",
   component: Select,
   argTypes: {
@@ -112,6 +112,18 @@ const storybookMeta: Meta<SelectProps> = {
       table: {
         type: {
           summary: "string",
+        },
+      },
+    },
+    hasMultipleChoices: {
+      control: "boolean",
+      description: "If `true`, the select component allows multiple selections",
+      table: {
+        type: {
+          summary: "boolean",
+        },
+        defaultValue: {
+          summary: false,
         },
       },
     },
@@ -136,18 +148,6 @@ const storybookMeta: Meta<SelectProps> = {
     isDisabled: {
       control: "boolean",
       description: "If `true`, the select component is disabled",
-      table: {
-        type: {
-          summary: "boolean",
-        },
-        defaultValue: {
-          summary: false,
-        },
-      },
-    },
-    isMultiSelect: {
-      control: "boolean",
-      description: "If `true`, the select component allows multiple selections",
       table: {
         type: {
           summary: "boolean",
@@ -255,7 +255,7 @@ const storybookMeta: Meta<SelectProps> = {
 
 export default storybookMeta;
 
-export const Default: StoryObj<SelectProps> = {
+export const Default: StoryObj<SelectProps<string | string[], boolean>> = {
   play: async ({ canvasElement, step }) => {
     await step("Select Earth from the listbox", async () => {
       const comboBoxElement = canvasElement.querySelector(
@@ -278,13 +278,13 @@ export const Default: StoryObj<SelectProps> = {
 };
 Default.args = {};
 
-export const Disabled: StoryObj<SelectProps> = {
+export const Disabled: StoryObj<SelectProps<string | string[], boolean>> = {
   args: {
     isDisabled: true,
   },
 };
 
-export const Error: StoryObj<SelectProps> = {
+export const Error: StoryObj<SelectProps<string | string[], boolean>> = {
   args: {
     errorMessage: "Select your destination.",
   },
@@ -295,35 +295,37 @@ export const Error: StoryObj<SelectProps> = {
   },
 };
 
-export const OptionsObject: StoryObj<SelectProps> = {
-  args: {
-    options: optionsObject,
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "Select can accept `options` as a flat array, an array of objects, or both. This demonstrates an array of objects with `value` and `name`.",
+export const OptionsObject: StoryObj<SelectProps<string | string[], boolean>> =
+  {
+    args: {
+      options: optionsObject,
+    },
+    parameters: {
+      docs: {
+        description: {
+          story:
+            "Select can accept `options` as a flat array, an array of objects, or both. This demonstrates an array of objects with `value` and `name`.",
+        },
       },
     },
-  },
-};
+  };
 
-export const OptionsGrouped: StoryObj<SelectProps> = {
-  args: {
-    options: optionsGrouped,
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Objects with `type: "heading"` will have their `text` displayed as a heading.',
+export const OptionsGrouped: StoryObj<SelectProps<string | string[], boolean>> =
+  {
+    args: {
+      options: optionsGrouped,
+    },
+    parameters: {
+      docs: {
+        description: {
+          story:
+            'Objects with `type: "heading"` will have their `text` displayed as a heading.',
+        },
       },
     },
-  },
-};
+  };
 
-export const MultiSelect: StoryObj<SelectProps> = {
+export const MultiSelect: StoryObj<SelectProps<string | string[], boolean>> = {
   args: {
     isMultiSelect: true,
   },


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

[OKTA-642069](https://oktainc.atlassian.net/browse/OKTA-642069)

Thanks to @bryancunningham-okta for doing the initial discovery!

## Summary

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

1. Fixes the type for `onChange` and everything else related to the value in `Select.
1. Deprecates `isMultiSelect` in favor of the new `hasMultipleChoices` (the same name we use on Autocomplete).

## Testing & Screenshots

- [X] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
N/A