### PR TITLE
fix autocomplete issues

### DIFF
--- a/packages/odyssey-react-mui/src/Autocomplete.tsx
+++ b/packages/odyssey-react-mui/src/Autocomplete.tsx
@@ -155,7 +155,7 @@ export type AutocompleteProps<
    *
    * You will need to implement this function if your `option` items are objects.
    */
-  isOptionEqualToValue?: (option: OptionType, value: OptionType) => boolean;
+  getIsOptionEqualToValue?: (option: OptionType, value: OptionType) => boolean;
 } & Pick<
   FieldComponentProps,
   "errorMessage" | "hint" | "id" | "isOptional" | "name"
@@ -186,7 +186,7 @@ const Autocomplete = <
   onFocus,
   options,
   value,
-  isOptionEqualToValue,
+  getIsOptionEqualToValue,
   testId,
 }: AutocompleteProps<OptionType, HasMultipleChoices, IsCustomValueAllowed>) => {
   const renderInput = useCallback(
@@ -312,7 +312,7 @@ const Autocomplete = <
       renderInput={renderInput}
       value={localValue}
       inputValue={localInputValue}
-      isOptionEqualToValue={isOptionEqualToValue}
+      isOptionEqualToValue={getIsOptionEqualToValue}
     />
   );
 };

--- a/packages/odyssey-react-mui/src/Autocomplete.tsx
+++ b/packages/odyssey-react-mui/src/Autocomplete.tsx
@@ -49,6 +49,15 @@ export type AutocompleteProps<
     IsCustomValueAllowed
   >["multiple"];
   /**
+   * The value for the input
+   */
+  inputValue?: UseAutocompleteProps<
+    OptionType,
+    HasMultipleChoices,
+    undefined,
+    IsCustomValueAllowed
+  >["inputValue"];
+  /**
    * Allows the input of custom values
    */
   isCustomValueAllowed?: MuiAutocompleteProps<
@@ -165,6 +174,7 @@ const Autocomplete = <
   errorMessage,
   hasMultipleChoices,
   id: idOverride,
+  inputValue,
   isCustomValueAllowed,
   isDisabled,
   isLoading,
@@ -176,7 +186,7 @@ const Autocomplete = <
   name: nameOverride,
   onBlur,
   onChange: onChangeProp,
-  onInputChange,
+  onInputChange: onInputChangeProp,
   onFocus,
   options,
   value,
@@ -218,16 +228,17 @@ const Autocomplete = <
     [errorMessage, hint, isOptional, label, nameOverride]
   );
 
-  const defaultValuesProp:
+  const defaultValuesProp = useMemo<
     | AutocompleteValue<
         OptionType,
         HasMultipleChoices,
         undefined,
         IsCustomValueAllowed
       >
