### PR TITLE
fix: fixed typing for shadow root element. updated tests to reflect changes

### DIFF
--- a/packages/odyssey-react-mui/src/OdysseyCacheProvider.tsx
+++ b/packages/odyssey-react-mui/src/OdysseyCacheProvider.tsx
@@ -17,51 +17,43 @@ declare global {
 }
 
 import createCache, { StylisPlugin } from "@emotion/cache";
-import { CacheProvider } from "@emotion/react";
-import { memo, ReactNode, useMemo } from "react";
-
+import { memo, useMemo, ReactNode } from "react";
 import { useUniqueAlphabeticalId } from "./useUniqueAlphabeticalId";
+import { CacheProvider } from "@emotion/react";
+
+// import { useUniqueAlphabeticalId } from "./useUniqueAlphabeticalId";
 
 export type OdysseyCacheProviderProps = {
   children: ReactNode;
+  nonce?: string;
+  /**
+   * Emotion caches styles into the style element.
+   * When enabling this prop, Emotion caches the styles at this element, rather than in <head>.
+   */
+  emotionRoot?: HTMLStyleElement;
   /**
    * Emotion renders into this HTML element.
    * When enabling this prop, Emotion renders at the top of this component rather than the bottom like it does in the HTML `<head>`.
    */
-  nonce?: string;
-  shadowDomElement?: HTMLElement;
+  shadowDomElement?: HTMLDivElement | HTMLElement;
   stylisPlugins?: StylisPlugin[];
 };
 
 const OdysseyCacheProvider = ({
   children,
-  nonce,
-  shadowDomElement,
-  stylisPlugins,
+  emotionRoot,
 }: OdysseyCacheProviderProps) => {
   const uniqueAlphabeticalId = useUniqueAlphabeticalId();
 
-  const emotionRootElement = useMemo(() => {
-    const emotionRootElement = document.createElement("div");
-
-    emotionRootElement.setAttribute("data-emotion-root", "data-emotion-root");
-
-    shadowDomElement?.prepend?.(emotionRootElement);
-
-    return emotionRootElement;
-  }, [shadowDomElement]);
-
-  const emotionCache = useMemo(
-    () =>
-      createCache({
-        container: emotionRootElement,
-        key: uniqueAlphabeticalId,
-        nonce: nonce || window.cspNonce,
-        prepend: Boolean(emotionRootElement),
-        stylisPlugins,
-      }),
-    [emotionRootElement, nonce, stylisPlugins, uniqueAlphabeticalId]
-  );
+  const emotionCache = useMemo(() => {
+    return createCache({
+      container: emotionRoot,
+      key: uniqueAlphabeticalId,
+      nonce: window.cspNonce,
+      prepend: true,
+      speedy: false, // <-- Needs to be set to false when shadow-dom is used!!
+    });
+  }, [emotionRoot, uniqueAlphabeticalId]);
 
   return <CacheProvider value={emotionCache}>{children}</CacheProvider>;
 };

--- a/packages/odyssey-react-mui/src/OdysseyCacheProvider.tsx
+++ b/packages/odyssey-react-mui/src/OdysseyCacheProvider.tsx
@@ -21,8 +21,6 @@ import { memo, useMemo, ReactNode } from "react";
 import { useUniqueAlphabeticalId } from "./useUniqueAlphabeticalId";
 import { CacheProvider } from "@emotion/react";
 
-// import { useUniqueAlphabeticalId } from "./useUniqueAlphabeticalId";
-
 export type OdysseyCacheProviderProps = {
   children: ReactNode;
   nonce?: string;
@@ -51,7 +49,7 @@ const OdysseyCacheProvider = ({
       key: uniqueAlphabeticalId,
       nonce: window.cspNonce,
       prepend: true,
-      speedy: false, // <-- Needs to be set to false when shadow-dom is used!!
+      speedy: false, // <-- Needs to be set to false when shadow-dom is used!! https://github.com/emotion-js/emotion/issues/2053#issuecomment-713429122
     });
   }, [emotionRoot, uniqueAlphabeticalId]);
 

