### PR TITLE
Fix strange width in last DataTable column

### DIFF
--- a/packages/odyssey-react-mui/src/labs/DataTable.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataTable.tsx
@@ -456,7 +456,9 @@ const DataTable = ({
     onSortingChange: handleSortingChange,
     onRowSelectionChange: handleRowSelectionChange,
     enableRowActions:
-      hasRowReordering || rowActionButtons || rowActionMenuItems ? true : false,
+      hasRowReordering === true || rowActionButtons || rowActionMenuItems
+        ? true
+        : false,
     positionActionsColumn: "last",
 
     muiTableHeadCellProps: ({ column }) => ({

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -2333,8 +2333,10 @@ export const components = ({
           },
 
           [`& .${dividerClasses.vertical}`]: {
-            borderStyle: "dotted",
+            borderStyle: "none none none dotted",
             borderWidth: 2,
+            borderRadius: 0,
+            marginRight: 2,
           },
         }),
       },

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -2208,7 +2208,6 @@ export const components = ({
       styleOverrides: {
         root: ({ theme, ownerState }) => ({
           ...theme.typography.body1,
-          maxWidth: odysseyTokens.TypographyLineLengthMax,
           borderBottom: `${odysseyTokens.BorderWidthMain} ${odysseyTokens.BorderStyleMain} ${odysseyTokens.HueNeutral100}`,
           textAlign: "start",
           verticalAlign: "baseline",
@@ -2354,6 +2353,7 @@ export const components = ({
           marginBlockEnd: odysseyTokens.Spacing4,
           marginInline: 0,
           overflowX: "auto",
+          display: "block !important",
 
           "&:last-child": {
             marginBlock: 0,

--- a/packages/odyssey-storybook/src/components/odyssey-labs/DataTable/DataTable.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/DataTable/DataTable.stories.tsx
@@ -461,3 +461,74 @@ export const Default: StoryObj<DataTableProps> = {
     );
   },
 };
+
+export const NoActions: StoryObj<DataTableProps> = {
+  args: {
+    hasChangeableDensity: true,
+    hasColumnResizing: true,
+    hasColumnVisibility: true,
+    hasFilters: true,
+    hasPagination: true,
+    hasRowSelection: true,
+    hasSearch: true,
+    hasSorting: true,
+    hasRowReordering: false,
+    paginationType: "paged",
+  },
+  render: function C(props) {
+    const data = incomingData;
+
+    const fetchData = ({
+      page,
+      resultsPerPage,
+      search,
+      filters,
+      sort,
+    }: {
+      page?: number;
+      resultsPerPage?: number;
+      search?: string;
+      filters?: DataFilter[];
+      sort?: MRT_SortingState;
+    }) => {
+      return processData({
+        initialData: data,
+        page: page,
+        resultsPerPage: resultsPerPage,
+        search: search,
+        filters: filters,
+        sort: sort,
+      });
+    };
+
+    const startingData = fetchData({});
+
+    return (
+      <Box>
+        <Callout severity="info">
+          Data in this table is procedurally-generated and will change on each
+          page refresh. Any resemblance to real information is coincidental.
+        </Callout>
+        <DataTable
+          columns={columns}
+          data={startingData}
+          totalRows={data.length}
+          getRowId={({ id }) => id}
+          fetchDataFn={fetchData}
+          hasSearchSubmitButton={true}
+          hasChangeableDensity={props.hasChangeableDensity}
+          hasColumnResizing={props.hasColumnResizing}
+          hasColumnVisibility={props.hasColumnVisibility}
+          hasFilters={props.hasFilters}
+          hasPagination={props.hasPagination}
+          hasRowSelection={props.hasRowSelection}
+          hasRowReordering={props.hasRowReordering}
+          hasSearch={props.hasSearch}
+          hasSorting={props.hasSorting}
+          paginationType={props.paginationType}
+          onRowSelectionChange={(rowSelection) => console.log(rowSelection)}
+        />
+      </Box>
+    );
+  },
+};


### PR DESCRIPTION
I'd originally misdiagnosed this problem as the Actions column showing up whether or not there were row actions. Turns out it was the last column showing an incorrect width, fixed with some CSS fixes that coincidentally improved the table appearance. The DataTable is now always the full width of the container, and handles column resizing more elegantly than it did before.