-    | undefined = useMemo(() => {
+    | undefined
+  >(() => {
     if (hasMultipleChoices) {
-      return defaultValue == undefined
+      return defaultValue === undefined
         ? ([] as AutocompleteValue<
             OptionType,
             HasMultipleChoices,
@@ -242,6 +253,11 @@ const Autocomplete = <
   const [localValue, setLocalValue] = useControlledState({
     controlledValue: value,
     uncontrolledValue: defaultValuesProp,
+  });
+
+  const [localInputValue, setLocalInputValue] = useControlledState({
+    controlledValue: inputValue,
+    uncontrolledValue: undefined,
   });
 
   const onChange = useCallback<
@@ -259,6 +275,23 @@ const Autocomplete = <
       onChangeProp?.(event, value, reason, details);
     },
     [onChangeProp, setLocalValue]
+  );
+
+  const onInputChange = useCallback<
+    NonNullable<
+      UseAutocompleteProps<
+        OptionType,
+        HasMultipleChoices,
+        undefined,
+        IsCustomValueAllowed
+      >["onInputChange"]
+    >
+  >(
+    (event, value, reason) => {
+      setLocalInputValue(value);
+      onInputChangeProp?.(event, value, reason);
+    },
+    [onInputChangeProp, setLocalInputValue]
   );
 
   return (
@@ -283,7 +316,7 @@ const Autocomplete = <
       readOnly={isReadOnly}
       renderInput={renderInput}
       value={localValue}
-      inputValue={undefined}
+      inputValue={localInputValue}
       isOptionEqualToValue={isOptionEqualToValue}
     />
   );

--- a/packages/odyssey-react-mui/src/labs/VirtualizedAutocomplete.tsx
+++ b/packages/odyssey-react-mui/src/labs/VirtualizedAutocomplete.tsx
@@ -161,7 +161,7 @@ export type AutocompleteProps<
    *
    * You will need to implement this function if your `option` items are objects.
    */
-  isOptionEqualToValue?: (option: OptionType, value: OptionType) => boolean;
+  getIsOptionEqualToValue?: (option: OptionType, value: OptionType) => boolean;
 } & Pick<
   FieldComponentProps,
   "errorMessage" | "hint" | "id" | "isOptional" | "name"
@@ -193,7 +193,7 @@ const VirtualizedAutocomplete = <
   onFocus,
   options,
   value,
-  isOptionEqualToValue,
+  getIsOptionEqualToValue,
   testId,
 }: AutocompleteProps<OptionType, HasMultipleChoices, IsCustomValueAllowed>) => {
   const renderInput = useCallback(
@@ -320,7 +320,7 @@ const VirtualizedAutocomplete = <
       renderInput={renderInput}
       value={localValue}
       inputValue={localInputValue}
-      isOptionEqualToValue={isOptionEqualToValue}
+      isOptionEqualToValue={getIsOptionEqualToValue}
     />
   );
 };

--- a/packages/odyssey-react-mui/src/labs/VirtualizedAutocomplete.tsx
+++ b/packages/odyssey-react-mui/src/labs/VirtualizedAutocomplete.tsx
@@ -19,10 +19,10 @@ import {
 } from "@mui/material";
 import { memo, useCallback, useMemo } from "react";
 
-import { Field } from "./Field";
-import { FieldComponentProps } from "./FieldComponentProps";
-import type { SeleniumProps } from "./SeleniumProps";
-import { useControlledState } from "./useControlledState";
+import { Field } from "../Field";
+import { FieldComponentProps } from "../FieldComponentProps";
+import type { SeleniumProps } from "../SeleniumProps";
+import { useControlledState } from "../useControlledState";
 
 export type AutocompleteProps<
   OptionType,
@@ -98,6 +98,12 @@ export type AutocompleteProps<
    */
   label: string;
   /**
+   * The component used to render the listbox.
+   */
+  ListboxComponent?: React.JSXElementConstructor<
+    React.HTMLAttributes<HTMLElement>
+  >;
+  /**
    * Callback fired when the autocomplete loses focus.
    */
   onBlur?: MuiAutocompleteProps<
@@ -162,7 +168,7 @@ export type AutocompleteProps<
 > &
   SeleniumProps;
 
-const Autocomplete = <
+const VirtualizedAutocomplete = <
   OptionType,
   HasMultipleChoices extends boolean | undefined,
   IsCustomValueAllowed extends boolean | undefined
@@ -179,6 +185,7 @@ const Autocomplete = <
   isReadOnly,
   hint,
   label,
+  ListboxComponent,
   name: nameOverride,
   onBlur,
   onChange: onChangeProp,
@@ -301,6 +308,7 @@ const Autocomplete = <
       freeSolo={isCustomValueAllowed}
       filterSelectedOptions={true}
       id={idOverride}
+      ListboxComponent={ListboxComponent}
       loading={isLoading}
       multiple={hasMultipleChoices}
       onBlur={onBlur}
@@ -318,8 +326,10 @@ const Autocomplete = <
 };
 
 // Need the `typeof Autocomplete` because generics don't get passed through
-const MemoizedAutocomplete = memo(Autocomplete) as typeof Autocomplete;
+const MemoizedAutocomplete = memo(
+  VirtualizedAutocomplete
+) as typeof VirtualizedAutocomplete;
 // @ts-expect-error displayName is expected to not be on `typeof Autocomplete`
 MemoizedAutocomplete.displayName = "Autocomplete";
 
