### PR TITLE
feat: commit template for new component contributions

### DIFF
--- a/.github/NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md
+++ b/.github/NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md
@@ -42,8 +42,8 @@ Thank you for contributing! Please follow the steps below to help us process you
 ### Responsive implementation
 
 - [ ] Use CSS media queries to define breakpoints and apply styles.
-- [ ] Test fluid layouts and resizing behavior at each breakpoint.
-- [ ] Optimize images for different screen resolutions.
+- [ ] Test fluid layouts and resizing behavior at each breakpoint as needed.
+- [ ] Optimize images for different screen resolutions as needed.
 
 ### Cross-browser compatibility
 

--- a/.github/NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md
+++ b/.github/NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,79 @@
+<!--
+Thank you for contributing! Please follow the steps below to help us process your PR quickly.
+
+- 📝 Use a meaningful title for the pull request and include the name of the package modified.
+- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
+- ✅ Add or edit tests to reflect the change (run `yarn test`).
+- 🙏 Please review your own PR to check for anything you may have missed.
+-->
+
+[REPLACE_WITH_JIRA_TICKET_NUMBER](https://oktainc.atlassian.net/browse/REPLACE_WITH_JIRA_TICKET_NUMBER)
+
+## Summary
+
+<!--
+  Add a description with these talking points:
+  1. Figma link if applicable.
+  2. A brief description of the work and why it was done in this particular way.
+-->
+
+## Component checklist
+
+<!-- Pease track and mark relevant items as part of the component development process -->
+
+### Code structure
+
+- [ ] Organize code using a modular component architecture.
+- [ ] Use semantic HTML for clear and meaningful structure.
+- [ ] Break down complex components into smaller, reusable parts.
+
+### Accessibility implementation
+
+- [ ] Apply ARIA attributes to indicate roles and relationships.
+- [ ] Test focus management and ensure interactive elements are keyboard accessible.
+- [ ] Include skip-to-content links for screen reader users.
+- [ ] Provide visual alternatives for auditory elements.
+
+### Internationalization (i18n) implementation
+
+- [ ] Separate text content from the component's code for translation.
+- [ ] Ensure the component renders correctly when language changes.
+
+### Responsive implementation
+
+- [ ] Use CSS media queries to define breakpoints and apply styles.
+- [ ] Test fluid layouts and resizing behavior at each breakpoint.
+- [ ] Optimize images for different screen resolutions.
+
+### Cross-browser compatibility
+
+- [ ] Test the component on major browsers (Chrome, Firefox, Safari, Edge, etc.).
+- [ ] Use browser prefixes or CSS libraries to handle compatibility issues.
+- [ ] Ensure consistent behavior and appearance across browsers.
+
+### Documentation
+
+- [ ] Create clear and concise usage documentation with step-by-step instructions.
+- [ ] Include code snippets, demos, and examples for various use cases.
+- [ ] Provide guidance on customization and handling special cases.
+
+### Finalize code
+
+- [ ] Review PR for final detailing
+- [ ] Approve PR in GitHub
+- [ ] Interaction designers, UI eng and visual designers need to review that the Storybook code matches the intended Figma design
+- [ ] Interaction designers need to confirm Storybook code matches Supernova
+- [ ] Interaction and visual designers merge Figma and code at the same time
+- [ ] Share updates to the [#design-system-team](https://okta.slack.com/archives/C02JL12CJPQ)
+
+### QA
+
+- [ ] Conduct unit testing to continuously verify individual component functionality.
+- [ ] Include unit tests to continuously verify component functionality
+- [ ] Screen reader test error/success states or message
+- [ ] Test edge cases and error scenarios to validate robustness
+
+### Testing and validation
+
+- [ ] Work shared in [Craft](https://docs.google.com/document/d/1dqaEzKW3SlKccw2ILjX7y3LQY0toeNe9OuwpOs2XxcI/edit#heading=h.j8zakyclqze5) to get feedback from the Odyssey team
+- [ ] Share work to get feedback from pillar design captains or product designers in [#design-team](https://okta.slack.com/archives/G7REPJFUY) as customer feedback is essential to help us validate our assumptions, identify pain points, and improve our user experience

--- a/.github/NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md
+++ b/.github/NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ Thank you for contributing! Please follow the steps below to help us process you
 
 ## Component checklist
 
-<!-- Pease track and mark relevant items as part of the component development process -->
+<!-- Pease track and mark relevant items as part of the component development process. Remove any non-applicable items. -->
 
 ### Code structure
 
@@ -39,7 +39,7 @@ Thank you for contributing! Please follow the steps below to help us process you
 - [ ] Separate text content from the component's code for translation.
 - [ ] Ensure the component renders correctly when language changes.
 
-### Responsive implementation
+### Responsive implementation (if applicable)
 
 - [ ] Use CSS media queries to define breakpoints and apply styles.
 - [ ] Test fluid layouts and resizing behavior at each breakpoint as needed.
@@ -59,8 +59,6 @@ Thank you for contributing! Please follow the steps below to help us process you
 
 ### Finalize code
 
-- [ ] Review PR for final detailing
-- [ ] Approve PR in GitHub
 - [ ] Interaction designers, UI eng and visual designers need to review that the Storybook code matches the intended Figma design
 - [ ] Interaction designers need to confirm Storybook code matches Supernova
 - [ ] Interaction and visual designers merge Figma and code at the same time

--- a/.github/NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md
+++ b/.github/NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md
@@ -75,5 +75,5 @@ Thank you for contributing! Please follow the steps below to help us process you
 
 ### Testing and validation
 
-- [ ] Work shared in [Craft](https://docs.google.com/document/d/1dqaEzKW3SlKccw2ILjX7y3LQY0toeNe9OuwpOs2XxcI/edit#heading=h.j8zakyclqze5) to get feedback from the Odyssey team
+- [ ] Share work in [Craft](https://docs.google.com/document/d/1dqaEzKW3SlKccw2ILjX7y3LQY0toeNe9OuwpOs2XxcI/edit#heading=h.j8zakyclqze5) to get feedback from the Odyssey team
 - [ ] Share work to get feedback from pillar design captains or product designers in [#design-team](https://okta.slack.com/archives/G7REPJFUY) as customer feedback is essential to help us validate our assumptions, identify pain points, and improve our user experience


### PR DESCRIPTION
Adds Github commit template for new component contributions.

[OKTA-672078](https://oktainc.atlassian.net/browse/OKTA-672078)
https://oktainc.atlassian.net/browse/OKTA-672078

## Summary

Creating a new template that we can use for new component contributions. The template includes the Developer checklist from the Odyssey Component Workflow project. The workflow for using this component will be integrated separately after this template is merged.

