### PR TITLE
Add ability to render a Badge inside a Tab

### DIFF
--- a/packages/odyssey-react-mui/src/Badge.tsx
+++ b/packages/odyssey-react-mui/src/Badge.tsx
@@ -55,16 +55,11 @@ const Badge = ({
     const greaterThanZeroContentMax = badgeContentMax > 0 ? badgeContentMax : 1;
     const threeDigitLimitedMax =
       greaterThanZeroContentMax > 999 ? 999 : greaterThanZeroContentMax;
-    const isOverContentMax = Boolean(
-      badgeContent && badgeContent > threeDigitLimitedMax
-    );
+    const isOverContentMax = badgeContent > threeDigitLimitedMax;
     const overContentMaxMessage = `${greaterThanZeroContentMax}+`;
     const formattedContent = isOverContentMax
       ? overContentMaxMessage
       : badgeContent.toString();
-
-    const contentIsLongerThanOneChar =
-      formattedContent && formattedContent.length > 1;
 
     const badgeStyles: CSSProperties = {
       display: "inline-flex",
@@ -77,9 +72,10 @@ const Badge = ({
       padding: "0 6px",
       backgroundColor: badgeTypeColors(odysseyDesignTokens)[type].background,
       color: badgeTypeColors(odysseyDesignTokens)[type].font,
-      borderRadius: contentIsLongerThanOneChar
-        ? `${odysseyDesignTokens.BorderRadiusOuter}`
-        : "50%",
+      borderRadius:
+        formattedContent.length > 1
+          ? `${odysseyDesignTokens.BorderRadiusOuter}`
+          : "50%",
       fontSize: `${odysseyDesignTokens.TypographyScale0}`,
       fontFamily: `${odysseyDesignTokens.TypographyFamilyMono}`,
       fontWeight: `${odysseyDesignTokens.TypographyWeightBodyBold}`,

--- a/packages/odyssey-react-mui/src/Badge.tsx
+++ b/packages/odyssey-react-mui/src/Badge.tsx
@@ -51,20 +51,21 @@ const Badge = ({
 }: BadgeProps) => {
   const odysseyDesignTokens = useOdysseyDesignTokens();
 
-  const greaterThanZeroContentMax = badgeContentMax > 0 ? badgeContentMax : 1;
-  const threeDigitLimitedMax =
-    greaterThanZeroContentMax > 999 ? 999 : greaterThanZeroContentMax;
-  const isOverContentMax = Boolean(
-    badgeContent && badgeContent > threeDigitLimitedMax
-  );
-  const overContentMaxMessage = `${greaterThanZeroContentMax}+`;
-  const formattedContent = isOverContentMax
-    ? overContentMaxMessage
-    : badgeContent;
-  const contentIsLongerThanOneChar = formattedContent?.toString()?.length > 1;
+  const renderBadge = useMemo(() => {
+    const greaterThanZeroContentMax = badgeContentMax > 0 ? badgeContentMax : 1;
+    const threeDigitLimitedMax =
+      greaterThanZeroContentMax > 999 ? 999 : greaterThanZeroContentMax;
+    const isOverContentMax = Boolean(
+      badgeContent && badgeContent > threeDigitLimitedMax
+    );
+    const overContentMaxMessage = `${greaterThanZeroContentMax}+`;
+    const formattedContent = isOverContentMax
+      ? overContentMaxMessage
+      : badgeContent;
 
-  const badgeStyles = useMemo<CSSProperties>(
-    () => ({
+    const contentIsLongerThanOneChar = formattedContent?.toString()?.length > 1;
+
+    const badgeStyles: CSSProperties = {
       display: "inline-flex",
       alignItems: "center",
       justifyContent: "center",
@@ -84,21 +85,18 @@ const Badge = ({
       lineHeight: 1,
       transitionDuration: `${odysseyDesignTokens.TransitionDurationMain}`,
       transitionProperty: `background-color, color`,
-    }),
-    [type, contentIsLongerThanOneChar, odysseyDesignTokens]
-  );
+    };
 
-  const shouldHideBadge = badgeContent <= 0 || !badgeContent;
+    const shouldHideBadge = badgeContent <= 0 || !badgeContent;
 
-  if (shouldHideBadge) {
-    return null;
-  }
+    if (shouldHideBadge) {
+      return null;
+    }
 
-  return (
-    <Box sx={badgeStyles} data-se={testId} translate={translate}>
-      {formattedContent}
-    </Box>
-  );
+    return <Box sx={badgeStyles}>{formattedContent}</Box>;
+  }, [badgeContent, badgeContentMax, type]);
+
+  return renderBadge;
 };
 
 const MemoizedBadge = memo(Badge);

--- a/packages/odyssey-react-mui/src/Badge.tsx
+++ b/packages/odyssey-react-mui/src/Badge.tsx
@@ -61,9 +61,10 @@ const Badge = ({
     const overContentMaxMessage = `${greaterThanZeroContentMax}+`;
     const formattedContent = isOverContentMax
       ? overContentMaxMessage
-      : badgeContent;
+      : badgeContent.toString();
 
-    const contentIsLongerThanOneChar = formattedContent?.toString()?.length > 1;
+    const contentIsLongerThanOneChar =
+      formattedContent && formattedContent.length > 1;
 
     const badgeStyles: CSSProperties = {
       display: "inline-flex",
@@ -73,7 +74,7 @@ const Badge = ({
       height: `calc(${odysseyDesignTokens.Spacing4} + ${odysseyDesignTokens.Spacing1})`,
       minHeight: `calc(${odysseyDesignTokens.Spacing4} + ${odysseyDesignTokens.Spacing1})`,
       // 6px horizontal padding per design requirements
-      padding: `0 calc(${odysseyDesignTokens.Spacing1} * 1.5)`,
+      padding: "0 6px",
       backgroundColor: badgeTypeColors(odysseyDesignTokens)[type].background,
       color: badgeTypeColors(odysseyDesignTokens)[type].font,
       borderRadius: contentIsLongerThanOneChar
@@ -87,13 +88,11 @@ const Badge = ({
       transitionProperty: `background-color, color`,
     };
 
-    const shouldRenderBadge = badgeContent && badgeContent > 0;
+    const hasNotificationCount = badgeContent && badgeContent > 0;
 
-    if (shouldRenderBadge) {
-      return <Box sx={badgeStyles}>{formattedContent}</Box>;
-    } else {
-      return null;
-    }
+    return hasNotificationCount ? (
+      <Box sx={badgeStyles}>{formattedContent}</Box>
+    ) : null;
   }, [badgeContent, badgeContentMax, odysseyDesignTokens, type]);
 
   return renderBadge;

--- a/packages/odyssey-react-mui/src/Badge.tsx
+++ b/packages/odyssey-react-mui/src/Badge.tsx
@@ -87,7 +87,9 @@ const Badge = ({
     const hasNotificationCount = badgeContent && badgeContent > 0;
 
     return hasNotificationCount ? (
-      <Box sx={badgeStyles}>{formattedContent}</Box>
+      <Box sx={badgeStyles} data-se={testId} translate={translate}>
+        {formattedContent}
+      </Box>
     ) : null;
   }, [badgeContent, badgeContentMax, odysseyDesignTokens, type]);
 

--- a/packages/odyssey-react-mui/src/Badge.tsx
+++ b/packages/odyssey-react-mui/src/Badge.tsx
@@ -91,7 +91,14 @@ const Badge = ({
         {formattedContent}
       </Box>
     ) : null;
-  }, [badgeContent, badgeContentMax, odysseyDesignTokens, type]);
+  }, [
+    badgeContent,
+    badgeContentMax,
+    odysseyDesignTokens,
+    testId,
+    translate,
+    type,
+  ]);
 
   return renderBadge;
 };

--- a/packages/odyssey-react-mui/src/Badge.tsx
+++ b/packages/odyssey-react-mui/src/Badge.tsx
@@ -82,6 +82,8 @@ const Badge = ({
       fontFamily: `${odysseyDesignTokens.TypographyFamilyMono}`,
       fontWeight: `${odysseyDesignTokens.TypographyWeightBodyBold}`,
       lineHeight: 1,
+      transitionDuration: `${odysseyDesignTokens.TransitionDurationMain}`,
+      transitionProperty: `background-color, color`,
     }),
     [type, contentIsLongerThanOneChar, odysseyDesignTokens]
   );

--- a/packages/odyssey-react-mui/src/Badge.tsx
+++ b/packages/odyssey-react-mui/src/Badge.tsx
@@ -87,14 +87,14 @@ const Badge = ({
       transitionProperty: `background-color, color`,
     };
 
-    const shouldHideBadge = badgeContent <= 0 || !badgeContent;
+    const shouldRenderBadge = badgeContent && badgeContent > 0;
 
-    if (shouldHideBadge) {
+    if (shouldRenderBadge) {
+      return <Box sx={badgeStyles}>{formattedContent}</Box>;
+    } else {
       return null;
     }
-
-    return <Box sx={badgeStyles}>{formattedContent}</Box>;
-  }, [badgeContent, badgeContentMax, type]);
+  }, [badgeContent, badgeContentMax, odysseyDesignTokens, type]);
 
   return renderBadge;
 };

--- a/packages/odyssey-react-mui/src/Tabs.tsx
+++ b/packages/odyssey-react-mui/src/Tabs.tsx
@@ -98,7 +98,7 @@ const TabLabel = ({
   return (
     <>
       {label}
-      {typeof notificationCount === "number" && notificationCount > 0 && (
+      {notificationCount !== undefined && notificationCount > 0 && (
         <Box
           sx={{
             marginInlineStart: notificationCount

--- a/packages/odyssey-react-mui/src/Tabs.tsx
+++ b/packages/odyssey-react-mui/src/Tabs.tsx
@@ -11,13 +11,6 @@
  */
 
 import {
-  TabContext as MuiTabContext,
-  TabList as MuiTabList,
-  TabListProps as MuiTabListProps,
-  TabPanel as MuiTabPanel,
-} from "@mui/lab";
-import { Tab as MuiTab } from "@mui/material";
-import {
   ReactElement,
   ReactNode,
   memo,
@@ -25,7 +18,18 @@ import {
   useEffect,
   useState,
 } from "react";
+import {
+  TabContext as MuiTabContext,
+  TabList as MuiTabList,
+  TabListProps as MuiTabListProps,
+  TabPanel as MuiTabPanel,
+} from "@mui/lab";
+import { Tab as MuiTab } from "@mui/material";
+
+import { useOdysseyDesignTokens } from "./OdysseyDesignTokensContext";
+import { Badge, BadgeProps } from "./Badge";
 import { AllowedProps } from "./AllowedProps";
+import { Box } from "./Box";
 
 export type TabItemProps = {
   /**
@@ -48,7 +52,12 @@ export type TabItemProps = {
    * The value associated with the TabItem
    */
   value?: string;
-} & AllowedProps;
+  /**
+   * The content for an optional badge
+   */
+  badgeContent?: BadgeProps["badgeContent"];
+} & Pick<BadgeProps, "badgeContentMax"> &
+  AllowedProps;
 
 export type TabsProps = {
   /**
@@ -81,6 +90,8 @@ const Tabs = ({
   value,
   onChange: onChangeProp,
 }: TabsProps) => {
+  const odysseyDesignTokens = useOdysseyDesignTokens();
+
   const [tabState, setTabState] = useState(initialValue ?? value ?? "0");
 
   const onChange = useCallback<NonNullable<MuiTabListProps["onChange"]>>(
@@ -100,16 +111,48 @@ const Tabs = ({
   return (
     <MuiTabContext value={tabState}>
       <MuiTabList onChange={onChange} aria-label={ariaLabel}>
-        {tabs.map((tab, index) => (
-          <MuiTab
-            data-se={tab.testId}
-            disabled={tab.isDisabled}
-            icon={tab.startIcon}
-            label={tab.label}
-            value={tab.value ? tab.value : index.toString()}
-            key={tab.value ? tab.value : index.toString()}
-          />
-        ))}
+        {tabs.map((tab, index) => {
+          const {
+            testId,
+            isDisabled,
+            label,
+            startIcon,
+            value,
+            badgeContent,
+            badgeContentMax,
+          } = tab;
+
+          const BadgeLabel = () => {
+            return (
+              <>
+                {label}
+                {badgeContent && (
+                  <Box
+                    sx={{
+                      marginInlineStart: odysseyDesignTokens.Spacing2,
+                    }}
+                  >
+                    <Badge
+                      badgeContent={badgeContent}
+                      badgeContentMax={badgeContentMax}
+                      type={value === tabState ? "attention" : "default"}
+                    />
+                  </Box>
+                )}
+              </>
+            );
+          };
+          return (
+            <MuiTab
+              data-se={testId}
+              disabled={isDisabled}
+              icon={startIcon}
+              label={<BadgeLabel />}
+              value={value ? value : index.toString()}
+              key={value ? value : index.toString()}
+            />
+          );
+        })}
       </MuiTabList>
       {tabs.map((tab, index) => (
         <MuiTabPanel

--- a/packages/odyssey-react-mui/src/Tabs.tsx
+++ b/packages/odyssey-react-mui/src/Tabs.tsx
@@ -45,6 +45,10 @@ export type TabItemProps = {
    */
   label: string;
   /**
+   * The content for an optional notification badge
+   */
+  notificationCount?: BadgeProps["badgeContent"];
+  /**
    * An optional icon to display at the start of the TabItem
    */
   startIcon?: ReactElement;
@@ -52,10 +56,6 @@ export type TabItemProps = {
    * The value associated with the TabItem
    */
   value?: string;
-  /**
-   * The content for an optional badge
-   */
-  badgeContent?: BadgeProps["badgeContent"];
 } & Pick<BadgeProps, "badgeContentMax"> &
   AllowedProps;
 
@@ -118,7 +118,7 @@ const Tabs = ({
             label,
             startIcon,
             value,
-            badgeContent,
+            notificationCount,
             badgeContentMax,
           } = tab;
 
@@ -126,21 +126,22 @@ const Tabs = ({
             return (
               <>
                 {label}
-                {!!badgeContent && badgeContent > 0 && (
-                  <Box
-                    sx={{
-                      marginInlineStart: badgeContent
-                        ? odysseyDesignTokens.Spacing2
-                        : 0,
-                    }}
-                  >
-                    <Badge
-                      badgeContent={badgeContent}
-                      badgeContentMax={badgeContentMax}
-                      type={value === tabState ? "attention" : "default"}
-                    />
-                  </Box>
-                )}
+                {typeof notificationCount === "number" &&
+                  notificationCount > 0 && (
+                    <Box
+                      sx={{
+                        marginInlineStart: notificationCount
+                          ? odysseyDesignTokens.Spacing2
+                          : 0,
+                      }}
+                    >
+                      <Badge
+                        badgeContent={notificationCount}
+                        badgeContentMax={badgeContentMax}
+                        type={value === tabState ? "attention" : "default"}
+                      />
+                    </Box>
+                  )}
               </>
             );
           };

--- a/packages/odyssey-react-mui/src/Tabs.tsx
+++ b/packages/odyssey-react-mui/src/Tabs.tsx
@@ -171,7 +171,7 @@ const Tabs = ({
         />
       );
     },
-    [tabState, value]
+    [tabState]
   );
 
   return (

--- a/packages/odyssey-react-mui/src/Tabs.tsx
+++ b/packages/odyssey-react-mui/src/Tabs.tsx
@@ -126,10 +126,12 @@ const Tabs = ({
             return (
               <>
                 {label}
-                {badgeContent && (
+                {!!badgeContent && badgeContent > 0 && (
                   <Box
                     sx={{
-                      marginInlineStart: odysseyDesignTokens.Spacing2,
+                      marginInlineStart: badgeContent
+                        ? odysseyDesignTokens.Spacing2
+                        : 0,
                     }}
                   >
                     <Badge
@@ -142,6 +144,7 @@ const Tabs = ({
               </>
             );
           };
+
           return (
             <MuiTab
               data-se={testId}

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -2208,10 +2208,11 @@ export const components = ({
         root: ({ ownerState }) => ({
           maxWidth: `calc(${odysseyTokens.TypographyLineLengthMax} / 2)`,
           minWidth: "unset",
-          minHeight: "unset",
+          minHeight: odysseyTokens.Spacing9,
           padding: `${odysseyTokens.Spacing4} ${odysseyTokens.Spacing1}`,
           fontSize: odysseyTokens.TypographySizeHeading6,
           fontFamily: odysseyTokens.TypographyFamilyHeading,
+          lineHeight: odysseyTokens.TypographyLineHeightUi,
           overflow: "visible",
           color: odysseyTokens.HueNeutral600,
           opacity: 1,

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -2212,7 +2212,8 @@ export const components = ({
           padding: `${odysseyTokens.Spacing4} ${odysseyTokens.Spacing1}`,
           fontSize: odysseyTokens.TypographySizeHeading6,
           fontFamily: odysseyTokens.TypographyFamilyHeading,
-          lineHeight: odysseyTokens.TypographyLineHeightUi,
+          // Increased line-height to avoid visual jump when Badge is rendered in a Tab
+          lineHeight: 1.5,
           overflow: "visible",
           color: odysseyTokens.HueNeutral600,
           opacity: 1,

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -2212,8 +2212,6 @@ export const components = ({
           padding: `${odysseyTokens.Spacing4} ${odysseyTokens.Spacing1}`,
           fontSize: odysseyTokens.TypographySizeHeading6,
           fontFamily: odysseyTokens.TypographyFamilyHeading,
-          // Increased line-height to avoid visual jump when Badge is rendered in a Tab
-          lineHeight: 1.5,
           overflow: "visible",
           color: odysseyTokens.HueNeutral600,
           opacity: 1,

--- a/packages/odyssey-storybook/src/components/odyssey-labs/LegacyTable/PaginatedTable.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/LegacyTable/PaginatedTable.stories.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { useCallback, useMemo, useRef, useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 import { Button } from "@okta/odyssey-react-mui";
 import {
@@ -19,7 +20,6 @@ import {
 } from "@okta/odyssey-react-mui/labs";
 
 import { MuiThemeDecorator } from "../../../../.storybook/components";
-import { useCallback, useRef, useState } from "react";
 
 const storybookMeta: Meta = {
   title: "Labs Components/Legacy Table/PaginatedTable",
@@ -541,7 +541,7 @@ export const Pagination: StoryObj<PaginatedTableProps<Person>> = {
   },
   render: function C(args) {
     const countRef = useRef(15);
-    const dataArg = args.data ?? [];
+    const dataArg = useMemo(() => args.data ?? [], [args]);
 
     const [data, setData] = useState(dataArg.slice(0, countRef.current));
 

--- a/packages/odyssey-storybook/src/components/odyssey-labs/LegacyTable/PaginatedTable.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/LegacyTable/PaginatedTable.stories.tsx
@@ -549,7 +549,7 @@ export const Pagination: StoryObj<PaginatedTableProps<Person>> = {
       countRef.current = countRef.current + 10;
 
       setData(dataArg.slice(0, Math.min(countRef.current, dataArg.length)));
-    }, [args.data, dataArg]);
+    }, [dataArg]);
 
     return (
       <PaginatedTable {...args} data={data} fetchMoreData={fetchMoreData} />

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
@@ -101,7 +101,7 @@ const storybookMeta: Meta<TabsProps & TabItemProps> = {
         },
       },
     },
-    badgeContent: {
+    notificationCount: {
       control: { type: "number" },
       description: "The value associated with the Badge",
       table: {
@@ -172,7 +172,7 @@ const DefaultTemplate: StoryObj<TabItemProps> = {
 
     if (args?.label) {
       tabs.push({
-        badgeContent: args?.badgeContent,
+        notificationCount: args?.notificationCount,
         badgeContentMax: args?.badgeContentMax,
         label: args.label,
         value: args.value,

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
@@ -110,10 +110,10 @@ const storybookMeta: Meta<TabsProps & TabItemProps> = {
         },
       },
     },
-    badgeContentMax: {
+    notificationCountMax: {
       control: { type: "number" },
       description:
-        "The limit at which the badge will show '`{badgeContentMax}`+'. A number between 0-999",
+        "The limit at which the badge will show '`{notificationCountMax}`+'. A number between 0-999",
       table: {
         type: {
           summary: "number",
@@ -173,7 +173,7 @@ const DefaultTemplate: StoryObj<TabItemProps> = {
     if (args?.label) {
       tabs.push({
         notificationCount: args?.notificationCount,
-        badgeContentMax: args?.badgeContentMax,
+        notificationCountMax: args?.notificationCountMax,
         label: args.label,
         value: args.value,
         isDisabled: args.isDisabled,
@@ -275,7 +275,7 @@ export const Controlled: StoryObj<TabItemProps> = {
 export const WithBadge: StoryObj<TabItemProps> = {
   ...DefaultTemplate,
   args: {
-    badgeContent: 0,
+    notificationCount: 0,
     label: "Xenomorphs",
     value: "xenomorphs",
     children: <ExampleTabContent label="Xenomorphs" />,

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
@@ -101,6 +101,32 @@ const storybookMeta: Meta<TabsProps & TabItemProps> = {
         },
       },
     },
+    badgeContent: {
+      control: { type: "number" },
+      description: "The value associated with the Badge",
+      table: {
+        type: {
+          summary: "number",
+        },
+      },
+    },
+    badgeContentMax: {
+      control: { type: "number" },
+      description:
+        "The limit at which the badge will show '`{badgeContentMax}`+'. A number between 0-999",
+      table: {
+        type: {
+          summary: "number",
+        },
+        defaultValue: {
+          summary: "999",
+        },
+      },
+      type: {
+        required: false,
+        name: "number",
+      },
+    },
   },
   args: {
     value: "stars",
@@ -248,36 +274,8 @@ export const Controlled: StoryObj<TabItemProps> = {
 
 export const WithBadge: StoryObj<TabItemProps> = {
   ...DefaultTemplate,
-  argTypes: {
-    badgeContent: {
-      control: { type: "number" },
-      description: "The value associated with the Badge",
-      table: {
-        type: {
-          summary: "number",
-        },
-      },
-    },
-    badgeContentMax: {
-      control: { type: "number" },
-      description:
-        "The limit at which the badge will show '`{badgeContentMax}`+'. A number between 0-999",
-      table: {
-        type: {
-          summary: "number",
-        },
-        defaultValue: {
-          summary: "999",
-        },
-      },
-      type: {
-        required: false,
-        name: "number",
-      },
-    },
-  },
   args: {
-    badgeContent: 9,
+    badgeContent: 0,
     label: "Xenomorphs",
     value: "xenomorphs",
     children: <ExampleTabContent label="Xenomorphs" />,

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
@@ -275,7 +275,7 @@ export const Controlled: StoryObj<TabItemProps> = {
 export const WithBadge: StoryObj<TabItemProps> = {
   ...DefaultTemplate,
   args: {
-    notificationCount: 0,
+    notificationCount: 1,
     label: "Xenomorphs",
     value: "xenomorphs",
     children: <ExampleTabContent label="Xenomorphs" />,

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tabs/Tabs.stories.tsx
@@ -146,6 +146,8 @@ const DefaultTemplate: StoryObj<TabItemProps> = {
 
     if (args?.label) {
       tabs.push({
+        badgeContent: args?.badgeContent,
+        badgeContentMax: args?.badgeContentMax,
         label: args.label,
         value: args.value,
         isDisabled: args.isDisabled,
@@ -241,5 +243,46 @@ export const Controlled: StoryObj<TabItemProps> = {
         </Box>
       </>
     );
+  },
+};
+
+export const WithBadge: StoryObj<TabItemProps> = {
+  ...DefaultTemplate,
+  argTypes: {
+    badgeContent: {
+      control: { type: "number" },
+      description: "The value associated with the Badge",
+      table: {
+        type: {
+          summary: "number",
+        },
+      },
+    },
+    badgeContentMax: {
+      control: { type: "number" },
+      description:
+        "The limit at which the badge will show '`{badgeContentMax}`+'. A number between 0-999",
+      table: {
+        type: {
+          summary: "number",
+        },
+        defaultValue: {
+          summary: "999",
+        },
+      },
+      type: {
+        required: false,
+        name: "number",
+      },
+    },
+  },
+  args: {
+    badgeContent: 9,
+    label: "Xenomorphs",
+    value: "xenomorphs",
+    children: <ExampleTabContent label="Xenomorphs" />,
+  },
+  play: async ({ canvasElement, step }) => {
+    selectTab({ canvasElement, step })("Tab Icon", "Xenomorphs");
   },
 };


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

[OKTA-668233](https://oktainc.atlassian.net/browse/OKTA-668233)

## Summary
- Adds ability to render a `Badge` in a `Tab`

#### Figma link
https://www.figma.com/file/zh7A9gjaDlI50Hctdvd1OB/branch/tRCCNYz7ZyNP6a0pSAMlf5/Odyssey-Components?type=design&node-id=16959%3A924&mode=design&t=K2b79s64TbwcxZKF-1

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots
#### Inactive tabs w/ Badge
<img width="482" alt="image" src="https://github.com/okta/odyssey/assets/148223016/d5269780-b37d-4217-b382-cbfe674a1897">

#### Active tab w/ Badge
<img width="485" alt="image" src="https://github.com/okta/odyssey/assets/148223016/d2f46ae8-0002-4435-8c43-61b58d0bb998">

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
