### PR TITLE
feat: add hint prop to Checkbox

### DIFF
--- a/packages/odyssey-react-mui/src/Checkbox.tsx
+++ b/packages/odyssey-react-mui/src/Checkbox.tsx
@@ -16,6 +16,7 @@ import {
   Checkbox as MuiCheckbox,
   CheckboxProps as MuiCheckboxProps,
   FormControlLabel,
+  FormHelperText,
 } from "@mui/material";
 
 import { FieldComponentProps } from "./FieldComponentProps";
@@ -56,6 +57,10 @@ export type CheckboxProps = {
    */
   label?: string;
   /**
+   * The helper text content
+   */
+  hint?: string;
+  /**
    * The checkbox validity, if different from its enclosing group. Defaults to "inherit".
    */
   validity?: (typeof checkboxValidityValues)[number];
@@ -77,6 +82,7 @@ const Checkbox = ({
   isIndeterminate,
   isRequired,
   label: labelProp,
+  hint,
   name: nameOverride,
   onChange: onChangeProp,
   testId,
@@ -90,19 +96,21 @@ const Checkbox = ({
   });
 
   const label = useMemo(() => {
-    if (isRequired) {
-      return (
-        <>
-          {labelProp}{" "}
-          <Typography component="span" color="textSecondary">
-            ({t("fieldlabel.required.text")})
-          </Typography>
-        </>
-      );
-    } else {
-      return <>{labelProp}</>;
-    }
-  }, [isRequired, labelProp, t]);
+    return (
+      <>
+        {labelProp}
+        {isRequired && (
+          <>
+            {" "}
+            <Typography component="span" color="textSecondary">
+              ({t("fieldlabel.required.text")})
+            </Typography>
+          </>
+        )}
+        {hint && <FormHelperText>{hint}</FormHelperText>}
+      </>
+    );
+  }, [isRequired, labelProp, hint, t]);
 
   const onChange = useCallback<NonNullable<MuiCheckboxProps["onChange"]>>(
     (event, checked) => {
@@ -114,6 +122,7 @@ const Checkbox = ({
 
   return (
     <FormControlLabel
+      sx={{ alignItems: "flex-start" }}
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledBy}
       className={
@@ -129,6 +138,9 @@ const Checkbox = ({
           indeterminate={isIndeterminate}
           onChange={onChange}
           required={isRequired}
+          sx={() => ({
+            marginBlockStart: "2px",
+          })}
         />
       }
       data-se={testId}

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Checkbox/Checkbox.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Checkbox/Checkbox.stories.tsx
@@ -94,6 +94,15 @@ const storybookMeta: Meta<typeof Checkbox> = {
         },
       },
     },
+    hint: {
+      control: "text",
+      description: "The helper text content",
+      table: {
+        type: {
+          summary: "string",
+        },
+      },
+    },
     name: fieldComponentPropsMetaData.name,
     onChange: {
       control: null,
@@ -221,6 +230,23 @@ export const Invalid: StoryObj<typeof Checkbox> = {
   },
   play: async ({ canvasElement, step }) => {
     checkTheBox({ canvasElement, step })("Checkbox Disabled");
+  },
+};
+
+export const Hint: StoryObj<typeof Checkbox> = {
+  parameters: {
+    docs: {
+      description: {
+        story: "hint provides helper text to the Checkbox",
+      },
+    },
+  },
+  args: {
+    label: "I agree to the terms and conditions",
+    hint: "Really helpful hint",
+  },
+  play: async ({ canvasElement, step }) => {
+    checkTheBox({ canvasElement, step })("Checkbox Hint");
   },
 };
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

[OKTA-670762](https://oktainc.atlassian.net/browse/OKTA-670762)

## Summary

**NOTE:** hint has been supported in TextField already, not code change is required.

Supports hint for Checkbox and TextField

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots
![Screenshot 2023-11-30 at 1 38 47 PM](https://github.com/okta/odyssey/assets/60160041/db5e2670-69fe-4150-8f20-fdf2b72dd55c)



- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