--- a/packages/odyssey-react-mui/src/OdysseyCacheProvider.tsx
+++ b/packages/odyssey-react-mui/src/OdysseyCacheProvider.tsx
@@ -47,7 +47,7 @@ const OdysseyCacheProvider = ({
 
   const emotionCache = useMemo(() => {
     return createCache({
-      container: emotionRoot,
+      ...(emotionRoot && { container: emotionRoot }),
       key: uniqueAlphabeticalId,
       nonce: window.cspNonce,
       prepend: true,

--- a/packages/odyssey-react-mui/src/OdysseyCacheProvider.tsx
+++ b/packages/odyssey-react-mui/src/OdysseyCacheProvider.tsx
@@ -29,7 +29,7 @@ export type OdysseyCacheProviderProps = {
    * When enabling this prop, Emotion renders at the top of this component rather than the bottom like it does in the HTML `<head>`.
    */
   nonce?: string;
-  shadowDomElement?: HTMLDivElement;
+  shadowDomElement?: HTMLElement;
   stylisPlugins?: StylisPlugin[];
 };
 

--- a/packages/odyssey-react-mui/src/OdysseyProvider.tsx
+++ b/packages/odyssey-react-mui/src/OdysseyProvider.tsx
@@ -35,6 +35,7 @@ export type OdysseyProviderProps = OdysseyCacheProviderProps &
 const OdysseyProvider = ({
   children,
   designTokensOverride,
+  emotionRoot,
   shadowDomElement,
   languageCode,
   nonce,
@@ -44,13 +45,16 @@ const OdysseyProvider = ({
 }: OdysseyProviderProps) => (
   <OdysseyCacheProvider
     nonce={nonce}
+    emotionRoot={emotionRoot}
     shadowDomElement={shadowDomElement}
     stylisPlugins={stylisPlugins}
   >
     <OdysseyThemeProvider
       designTokensOverride={designTokensOverride}
+      emotionRoot={emotionRoot}
       shadowDomElement={shadowDomElement}
       themeOverride={themeOverride}
+      withCache={false}
     >
       <ScopedCssBaseline>
         <OdysseyTranslationProvider

--- a/packages/odyssey-react-mui/src/OdysseyThemeProvider.tsx
+++ b/packages/odyssey-react-mui/src/OdysseyThemeProvider.tsx
@@ -29,7 +29,7 @@ export type OdysseyThemeProviderProps = {
   children: ReactNode;
   designTokensOverride?: DesignTokensOverride;
   emotionRoot?: HTMLStyleElement;
-  shadowDomElement?: HTMLDivElement;
+  shadowDomElement?: HTMLDivElement | HTMLElement | undefined;
   themeOverride?: ThemeOptions;
   withCache?: boolean;
 };

--- a/packages/odyssey-react-mui/src/OdysseyThemeProvider.tsx
+++ b/packages/odyssey-react-mui/src/OdysseyThemeProvider.tsx
@@ -21,6 +21,8 @@ import { deepmerge } from "@mui/utils";
 import { createOdysseyMuiTheme, DesignTokensOverride } from "./theme";
 import * as Tokens from "@okta/odyssey-design-tokens";
 import { OdysseyDesignTokensContext } from "./OdysseyDesignTokensContext";
+import { CacheProvider } from "@emotion/react";
+import createCache from "@emotion/cache";
 
 export type OdysseyThemeProviderProps = {
   children: ReactNode;
@@ -53,12 +55,24 @@ const OdysseyThemeProvider = ({
     [odysseyTheme, themeOverride]
   );
 
+  const cache = useMemo(
+    () =>
+      createCache({
+        key: "css",
+        prepend: true,
+        nonce: window.cspNonce,
+      }),
+    []
+  );
+
   return (
-    <MuiThemeProvider theme={customOdysseyTheme ?? odysseyTheme}>
-      <OdysseyDesignTokensContext.Provider value={odysseyTokens}>
-        {children}
-      </OdysseyDesignTokensContext.Provider>
-    </MuiThemeProvider>
+    <CacheProvider value={cache}>
+      <MuiThemeProvider theme={customOdysseyTheme ?? odysseyTheme}>
+        <OdysseyDesignTokensContext.Provider value={odysseyTokens}>
+          {children}
+        </OdysseyDesignTokensContext.Provider>
+      </MuiThemeProvider>
+    </CacheProvider>
   );
 };
 

--- a/packages/odyssey-react-mui/src/OdysseyThemeProvider.tsx
+++ b/packages/odyssey-react-mui/src/OdysseyThemeProvider.tsx
@@ -25,7 +25,7 @@ import { OdysseyDesignTokensContext } from "./OdysseyDesignTokensContext";
 export type OdysseyThemeProviderProps = {
   children: ReactNode;
   designTokensOverride?: DesignTokensOverride;
-  shadowDomElement?: HTMLDivElement;
+  shadowDomElement?: HTMLElement;
   themeOverride?: ThemeOptions;
 };
 

--- a/packages/odyssey-react-mui/src/OdysseyThemeProvider.tsx
+++ b/packages/odyssey-react-mui/src/OdysseyThemeProvider.tsx
@@ -69,7 +69,7 @@ const OdysseyThemeProvider = ({
         key: uniqueAlphabeticalId,
         prepend: true,
         nonce: window.cspNonce,
-        speedy: false,
+        speedy: false, // <-- Needs to be set to false when shadow-dom is used!! https://github.com/emotion-js/emotion/issues/2053#issuecomment-713429122
       }),
     [emotionRoot, uniqueAlphabeticalId]
   );
@@ -86,7 +86,7 @@ const OdysseyThemeProvider = ({
     );
   }
   return (
-    <MuiThemeProvider theme={odysseyTheme}>
+    <MuiThemeProvider theme={customOdysseyTheme ?? odysseyTheme}>
       <OdysseyDesignTokensContext.Provider value={odysseyTokens}>
         {children}
       </OdysseyDesignTokensContext.Provider>

--- a/packages/odyssey-react-mui/src/createShadowRootElement.ts
+++ b/packages/odyssey-react-mui/src/createShadowRootElement.ts
@@ -10,12 +10,22 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-export const createShadowRootElement = (containerElement: HTMLElement) => {
+export const createShadowRootElement = (
+  containerElement: HTMLElement
+): [HTMLStyleElement, HTMLDivElement] => {
   const shadowRoot = containerElement.attachShadow({ mode: "open" });
 
+  // the element that styles will be cached into
+  const emotionRoot = document.createElement("style");
+  emotionRoot.setAttribute("id", "style-root");
+  emotionRoot.setAttribute("nonce", window.cspNonce);
+
+  // the element that emotion renders html into
   const shadowRootElement = document.createElement("div");
+  shadowRootElement.setAttribute("id", "shadow-root");
 
-  shadowRoot.append(shadowRootElement);
+  shadowRoot.appendChild(emotionRoot);
+  shadowRoot.appendChild(shadowRootElement);
 
-  return shadowRoot;
+  return [emotionRoot, shadowRootElement];
 };

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -53,7 +53,7 @@ export const components = ({
   shadowDomElement,
 }: {
   odysseyTokens: DesignTokens;
-  shadowDomElement?: HTMLDivElement;
+  shadowDomElement?: HTMLElement;
 }): ThemeOptions["components"] => {
   return {
     MuiAccordion: {

--- a/packages/odyssey-react-mui/src/theme/createOdysseyMuiTheme.ts
+++ b/packages/odyssey-react-mui/src/theme/createOdysseyMuiTheme.ts
@@ -32,7 +32,7 @@ export const createOdysseyMuiTheme = ({
   shadowDomElement,
 }: {
   odysseyTokens: DesignTokens;
-  shadowDomElement?: HTMLDivElement;
+  shadowDomElement?: HTMLElement;
 }) =>
   createTheme({
     components: components({

--- a/packages/odyssey-storybook/.storybook/components/MuiThemeDecorator.tsx
+++ b/packages/odyssey-storybook/.storybook/components/MuiThemeDecorator.tsx
@@ -1,7 +1,6 @@
 import {
   createOdysseyMuiTheme,
   OdysseyProvider,
-  OdysseyTranslationProvider,
 } from "@okta/odyssey-react-mui";
 import { CssBaseline, ScopedCssBaseline } from "@mui/material";
 import { ThemeProvider as StorybookThemeProvider } from "@storybook/theming";
@@ -16,21 +15,22 @@ const styles = {
 const odysseyTheme = createOdysseyMuiTheme({ odysseyTokens });
 
 export const MuiThemeDecorator: Decorator = (Story, context) => {
-  const { canvasElement } = context;
+  const {
+    canvasElement,
+    globals: { locale },
+  } = context;
   const shadowRootElement = canvasElement.parentElement ?? undefined;
   return (
-    <OdysseyProvider shadowDomElement={shadowRootElement}>
-      <OdysseyTranslationProvider languageCode={context.globals.locale}>
-        {/* @ts-expect-error type mismatch on "typography" */}
-        <StorybookThemeProvider theme={odysseyTheme}>
-          <CssBaseline />
-          <div style={styles}>
-            <ScopedCssBaseline>
-              <Story />
-            </ScopedCssBaseline>
-          </div>
-        </StorybookThemeProvider>
-      </OdysseyTranslationProvider>
+    <OdysseyProvider languageCode={locale} shadowDomElement={shadowRootElement}>
+      {/* @ts-expect-error type mismatch on "typography" */}
+      <StorybookThemeProvider theme={odysseyTheme}>
+        <CssBaseline />
+        <div style={styles}>
+          <ScopedCssBaseline>
+            <Story />
+          </ScopedCssBaseline>
+        </div>
+      </StorybookThemeProvider>
     </OdysseyProvider>
   );
 };

--- a/packages/odyssey-storybook/.storybook/components/MuiThemeDecorator.tsx
+++ b/packages/odyssey-storybook/.storybook/components/MuiThemeDecorator.tsx
@@ -1,6 +1,6 @@
 import {
   createOdysseyMuiTheme,
-  OdysseyThemeProvider,
+  OdysseyProvider,
   OdysseyTranslationProvider,
 } from "@okta/odyssey-react-mui";
 import { CssBaseline, ScopedCssBaseline } from "@mui/material";
@@ -15,18 +15,22 @@ const styles = {
 
 const odysseyTheme = createOdysseyMuiTheme({ odysseyTokens });
 
-export const MuiThemeDecorator: Decorator = (Story, context) => (
-  <OdysseyThemeProvider>
-    <OdysseyTranslationProvider languageCode={context.globals.locale}>
-      {/* @ts-expect-error type mismatch on "typography" */}
-      <StorybookThemeProvider theme={odysseyTheme}>
-        <CssBaseline />
-        <div style={styles}>
-          <ScopedCssBaseline>
-            <Story />
-          </ScopedCssBaseline>
-        </div>
-      </StorybookThemeProvider>
-    </OdysseyTranslationProvider>
-  </OdysseyThemeProvider>
-);
+export const MuiThemeDecorator: Decorator = (Story, context) => {
+  const { canvasElement } = context;
+  const shadowRootElement = canvasElement.parentElement ?? undefined;
+  return (
+    <OdysseyProvider shadowDomElement={shadowRootElement}>
+      <OdysseyTranslationProvider languageCode={context.globals.locale}>
+        {/* @ts-expect-error type mismatch on "typography" */}
+        <StorybookThemeProvider theme={odysseyTheme}>
+          <CssBaseline />
+          <div style={styles}>
+            <ScopedCssBaseline>
+              <Story />
+            </ScopedCssBaseline>
+          </div>
+        </StorybookThemeProvider>
+      </OdysseyTranslationProvider>
+    </OdysseyProvider>
+  );
+};

--- a/packages/odyssey-storybook/src/components/odyssey-labs/DatePicker/DatePicker.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/DatePicker/DatePicker.stories.tsx
@@ -12,7 +12,7 @@
 
 import { useMemo, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
-import { OdysseyThemeProvider } from "@okta/odyssey-react-mui";
+import { OdysseyProvider } from "@okta/odyssey-react-mui";
 import {
   AdapterDateFns,
   DatePicker,
@@ -70,6 +70,22 @@ const storybookMeta: Meta<DatePickerProps<unknown, unknown>> = {
 export default storybookMeta;
 
 export const DatePickerStandard: StoryObj<DatePickerProps<string, string>> = {
+  decorators: [
+    (Story, context) => {
+      const { canvasElement } = context;
+      const parentElement = canvasElement.parentElement ?? undefined;
+      return (
+        <OdysseyProvider
+          themeOverride={datePickerTheme}
+          shadowDomElement={parentElement}
+        >
+          <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <Story />
+          </LocalizationProvider>
+        </OdysseyProvider>
+      );
+    },
+  ],
   render: function C(props) {
     const [value, setValue] = useState("09/05/1977");
     const datePickerProps = useMemo<DatePickerProps<string, string>>(
@@ -81,12 +97,6 @@ export const DatePickerStandard: StoryObj<DatePickerProps<string, string>> = {
       [props, value]
     );
 
-    return (
-      <OdysseyThemeProvider themeOverride={datePickerTheme}>
-        <LocalizationProvider dateAdapter={AdapterDateFns}>
-          <DatePicker {...datePickerProps} />
-        </LocalizationProvider>
-      </OdysseyThemeProvider>
-    );
+    return <DatePicker {...datePickerProps} />;
   },
 };

--- a/packages/odyssey-storybook/src/contributing/CustomTheme.stories.tsx
+++ b/packages/odyssey-storybook/src/contributing/CustomTheme.stories.tsx
@@ -20,13 +20,13 @@ import {
   ListItemText,
   MenuItem,
   MenuList,
-  OdysseyThemeProvider,
   Paper,
   Radio,
   RadioGroup,
   TextField,
   ThemeOptions,
   ThemeProvider as MuiThemeProvider,
+  OdysseyProvider,
 } from "@okta/odyssey-react-mui";
 
 import { MuiThemeDecorator } from "../../.storybook/components/MuiThemeDecorator";
@@ -39,21 +39,32 @@ export default {
 };
 
 export const ButtonStory: StoryObj = {
+  decorators: [
+    (Story, context) => {
+      const odysseyDesignTokensOverrides: DesignTokensOverride = {
+        BorderRadiusMain: "12px",
+        HueBlue500: "green", //base background color
+        HueBlue900: "rgb(150,0,0,1)", //used for hover/focus
+        TypographyLineHeightHeading1: 1.2,
+        Spacing0: "1rem",
+      };
+      const shadowRootElement =
+        context.canvasElement.parentElement ?? undefined;
+      return (
+        <OdysseyProvider
+          designTokensOverride={odysseyDesignTokensOverrides}
+          shadowDomElement={shadowRootElement}
+        >
+          <Story />
+        </OdysseyProvider>
+      );
+    },
+  ],
   render: function C() {
-    const odysseyDesignTokensOverrides: DesignTokensOverride = {
-      BorderRadiusMain: "12px",
-      HueBlue500: "green", //base background color
-      HueBlue900: "rgb(150,0,0,1)", //used for hover/focus
-      TypographyLineHeightHeading1: 1.2,
-      Spacing0: "1rem",
-    };
-
     return (
-      <OdysseyThemeProvider designTokensOverride={odysseyDesignTokensOverrides}>
-        <div>
-          <Button label="Primary" variant="primary" />
-        </div>
-      </OdysseyThemeProvider>
+      <div>
+        <Button label="Primary" variant="primary" />
+      </div>
     );
   },
 };
@@ -61,21 +72,28 @@ export const ButtonStory: StoryObj = {
 ButtonStory.storyName = "Button";
 
 export const TextFieldStory: StoryObj = {
+  decorators: [
+    (Story, context) => {
+      const odysseyDesignTokensOverrides: DesignTokensOverride = {
+        HueBlue500: "orange",
+      };
+      const shadowRootElement =
+        context.canvasElement.parentElement ?? undefined;
+      return (
+        <OdysseyProvider
+          designTokensOverride={odysseyDesignTokensOverrides}
+          shadowDomElement={shadowRootElement}
+        >
+          <Story />
+        </OdysseyProvider>
+      );
+    },
+  ],
   render: function C() {
-    const odysseyDesignTokensOverrides: DesignTokensOverride = {
-      HueBlue500: "orange",
-    };
-
     return (
       <>
         <TextField autoCompleteType="name" label="Name" type="text" />
-        <OdysseyThemeProvider
-          designTokensOverride={odysseyDesignTokensOverrides}
-        >
-          <div>
-            <TextField autoCompleteType="name" label="Password" type="text" />
-          </div>
-        </OdysseyThemeProvider>
+        <TextField autoCompleteType="name" label="Password" type="text" />
       </>
     );
   },
@@ -84,26 +102,35 @@ export const TextFieldStory: StoryObj = {
 TextFieldStory.storyName = "TextField";
 
 export const RadioGroupStory: StoryObj = {
+  decorators: [
+    (Story, context) => {
+      const odysseyDesignTokensOverrides: DesignTokensOverride = {
+        HueBlue500: "rgba(0, 160, 100, 1)", // THIS IS A SAMPLE. DO NOT USE!
+      };
+      const shadowRootElement =
+        context.canvasElement.parentElement ?? undefined;
+      return (
+        <OdysseyProvider
+          designTokensOverride={odysseyDesignTokensOverrides}
+          shadowDomElement={shadowRootElement}
+        >
+          <Story />
+        </OdysseyProvider>
+      );
+    },
+  ],
   render: function C() {
-    const odysseyDesignTokensOverrides: DesignTokensOverride = {
-      HueBlue500: "rgba(0, 160, 100, 1)", // THIS IS A SAMPLE. DO NOT USE!
-    };
-
     return (
-      <OdysseyThemeProvider designTokensOverride={odysseyDesignTokensOverrides}>
-        <div>
-          <RadioGroup
-            defaultValue="Lightspeed"
-            id="radio-buttons-group"
-            label="Speed"
-            aria-describedby="radio-hint radio-error"
-          >
-            <Radio value="lightspeed" label="Lightspeed" />
-            <Radio value="Warp Speed" label="Warp Speed" />
-            <Radio value="Ludicrous Speed" label="Ludicrous Speed" />
-          </RadioGroup>
-        </div>
-      </OdysseyThemeProvider>
+      <RadioGroup
+        defaultValue="Lightspeed"
+        id="radio-buttons-group"
+        label="Speed"
+        aria-describedby="radio-hint radio-error"
+      >
+        <Radio value="lightspeed" label="Lightspeed" />
+        <Radio value="Warp Speed" label="Warp Speed" />
+        <Radio value="Ludicrous Speed" label="Ludicrous Speed" />
+      </RadioGroup>
     );
   },
 };

--- a/packages/odyssey-storybook/src/installation/ShadowDom.mdx
+++ b/packages/odyssey-storybook/src/installation/ShadowDom.mdx
@@ -8,12 +8,22 @@ Sometimes, you may need to sandbox your application's styles so Odyssey componen
 
 To sandbox your application's styles, you need to use a Shadow DOM. Odyssey natively supports the use of a Shadow DOM and even exports some helper functions.
 
+When creating the shadow root for your application, `createshadowDomElement` will return 2 elements in a tuple:
+
+<dl>
+  <dt>emotionRoot</dt>
+  <dd>A `style` node within the shadow root of the root node of your application. Emotion will cache styles here.</dd>
+
+  <dt>shadowDomElementRoot</dt>
+  <dd>A `div` node within the shadow root of your root node of your application. React-DOM should use this to create a root to render your application to.</dd>
+</dl>
+
 To create a Shadow DOM, simply use the `createshadowDomElement` function from Odyssey:
 
 ```tsx
 import { createshadowDomElement } from "@okta/odyssey-react-mui";
 
-const shadowDomElement = createshadowDomElement(
+const [emotionRoot, shadowDomElementRoot] = createshadowDomElement(
   document.querySelector("#root") as HTMLElement
 );
 ```
@@ -21,11 +31,63 @@ const shadowDomElement = createshadowDomElement(
 Then render your React app into the Shadow DOM root element and pass it to Odyssey's top-level `OdysseyProvider` like so:
 
 ```tsx
-ReactDOM.createRoot(shadowDomElement).render(
-  <OdysseyProvider shadowDomElement={shadowDomElement}>
+ReactDOM.createRoot(shadowDomElementRoot).render(
+  <OdysseyProvider
+    emotionRoot={emotionRoot}
+    shadowDomElement={shadowDomElementRoot}
+  >
     <App />
   </OdysseyProvider>
 );
+```
+
+If you are using a shadow DOM and a separate Emotion Cache in your application for other CSS styles within your app, you will need to create an instance of `Emotion`
+and supply it a container reference to the created `emotionRoot` above:
+
+```ts
+// utils.ts
+
+// Assumes the ID of the root element of your web application to be `root`
+// The ID of the `emotionRoot` style element is `style-root`
+
+import createEmotion from "@emotion/css/create-instance";
+
+export const getCss = () => {
+  const { css } = createEmotion({
+    key: "css",
+    nonce: window.cspNonce,
+    speedy: false,
+    prepend: true,
+    container:
+      document
+        .querySelector("#root")
+        ?.shadowRoot?.querySelector("#style-root") || undefined,
+  });
+  return css;
+};
+```
+
+The in your code, you can do something like:
+
+```tsx
+// MyComponent.tsx
+
+import { getCss } from "./utils"
+
+export const MyComponent = () => {
+
+  const css = getCss();
+
+  const componentStyle = css`
+    backgroundColor: white
+  `;
+
+  return (
+    <div className={componentStyle}>
+      { //... things }
+    </div>
+  )
+}
 ```
 
 If you're using separate `OdysseyThemeProvider` and `OdysseyCacheProvider` components, both of those also take the `shadowDomElement` element.


### PR DESCRIPTION
## Summary
- Change shadow root element type from `HTMLDivElement` to `HTMLElement` to avoid need to cast
- Fixed broken shadow dom themed tests
- Updated tests to show how to use `OdysseyProvider`

[OKTA-670823](https://oktainc.atlassian.net/browse/OKTA-670823)

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
