### PR TITLE
Allow link in hint text

### DIFF
--- a/packages/odyssey-react-mui/src/Autocomplete.tsx
+++ b/packages/odyssey-react-mui/src/Autocomplete.tsx
@@ -161,7 +161,13 @@ export type AutocompleteProps<
   getIsOptionEqualToValue?: (option: OptionType, value: OptionType) => boolean;
 } & Pick<
   FieldComponentProps,
-  "errorMessage" | "hint" | "id" | "isOptional" | "name" | "isFullWidth"
+  | "errorMessage"
+  | "hint"
+  | "HintLinkComponent"
+  | "id"
+  | "isFullWidth"
+  | "isOptional"
+  | "name"
 > &
   SeleniumProps;
 
@@ -182,6 +188,7 @@ const Autocomplete = <
   isOptional = false,
   isReadOnly,
   hint,
+  HintLinkComponent,
   label,
   name: nameOverride,
   onBlur,
@@ -240,6 +247,7 @@ const Autocomplete = <
         hasVisibleLabel
         id={InputLabelProps.htmlFor}
         hint={hint}
+        HintLinkComponent={HintLinkComponent}
         label={label}
         isOptional={isOptional}
         renderFieldComponent={({
@@ -264,7 +272,7 @@ const Autocomplete = <
         )}
       />
     ),
-    [errorMessage, hint, isOptional, label, nameOverride]
+    [errorMessage, hint, HintLinkComponent, isOptional, label, nameOverride]
   );
   const onChange = useCallback<
     NonNullable<