-export { MemoizedAutocomplete as Autocomplete };
+export { MemoizedAutocomplete as VirtualizedAutocomplete };

--- a/packages/odyssey-react-mui/src/labs/index.ts
+++ b/packages/odyssey-react-mui/src/labs/index.ts
@@ -23,3 +23,4 @@ export * from "./materialReactTableTypes";
 export * from "./PaginatedTable";
 export * from "./StaticTable";
 export * from "./GroupPicker";
+export * from "./VirtualizedAutocomplete";

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
@@ -18,6 +18,7 @@ import { userEvent, waitFor, within, screen } from "@storybook/testing-library";
 import { fieldComponentPropsMetaData } from "../../../fieldComponentPropsMetaData";
 import { axeRun } from "../../../axe-util";
 import { MuiThemeDecorator } from "../../../../.storybook/components";
+import { useCallback, useState } from "react";
 
 const stations: ReadonlyArray<StationType> = [
   { label: "Anderson Station" },
@@ -331,5 +332,80 @@ export const ReadOnly: StoryObj<AutocompleteType> = {
   args: {
     isReadOnly: true,
     value: { label: "Tycho Station" },
+  },
+};
+
+type IssueOption = {
+  id: string;
+  label: string;
+  externalValue: string;
+  description: string;
+};
+export const Issue: StoryObj<
+  typeof Autocomplete<IssueOption, boolean, boolean>
+> = {
+  args: {
+    options: [
+      {
+        id: "ent1rs1yjAIYGKjX48g6",
+        label: "SE4 value1",
+        externalValue: "externalValue SE4 value1",
+        description: "Description SE4 value1",
+      },
+      {
+        id: "ent1rs1ys3O7JDBxe8g6",
+        label: "SE4 value10",
+        externalValue: "externalValue SE4 value10",
+        description: "Description SE4 value10",
+      },
+      {
+        id: "ent1rs21aA4w60TJG8g6",
+        label: "SE4 value100",
+        externalValue: "externalValue SE4 value100",
+        description: "Description SE4 value100",
+      },
+      {
+        id: "ent1rs2qgOg42zhYV8g6",
+        label: "SE4 value1006",
+        externalValue: "externalValue SE4 value1006",
+        description: "Description SE4 value1006",
+      },
+    ],
+    value: [
+      {
+        id: "ent1rs21aA4w60TJG8g6",
+        label: "SE4 value100",
+        externalValue: "externalValue SE4 value100",
+        description: "Description SE4 value100",
+      },
+      {
+        id: "ent1rs1yjAIYGKjX48g6",
+        label: "SE4 value1",
+        externalValue: "externalValue SE4 value1",
+        description: "Description SE4 value1",
+      },
+    ],
+    hasMultipleChoices: true,
+    isReadOnly: false,
+    label: "label",
+    isOptionEqualToValue: (option, value) => option.id === value.id,
+  },
+  render: function C(props) {
+    const [localValue, setLocalValue] = useState([
+      {
+        id: "ent1rs21aA4w60TJG8g6",
+        label: "SE4 value100",
+        externalValue: "externalValue SE4 value100",
+        description: "Description SE4 value100",
+      },
+      {
+        id: "ent1rs1yjAIYGKjX48g6",
+        label: "SE4 value1",
+        externalValue: "externalValue SE4 value1",
+        description: "Description SE4 value1",
+      },
+    ]);
+    const onChange = useCallback((_, v) => setLocalValue(v), []);
+    return <Autocomplete {...props} value={localValue} onChange={onChange} />;
   },
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
@@ -335,77 +335,100 @@ export const ReadOnly: StoryObj<AutocompleteType> = {
   },
 };
 
-type IssueOption = {
+type MoonMeta = {
   id: string;
   label: string;
-  externalValue: string;
+  diameterInKm: number;
   description: string;
 };
-export const Issue: StoryObj<
-  typeof Autocomplete<IssueOption, boolean, boolean>
-> = {
+
+type JupiterMoonsAutocomplete = typeof Autocomplete<MoonMeta, boolean, boolean>;
+
+const jupiterGalileanMoons: MoonMeta[] = [
+  {
+    id: "ent1rs1yjAIYGKjX48g6",
+    label: "Io",
+    diameterInKm: 3643.2,
+    description:
+      "The innermost and third-largest of the four Galilean moons of the planet Jupiter.",
+  },
+  {
+    id: "ent1rs1ys3O7JDBxe8g6",
+    label: "Europa",
+    diameterInKm: 3121.6,
+    description:
+      "The smallest of the four Galilean moons orbiting Jupiter, and the sixth-closest to the planet of all the 95 known moons of Jupiter.",
+  },
+  {
+    id: "ent1rs21aA4w60TJG8g6",
+    label: "Ganymede",
+    diameterInKm: 5268.2,
+    description:
+      "The largest and most massive natural satellite of Jupiter as well as in the Solar System, being a planetary-mass moon.",
+  },
+  {
+    id: "ent1rs2qgOg42zhYV8g6",
+    label: "Callisto",
+    diameterInKm: 4820.6,
+    description:
+      "The third-largest moon after Ganymede and Saturn's largest moon Titan, and as large as the smallest planet Mercury",
+  },
+];
+
+export const ControlledMultipleAutocomplete: StoryObj<JupiterMoonsAutocomplete> =
+  {
+    args: {
+      options: jupiterGalileanMoons,
+      value: jupiterGalileanMoons.slice(0, 2),
+      hasMultipleChoices: true,
+      isReadOnly: false,
+      label: "label",
+      isOptionEqualToValue: (option, value) => option.id === value.id,
+    },
+    render: function C(props) {
+      const [localValue, setLocalValue] = useState<MoonMeta[] | undefined>(
+        jupiterGalileanMoons.slice(0, 2)
+      );
+      const onChange = useCallback((_, v) => setLocalValue(v), []);
+      return <Autocomplete {...props} value={localValue} onChange={onChange} />;
+    },
+  };
+
+export const UnontrolledMultipleAutocomplete: StoryObj<JupiterMoonsAutocomplete> =
+  {
+    args: {
+      options: jupiterGalileanMoons,
+      defaultValue: jupiterGalileanMoons.slice(0, 2),
+      hasMultipleChoices: true,
+      isReadOnly: false,
+      label: "label",
+      isOptionEqualToValue: (option, value) => option.id === value.id,
+    },
+  };
+
+export const ControlledAutocomplete: StoryObj<JupiterMoonsAutocomplete> = {
   args: {
-    options: [
-      {
-        id: "ent1rs1yjAIYGKjX48g6",
-        label: "SE4 value1",
-        externalValue: "externalValue SE4 value1",
-        description: "Description SE4 value1",
-      },
-      {
-        id: "ent1rs1ys3O7JDBxe8g6",
-        label: "SE4 value10",
-        externalValue: "externalValue SE4 value10",
-        description: "Description SE4 value10",
-      },
-      {
-        id: "ent1rs21aA4w60TJG8g6",
-        label: "SE4 value100",
-        externalValue: "externalValue SE4 value100",
-        description: "Description SE4 value100",
-      },
-      {
-        id: "ent1rs2qgOg42zhYV8g6",
-        label: "SE4 value1006",
-        externalValue: "externalValue SE4 value1006",
-        description: "Description SE4 value1006",
-      },
-    ],
-    value: [
-      {
-        id: "ent1rs21aA4w60TJG8g6",
-        label: "SE4 value100",
-        externalValue: "externalValue SE4 value100",
-        description: "Description SE4 value100",
-      },
-      {
-        id: "ent1rs1yjAIYGKjX48g6",
-        label: "SE4 value1",
-        externalValue: "externalValue SE4 value1",
-        description: "Description SE4 value1",
-      },
-    ],
-    hasMultipleChoices: true,
+    options: jupiterGalileanMoons,
+    value: jupiterGalileanMoons[0],
     isReadOnly: false,
     label: "label",
     isOptionEqualToValue: (option, value) => option.id === value.id,
   },
   render: function C(props) {
-    const [localValue, setLocalValue] = useState([
-      {
-        id: "ent1rs21aA4w60TJG8g6",
-        label: "SE4 value100",
-        externalValue: "externalValue SE4 value100",
-        description: "Description SE4 value100",
-      },
-      {
-        id: "ent1rs1yjAIYGKjX48g6",
-        label: "SE4 value1",
-        externalValue: "externalValue SE4 value1",
-        description: "Description SE4 value1",
-      },
-    ]);
+    const [localValue, setLocalValue] = useState<MoonMeta | undefined>(
+      jupiterGalileanMoons[0]
+    );
     const onChange = useCallback((_, v) => setLocalValue(v), []);
     return <Autocomplete {...props} value={localValue} onChange={onChange} />;
+  },
+};
+
+export const UnontrolledAutocomplete: StoryObj<JupiterMoonsAutocomplete> = {
+  args: {
+    options: jupiterGalileanMoons,
+    defaultValue: jupiterGalileanMoons[0],
+    isReadOnly: false,
+    label: "label",
+    isOptionEqualToValue: (option, value) => option.id === value.id,
   },
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
@@ -383,7 +383,7 @@ export const ControlledMultipleAutocomplete: StoryObj<JupiterMoonsAutocomplete> 
       hasMultipleChoices: true,
       isReadOnly: false,
       label: "label",
-      isOptionEqualToValue: (option, value) => option.id === value.id,
+      getIsOptionEqualToValue: (option, value) => option.id === value.id,
     },
     render: function C(props) {
       const [localValue, setLocalValue] = useState<MoonMeta[] | undefined>(
@@ -402,7 +402,7 @@ export const UnontrolledMultipleAutocomplete: StoryObj<JupiterMoonsAutocomplete>
       hasMultipleChoices: true,
       isReadOnly: false,
       label: "label",
-      isOptionEqualToValue: (option, value) => option.id === value.id,
+      getIsOptionEqualToValue: (option, value) => option.id === value.id,
     },
   };
 
@@ -412,7 +412,7 @@ export const ControlledAutocomplete: StoryObj<JupiterMoonsAutocomplete> = {
     value: jupiterGalileanMoons[0],
     isReadOnly: false,
     label: "label",
-    isOptionEqualToValue: (option, value) => option.id === value.id,
+    getIsOptionEqualToValue: (option, value) => option.id === value.id,
   },
   render: function C(props) {
     const [localValue, setLocalValue] = useState<MoonMeta | undefined>(
@@ -429,6 +429,6 @@ export const UnontrolledAutocomplete: StoryObj<JupiterMoonsAutocomplete> = {
     defaultValue: jupiterGalileanMoons[0],
     isReadOnly: false,
     label: "label",
-    isOptionEqualToValue: (option, value) => option.id === value.id,
+    getIsOptionEqualToValue: (option, value) => option.id === value.id,
   },
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
@@ -423,7 +423,7 @@ export const ControlledAutocomplete: StoryObj<JupiterMoonsAutocomplete> = {
   },
 };
 
-export const UnontrolledAutocomplete: StoryObj<JupiterMoonsAutocomplete> = {
+export const UncontrolledAutocomplete: StoryObj<JupiterMoonsAutocomplete> = {
   args: {
     options: jupiterGalileanMoons,
     defaultValue: jupiterGalileanMoons[0],


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

[okta-665431](https://oktainc.atlassian.net/browse/okta-665431)

## Summary
Improvements:
- Add ability to have Autocomplete work in a controlled / uncontrolled manner 
- Allow for user to provide `isOptionEqualToValue` predicate to test that option matches value when options are objects
- Allow user to provide default values (required for uncontrolled component scenario)
- Add controlled state object to drive internal state of autocomplete
- Add more stories to cover the controlled and uncontrolled scenarios

Fixes:
- Fix typing for `options` prop
- Fix typing for `value` prop
- Reflect `onChange` back to parent component

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