--- a/packages/odyssey-react-mui/src/CheckboxGroup.tsx
+++ b/packages/odyssey-react-mui/src/CheckboxGroup.tsx
@@ -33,13 +33,17 @@ export type CheckboxGroupProps = {
    * The label text for the CheckboxGroup
    */
   label: string;
-} & Pick<FieldComponentProps, "errorMessage" | "hint" | "isDisabled"> &
+} & Pick<
+  FieldComponentProps,
+  "errorMessage" | "hint" | "HintLinkComponent" | "isDisabled"
+> &
   SeleniumProps;
 
 const CheckboxGroup = ({
   children,
   errorMessage,
   hint,
+  HintLinkComponent,
   isDisabled,
   isRequired = false,
   label,
@@ -65,6 +69,7 @@ const CheckboxGroup = ({
       fieldType="group"
       hasVisibleLabel={true}
       hint={hint}
+      HintLinkComponent={HintLinkComponent}
       isDisabled={isDisabled}
       isOptional={!isRequired}
       label={label}

--- a/packages/odyssey-react-mui/src/Field.tsx
+++ b/packages/odyssey-react-mui/src/Field.tsx
@@ -16,6 +16,8 @@ import {
   FormControl as MuiFormControl,
   FormLabel as MuiFormLabel,
 } from "@mui/material";
+
+import { FieldComponentProps } from "./FieldComponentProps";
 import { FieldError } from "./FieldError";
 import { FieldHint } from "./FieldHint";
 import { FieldLabel } from "./FieldLabel";
@@ -28,10 +30,6 @@ export const fieldTypeValues = ["single", "group"] as const;
 
 export type FieldProps = {
   /**
-   * If `error` is not undefined, the `input` will indicate an error.
-   */
-  errorMessage?: string;
-  /**
    * The field type determines how ARIA components are setup. It's important to use this to denote if you expect only one component (like a text field) or multiple (like a radio group).
    */
   fieldType: (typeof fieldTypeValues)[number];
@@ -40,14 +38,6 @@ export type FieldProps = {
    */
   hasVisibleLabel: boolean;
   /**
-   * The helper text content.
-   */
-  hint?: string;
-  /**
-   * The id of the `input` element.
-   */
-  id?: string;
-  /**
    * Important for narrowing down the `fieldset` role to "radiogroup".
    */
   isRadioGroup?: boolean;
@@ -55,18 +45,6 @@ export type FieldProps = {
    * Important for determining if children inherit error state
    */
   isCheckboxGroup?: boolean;
-  /**
-   * If `true`, the component is disabled.
-   */
-  isDisabled?: boolean;
-  /**
-   * If `true`, the component can stretch to fill the width of the container.
-   */
-  isFullWidth?: boolean;
-  /**
-   * If `true`, the `input` element is not required.
-   */
-  isOptional?: boolean;
   /**
    * The label for the `input` element.
    */
@@ -98,6 +76,7 @@ const Field = ({
   fieldType,
   hasVisibleLabel,
   hint,
+  HintLinkComponent,
   id: idOverride,
   isDisabled: isDisabledProp = false,
   isFullWidth = false,
@@ -105,7 +84,17 @@ const Field = ({
   isOptional = false,
   label,
   renderFieldComponent,
-}: FieldProps) => {
+}: FieldProps &
+  Pick<
+    FieldComponentProps,
+    | "errorMessage"
+    | "hint"
+    | "HintLinkComponent"
+    | "id"
+    | "isDisabled"
+    | "isFullWidth"
+    | "isOptional"
+  >) => {
   const { t } = useTranslation();
 
   const id = useUniqueId(idOverride);
@@ -152,7 +141,9 @@ const Field = ({
         />
       )}
 
-      {hint && <FieldHint id={hintId} text={hint} />}
+      {hint && (
+        <FieldHint id={hintId} LinkComponent={HintLinkComponent} text={hint} />
+      )}
 
       {renderFieldComponent({
         ariaDescribedBy,

--- a/packages/odyssey-react-mui/src/FieldComponentProps.ts
+++ b/packages/odyssey-react-mui/src/FieldComponentProps.ts
@@ -10,6 +10,10 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { ReactElement } from "react";
+
+import { Link } from "./Link";
+
 export type FieldComponentProps = {
   /**
    * If `error` is not undefined, the `input` will indicate an error.
@@ -19,6 +23,10 @@ export type FieldComponentProps = {
    * The helper text content.
    */
   hint?: string;
+  /**
+   * A `Link` component to provide greater context that is rendered at the end of the `hint` text
+   */
+  HintLinkComponent?: ReactElement<typeof Link>;
   /**
    * The id of the `input` element.
    */

--- a/packages/odyssey-react-mui/src/FieldHint.tsx
+++ b/packages/odyssey-react-mui/src/FieldHint.tsx
@@ -14,17 +14,23 @@ import { memo } from "react";
 
 import { FormHelperText } from "@mui/material";
 
+import { FieldComponentProps } from "./FieldComponentProps";
 import type { SeleniumProps } from "./SeleniumProps";
 
 export type FieldHintProps = {
+  LinkComponent?: FieldComponentProps["HintLinkComponent"];
   id?: string;
   text: string;
 } & SeleniumProps;
 
-const FieldHint = ({ id, testId, text }: FieldHintProps) => {
+const FieldHint = ({ id, LinkComponent, testId, text }: FieldHintProps) => {
+  console.log({ LinkComponent });
   return (
     <FormHelperText data-se={testId} id={id}>
       {text}
+      {LinkComponent && (
+        <span className="field-hint-link-component">{LinkComponent}</span>
+      )}
     </FormHelperText>
   );
 };

--- a/packages/odyssey-react-mui/src/NativeSelect.tsx
+++ b/packages/odyssey-react-mui/src/NativeSelect.tsx
@@ -81,7 +81,13 @@ export type NativeSelectProps<
   value?: Value;
 } & Pick<
   FieldComponentProps,
-  "errorMessage" | "hint" | "id" | "isDisabled" | "isOptional" | "isFullWidth"
+  | "errorMessage"
+  | "hint"
+  | "HintLinkComponent"
+  | "id"
+  | "isDisabled"
+  | "isFullWidth"
+  | "isOptional"
 > &
   SeleniumProps;
 
@@ -95,6 +101,7 @@ const NativeSelect: ForwardRefWithType = forwardRef(
       errorMessage,
       hasMultipleChoices: hasMultipleChoicesProp,
       hint,
+      HintLinkComponent,
       id: idOverride,
       isDisabled = false,
       isFullWidth = false,
@@ -178,6 +185,7 @@ const NativeSelect: ForwardRefWithType = forwardRef(
         fieldType="single"
         hasVisibleLabel
         hint={hint}
+        HintLinkComponent={HintLinkComponent}
         id={idOverride}
         isDisabled={isDisabled}
         isFullWidth={isFullWidth}

--- a/packages/odyssey-react-mui/src/RadioGroup.tsx
+++ b/packages/odyssey-react-mui/src/RadioGroup.tsx
@@ -45,7 +45,7 @@ export type RadioGroupProps = {
   value?: RadioProps["value"];
 } & Pick<
   FieldComponentProps,
-  "errorMessage" | "hint" | "id" | "isDisabled" | "name"
+  "errorMessage" | "hint" | "HintLinkComponent" | "id" | "isDisabled" | "name"
 > &
   SeleniumProps;
 
@@ -54,6 +54,7 @@ const RadioGroup = ({
   defaultValue,
   errorMessage,
   hint,
+  HintLinkComponent,
   id: idOverride,
   isDisabled,
   label,
@@ -101,6 +102,7 @@ const RadioGroup = ({
       fieldType="group"
       hasVisibleLabel={false}
       hint={hint}
+      HintLinkComponent={HintLinkComponent}
       id={idOverride}
       isDisabled={isDisabled}
       label={label}

--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -86,11 +86,12 @@ export type SelectProps<
   FieldComponentProps,
   | "errorMessage"
   | "hint"
+  | "HintLinkComponent"
   | "id"
   | "isDisabled"
+  | "isFullWidth"
   | "isOptional"
   | "name"
-  | "isFullWidth"
 > &
   SeleniumProps;
 
@@ -118,6 +119,7 @@ const Select = <
   errorMessage,
   hasMultipleChoices: hasMultipleChoicesProp,
   hint,
+  HintLinkComponent,
   id: idOverride,
   isDisabled = false,
   isFullWidth = false,
@@ -287,6 +289,7 @@ const Select = <
       fieldType="single"
       hasVisibleLabel
       hint={hint}
+      HintLinkComponent={HintLinkComponent}
       id={idOverride}
       isDisabled={isDisabled}
       isFullWidth={isFullWidth}

--- a/packages/odyssey-react-mui/src/TextField.tsx
+++ b/packages/odyssey-react-mui/src/TextField.tsx
@@ -102,6 +102,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       endAdornment,
       errorMessage,
       hint,
+      HintLinkComponent,
       id: idOverride,
       isDisabled = false,
       isFullWidth = false,
@@ -204,6 +205,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         fieldType="single"
         hasVisibleLabel
         hint={hint}
+        HintLinkComponent={HintLinkComponent}
         id={idOverride}
         isDisabled={isDisabled}
         isFullWidth={isFullWidth}

--- a/packages/odyssey-react-mui/src/labs/DataTable.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataTable.tsx
@@ -628,7 +628,14 @@ const DataTable = ({
         )}
       </>
     ),
-    [density, columnVisibility, columns, hasChangeableDensity]
+    [
+      columnVisibility,
+      columns,
+      density,
+      hasChangeableDensity,
+      handleColumnVisibility,
+      hasColumnVisibility,
+    ]
   );
 
   return (

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -1478,6 +1478,9 @@ export const components = ({
       },
       styleOverrides: {
         root: {
+          display: "flex",
+          justifyContent: "flex-start",
+          alignItems: "center",
           fontSize: odysseyTokens.TypographySizeSubordinate,
           lineHeight: odysseyTokens.TypographyLineHeightBody,
           marginBlockStart: odysseyTokens.Spacing2,
@@ -1490,6 +1493,10 @@ export const components = ({
             marginBlockEnd: 0,
           },
           textAlign: "start",
+
+          ".field-hint-link-component": {
+            marginInlineStart: odysseyTokens.Spacing1,
+          },
         },
       },
     },

--- a/packages/odyssey-storybook/src/components/odyssey-labs/LegacyTable/PaginatedTable.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/LegacyTable/PaginatedTable.stories.tsx
@@ -19,7 +19,7 @@ import {
 } from "@okta/odyssey-react-mui/labs";
 
 import { MuiThemeDecorator } from "../../../../.storybook/components";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 const storybookMeta: Meta = {
   title: "Labs Components/Legacy Table/PaginatedTable",
@@ -541,7 +541,7 @@ export const Pagination: StoryObj<PaginatedTableProps<Person>> = {
   },
   render: function C(args) {
     const countRef = useRef(15);
-    const dataArg = useMemo(() => args.data ?? [], [args.data]);
+    const dataArg = args.data ?? [];
 
     const [data, setData] = useState(dataArg.slice(0, countRef.current));
 
@@ -549,7 +549,7 @@ export const Pagination: StoryObj<PaginatedTableProps<Person>> = {
       countRef.current = countRef.current + 10;
 
       setData(dataArg.slice(0, Math.min(countRef.current, dataArg.length)));
-    }, [countRef, dataArg]);
+    }, [args.data, dataArg]);
 
     return (
       <PaginatedTable {...args} data={data} fetchMoreData={fetchMoreData} />

--- a/packages/odyssey-storybook/src/components/odyssey-labs/LegacyTable/PaginatedTable.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/LegacyTable/PaginatedTable.stories.tsx
@@ -19,7 +19,7 @@ import {
 } from "@okta/odyssey-react-mui/labs";
 
 import { MuiThemeDecorator } from "../../../../.storybook/components";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 const storybookMeta: Meta = {
   title: "Labs Components/Legacy Table/PaginatedTable",
@@ -541,7 +541,7 @@ export const Pagination: StoryObj<PaginatedTableProps<Person>> = {
   },
   render: function C(args) {
     const countRef = useRef(15);
-    const dataArg = args.data ?? [];
+    const dataArg = useMemo(() => args.data ?? [], [args.data]);
 
     const [data, setData] = useState(dataArg.slice(0, countRef.current));
 
@@ -549,7 +549,7 @@ export const Pagination: StoryObj<PaginatedTableProps<Person>> = {
       countRef.current = countRef.current + 10;
 
       setData(dataArg.slice(0, Math.min(countRef.current, dataArg.length)));
-    }, [args.data, dataArg]);
+    }, [countRef, dataArg]);
 
     return (
       <PaginatedTable {...args} data={data} fetchMoreData={fetchMoreData} />

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
@@ -63,6 +63,7 @@ const storybookMeta: Meta<typeof Autocomplete> = {
       },
     },
     hint: fieldComponentPropsMetaData.hint,
+    HintLinkComponent: fieldComponentPropsMetaData.HintLinkComponent,
     id: fieldComponentPropsMetaData.id,
     isCustomValueAllowed: {
       control: "boolean",

--- a/packages/odyssey-storybook/src/components/odyssey-mui/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -47,6 +47,7 @@ const storybookMeta: Meta<CheckboxGroupStoryProps> = {
     },
     errorMessage: fieldComponentPropsMetaData.errorMessage,
     hint: fieldComponentPropsMetaData.hint,
+    HintLinkComponent: fieldComponentPropsMetaData.HintLinkComponent,
     isDisabled: fieldComponentPropsMetaData.isDisabled,
     isRequired: {
       control: "boolean",

--- a/packages/odyssey-storybook/src/components/odyssey-mui/NativeSelect/NativeSelect.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/NativeSelect/NativeSelect.stories.tsx
@@ -44,6 +44,7 @@ const storybookMeta: Meta<typeof NativeSelect> = {
     },
     errorMessage: fieldComponentPropsMetaData.errorMessage,
     hint: fieldComponentPropsMetaData.hint,
+    HintLinkComponent: fieldComponentPropsMetaData.HintLinkComponent,
     id: fieldComponentPropsMetaData.id,
     isDisabled: fieldComponentPropsMetaData.isDisabled,
     isFullWidth: fieldComponentPropsMetaData.isFullWidth,

--- a/packages/odyssey-storybook/src/components/odyssey-mui/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/RadioGroup/RadioGroup.stories.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { useCallback, useState } from "react";
 import { Radio, RadioGroup } from "@okta/odyssey-react-mui";
 import { Meta, StoryObj } from "@storybook/react";
 import { expect } from "@storybook/jest";
@@ -18,7 +19,6 @@ import { fieldComponentPropsMetaData } from "../../../fieldComponentPropsMetaDat
 import { MuiThemeDecorator } from "../../../../.storybook/components";
 import { userEvent, within } from "@storybook/testing-library";
 import { axeRun } from "../../../axe-util";
-import { useCallback, useState } from "react";
 
 const storybookMeta: Meta<typeof RadioGroup> = {
   title: "MUI Components/Forms/RadioGroup",
@@ -50,6 +50,7 @@ const storybookMeta: Meta<typeof RadioGroup> = {
     },
     errorMessage: fieldComponentPropsMetaData.errorMessage,
     hint: fieldComponentPropsMetaData.hint,
+    HintLinkComponent: fieldComponentPropsMetaData.HintLinkComponent,
     id: fieldComponentPropsMetaData.id,
     isDisabled: fieldComponentPropsMetaData.isDisabled,
     label: {

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Select/Select.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Select/Select.stories.tsx
@@ -12,12 +12,13 @@
 
 import { Meta, StoryObj } from "@storybook/react";
 import { Select, SelectProps } from "@okta/odyssey-react-mui";
-import { MuiThemeDecorator } from "../../../../.storybook/components";
 import { userEvent, waitFor, screen } from "@storybook/testing-library";
-import { axeRun } from "../../../axe-util";
 import { expect } from "@storybook/jest";
-import { fieldComponentPropsMetaData } from "../../../fieldComponentPropsMetaData";
 import { useCallback, useState } from "react";
+
+import { MuiThemeDecorator } from "../../../../.storybook/components";
+import { axeRun } from "../../../axe-util";
+import { fieldComponentPropsMetaData } from "../../../fieldComponentPropsMetaData";
 
 const optionsArray: SelectProps<string | string[], boolean>["options"] = [
   "Earth",
@@ -135,21 +136,11 @@ const storybookMeta: Meta<SelectProps<string | string[], boolean>> = {
       },
     },
     hint: fieldComponentPropsMetaData.hint,
+    HintLinkComponent: fieldComponentPropsMetaData.HintLinkComponent,
     id: fieldComponentPropsMetaData.id,
     isDisabled: fieldComponentPropsMetaData.isFullWidth,
     isFullWidth: fieldComponentPropsMetaData.isFullWidth,
-    isOptional: {
-      control: "boolean",
-      description: "If `true`, the select component is optional",
-      table: {
-        type: {
-          summary: "boolean",
-        },
-        defaultValue: {
-          summary: false,
-        },
-      },
-    },
+    isOptional: fieldComponentPropsMetaData.isOptional,
     label: {
       control: "text",
       description: "The label text for the select component",

--- a/packages/odyssey-storybook/src/components/odyssey-mui/TextField/TextField.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/TextField/TextField.stories.tsx
@@ -68,6 +68,7 @@ const storybookMeta: Meta<typeof TextField> = {
       },
     },
     hint: fieldComponentPropsMetaData.hint,
+    HintLinkComponent: fieldComponentPropsMetaData.HintLinkComponent,
     id: fieldComponentPropsMetaData.id,
     isDisabled: fieldComponentPropsMetaData.isDisabled,
     isFullWidth: fieldComponentPropsMetaData.isFullWidth,

--- a/packages/odyssey-storybook/src/fieldComponentPropsMetaData.ts
+++ b/packages/odyssey-storybook/src/fieldComponentPropsMetaData.ts
@@ -44,6 +44,15 @@ export const fieldComponentPropsMetaData: Partial<
       },
     },
   },
+  HintLinkComponent: {
+    description:
+      "A `Link` component to provide greater context that is rendered at the end of the `hint` text",
+    table: {
+      type: {
+        summary: "ReactNode",
+      },
+    },
+  },
   isDisabled: {
     control: "boolean",
     description: "If `true`, the component is disabled",


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

[OKTA-665365](https://oktainc.atlassian.net/browse/OKTA-665365)

## Summary
- Add prop to allow `Link` component to be rendered at the end of hint text
<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots
<img width="572" alt="image" src="https://github.com/okta/odyssey/assets/148223016/a302dcc0-c3f8-4e39-be2b-85c6a88546af">

- [x] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
