### PR TITLE
Support translate attribute as part of AllowedProps

### DIFF
--- a/packages/odyssey-react-mui/src/Accordion.tsx
+++ b/packages/odyssey-react-mui/src/Accordion.tsx
@@ -11,7 +11,7 @@
  */
 
 import { ReactNode, memo } from "react";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 import {
   Accordion as MuiAccordion,
   AccordionDetails as MuiAccordionDetails,
@@ -60,7 +60,7 @@ export type AccordionProps = {
       isExpanded?: never;
     }
 ) &
-  SeleniumProps;
+  AllowedProps;
 
 const Accordion = ({
   children,
@@ -70,6 +70,7 @@ const Accordion = ({
   isDisabled,
   isExpanded,
   onChange,
+  translate,
 }: AccordionProps) => {
   return (
     <MuiAccordion
@@ -81,7 +82,9 @@ const Accordion = ({
       className={hasShadow ? `hasShadow` : undefined}
     >
       <MuiAccordionSummary expandIcon={<ChevronDownIcon />}>
-        <Support component="div">{label}</Support>
+        <Support component="div" translate={translate}>
+          {label}
+        </Support>
       </MuiAccordionSummary>
       <MuiAccordionDetails>{children}</MuiAccordionDetails>
     </MuiAccordion>

--- a/packages/odyssey-react-mui/src/AllowedProps.ts
+++ b/packages/odyssey-react-mui/src/AllowedProps.ts
@@ -10,11 +10,15 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-export type SeleniumProps = {
+export type AllowedProps = {
   /**
    * This prop puts a `data` attribute on an HTML element in this component with the value provided.
    *
    * @deprecated **WARNING:** You should be using Semantic Selectors instead of this property. This is a temporary measure for backwards compatibility with existing Selenium tests.
    */
   testId?: string;
+  /**
+   * This prop puts a `translate` attribute on an HTML element. It should be used to indicate whether text within the element should be translated.
+   */
+  translate?: "yes" | "no";
 };

--- a/packages/odyssey-react-mui/src/Autocomplete.tsx
+++ b/packages/odyssey-react-mui/src/Autocomplete.tsx
@@ -21,7 +21,7 @@ import { memo, useCallback, useMemo, useRef } from "react";
 
 import { Field } from "./Field";
 import { FieldComponentProps } from "./FieldComponentProps";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 import {
   ComponentControlledState,
   useInputValues,
@@ -169,7 +169,7 @@ export type AutocompleteProps<
   | "isOptional"
   | "name"
 > &
-  SeleniumProps;
+  AllowedProps;
 
 const Autocomplete = <
   OptionType,
@@ -199,6 +199,7 @@ const Autocomplete = <
   value,
   getIsOptionEqualToValue,
   testId,
+  translate,
 }: AutocompleteProps<OptionType, HasMultipleChoices, IsCustomValueAllowed>) => {
   const controlledStateRef = useRef(
     getControlState({ controlledValue: value, uncontrolledValue: defaultValue })
@@ -329,6 +330,7 @@ const Autocomplete = <
       readOnly={isReadOnly}
       renderInput={renderInput}
       isOptionEqualToValue={getIsOptionEqualToValue}
+      translate={translate}
     />
   );
 };

--- a/packages/odyssey-react-mui/src/Badge.tsx
+++ b/packages/odyssey-react-mui/src/Badge.tsx
@@ -17,7 +17,7 @@ import {
   DesignTokens,
 } from "./OdysseyDesignTokensContext";
 import { Box } from "./Box";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 
 export const badgeTypeValues = ["default", "attention", "danger"] as const;
 
@@ -25,7 +25,7 @@ export type BadgeProps = {
   badgeContent: number;
   badgeContentMax?: number;
   type?: (typeof badgeTypeValues)[number];
-} & SeleniumProps;
+} & AllowedProps;
 
 const badgeTypeColors = (odysseyTokens: DesignTokens) => ({
   default: {
@@ -45,6 +45,8 @@ const badgeTypeColors = (odysseyTokens: DesignTokens) => ({
 const Badge = ({
   badgeContent,
   badgeContentMax = 999,
+  testId,
+  translate,
   type = "default",
 }: BadgeProps) => {
   const odysseyDesignTokens = useOdysseyDesignTokens();
@@ -90,7 +92,11 @@ const Badge = ({
     return null;
   }
 
-  return <Box sx={badgeStyles}>{formattedContent}</Box>;
+  return (
+    <Box sx={badgeStyles} data-se={testId} translate={translate}>
+      {formattedContent}
+    </Box>
+  );
 };
 
 const MemoizedBadge = memo(Badge);

--- a/packages/odyssey-react-mui/src/Banner.tsx
+++ b/packages/odyssey-react-mui/src/Banner.tsx
@@ -16,7 +16,7 @@ import { ScreenReaderText } from "./ScreenReaderText";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 
 export const bannerRoleValues = ["status", "alert"] as const;
 export const bannerSeverityValues: AlertColor[] = [
@@ -56,7 +56,7 @@ export type BannerProps = {
    * The text content of the alert
    */
   text: string;
-} & SeleniumProps;
+} & AllowedProps;
 
 const Banner = ({
   linkUrl,
@@ -66,6 +66,7 @@ const Banner = ({
   severity,
   text,
   testId,
+  translate,
 }: BannerProps) => {
   const { t } = useTranslation();
 
@@ -78,9 +79,9 @@ const Banner = ({
       variant="banner"
     >
       <ScreenReaderText>{t(`severity.${severity}`)}:</ScreenReaderText>
-      <AlertTitle>{text}</AlertTitle>
+      <AlertTitle translate={translate}>{text}</AlertTitle>
       {linkUrl && (
-        <Link href={linkUrl} variant="monochrome">
+        <Link href={linkUrl} variant="monochrome" translate={translate}>
           {linkText}
         </Link>
       )}

--- a/packages/odyssey-react-mui/src/Banner.tsx
+++ b/packages/odyssey-react-mui/src/Banner.tsx
@@ -78,7 +78,9 @@ const Banner = ({
       severity={severity}
       variant="banner"
     >
-      <ScreenReaderText>{t(`severity.${severity}`)}:</ScreenReaderText>
+      <ScreenReaderText translate={translate}>
+        {t(`severity.${severity}`)}:
+      </ScreenReaderText>
       <AlertTitle translate={translate}>{text}</AlertTitle>
       {linkUrl && (
         <Link href={linkUrl} variant="monochrome" translate={translate}>

--- a/packages/odyssey-react-mui/src/Box.tsx
+++ b/packages/odyssey-react-mui/src/Box.tsx
@@ -13,17 +13,17 @@
 import { Box as MuiBox, BoxProps as MuiBoxProps } from "@mui/material";
 import { ReactNode, forwardRef, memo } from "react";
 
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 
 export type BoxProps = {
   children?: ReactNode;
   component?: MuiBoxProps["component"];
   id?: MuiBoxProps["id"];
   sx?: MuiBoxProps["sx"];
-} & SeleniumProps;
+} & AllowedProps;
 
 const Box = forwardRef<HTMLElement, BoxProps>(
-  ({ children, component, id, sx, testId }, ref) => (
+  ({ children, component, id, sx, testId, translate }, ref) => (
     <MuiBox
       ref={ref}
       children={children}
@@ -31,6 +31,7 @@ const Box = forwardRef<HTMLElement, BoxProps>(
       data-se={testId}
       id={id}
       sx={sx}
+      translate={translate}
     />
   )
 );

--- a/packages/odyssey-react-mui/src/Breadcrumbs.tsx
+++ b/packages/odyssey-react-mui/src/Breadcrumbs.tsx
@@ -29,6 +29,7 @@ import {
 import { GroupIcon, HomeIcon, UserIcon } from "./icons.generated";
 import { Subordinate } from "./Typography";
 import { useTranslation } from "react-i18next";
+import { AllowedProps } from "./AllowedProps";
 
 export type BreadcrumbType = "listItem" | "menuItem" | "currentPage";
 
@@ -42,7 +43,7 @@ export type BreadcrumbsProps = {
   children: ReactElement<typeof Breadcrumb>[];
   homeHref?: string;
   maxVisibleItems?: number;
-};
+} & AllowedProps;
 
 export type BreadcrumbContextType = {
   breadcrumbType: BreadcrumbType;
@@ -101,6 +102,8 @@ const BreadcrumbList = ({
   children,
   homeHref,
   maxVisibleItems = defaultTruncationValue,
+  testId,
+  translate,
 }: BreadcrumbsProps) => {
   const { t } = useTranslation();
 
@@ -137,6 +140,8 @@ const BreadcrumbList = ({
     <MuiBreadcrumbs
       maxItems={children.length + 1}
       aria-label={t("breadcrumbs.label.text")}
+      data-se={testId}
+      translate={translate}
     >
       {homeHref && (
         <ButtonBase href={homeHref} aria-label={t("breadcrumbs.home.text")}>

--- a/packages/odyssey-react-mui/src/Button.tsx
+++ b/packages/odyssey-react-mui/src/Button.tsx
@@ -16,7 +16,7 @@ import { memo, ReactElement, useCallback } from "react";
 
 import { MuiPropsContext, useMuiProps } from "./MuiPropsContext";
 import { Tooltip } from "./Tooltip";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 
 export const buttonSizeValues = ["small", "medium", "large"] as const;
 export const buttonTypeValues = ["button", "submit", "reset"] as const;
@@ -102,7 +102,7 @@ export type ButtonProps = {
       startIcon?: ReactElement;
     }
 ) &
-  SeleniumProps;
+  AllowedProps;
 
 const Button = ({
   ariaDescribedBy,
@@ -118,6 +118,7 @@ const Button = ({
   startIcon,
   testId,
   tooltipText,
+  translate,
   type = "button",
   variant,
 }: ButtonProps) => {
@@ -138,6 +139,7 @@ const Button = ({
         onClick={onClick}
         size={size}
         startIcon={startIcon}
+        translate={translate}
         type={type}
         variant={variant}
       >
@@ -157,6 +159,7 @@ const Button = ({
       size,
       startIcon,
       testId,
+      translate,
       type,
       variant,
     ]

--- a/packages/odyssey-react-mui/src/Callout.tsx
+++ b/packages/odyssey-react-mui/src/Callout.tsx
@@ -58,7 +58,9 @@ const Callout = ({
 
   return (
     <Alert data-se={testId} role={role} severity={severity} variant="callout">
-      <ScreenReaderText>{t(`severity.${severity}`)}</ScreenReaderText>
+      <ScreenReaderText translate={translate}>
+        {t(`severity.${severity}`)}
+      </ScreenReaderText>
       {title && <AlertTitle translate={translate}>{title}</AlertTitle>}
       <Box component="div">{children}</Box>
     </Alert>

--- a/packages/odyssey-react-mui/src/Callout.tsx
+++ b/packages/odyssey-react-mui/src/Callout.tsx
@@ -15,7 +15,7 @@ import { Alert, AlertTitle, Box } from "@mui/material";
 import { ScreenReaderText } from "./ScreenReaderText";
 import { useTranslation } from "react-i18next";
 
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 
 export const calloutRoleValues = ["status", "alert"] as const;
 export const calloutSeverityValues = [
@@ -44,15 +44,22 @@ export type CalloutProps = {
    * The title of the Callout
    */
   title?: string;
-} & SeleniumProps;
+} & AllowedProps;
 
-const Callout = ({ children, role, severity, testId, title }: CalloutProps) => {
+const Callout = ({
+  children,
+  role,
+  severity,
+  testId,
+  title,
+  translate,
+}: CalloutProps) => {
   const { t } = useTranslation();
 
   return (
     <Alert data-se={testId} role={role} severity={severity} variant="callout">
       <ScreenReaderText>{t(`severity.${severity}`)}</ScreenReaderText>
-      {title && <AlertTitle>{title}</AlertTitle>}
+      {title && <AlertTitle translate={translate}>{title}</AlertTitle>}
       <Box component="div">{children}</Box>
     </Alert>
   );

--- a/packages/odyssey-react-mui/src/Checkbox.tsx
+++ b/packages/odyssey-react-mui/src/Checkbox.tsx
@@ -22,7 +22,7 @@ import {
 
 import { FieldComponentProps } from "./FieldComponentProps";
 import { Typography } from "./Typography";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 import { ComponentControlledState, getControlState } from "./inputUtils";
 import { CheckedFieldProps } from "./FormCheckedProps";
 
@@ -75,7 +75,7 @@ export type CheckboxProps = {
   onBlur?: MuiFormControlLabelProps["onBlur"];
 } & Pick<FieldComponentProps, "id" | "isDisabled" | "name"> &
   CheckedFieldProps<MuiCheckboxProps> &
-  SeleniumProps;
+  AllowedProps;
 
 const Checkbox = ({
   ariaLabel,
@@ -92,6 +92,7 @@ const Checkbox = ({
   onChange: onChangeProp,
   onBlur: onBlurProp,
   testId,
+  translate,
   validity = "inherit",
   value,
 }: CheckboxProps) => {
@@ -121,10 +122,10 @@ const Checkbox = ({
             </Typography>
           </>
         )}
-        {hint && <FormHelperText>{hint}</FormHelperText>}
+        {hint && <FormHelperText translate={translate}>{hint}</FormHelperText>}
       </>
     );
-  }, [isRequired, labelProp, hint, t]);
+  }, [isRequired, labelProp, hint, t, translate]);
 
   const onChange = useCallback<NonNullable<MuiCheckboxProps["onChange"]>>(
     (event, checked) => {
@@ -171,6 +172,7 @@ const Checkbox = ({
       value={value}
       required={isRequired}
       onBlur={onBlur}
+      translate={translate}
     />
   );
 };

--- a/packages/odyssey-react-mui/src/CheckboxGroup.tsx
+++ b/packages/odyssey-react-mui/src/CheckboxGroup.tsx
@@ -38,7 +38,7 @@ export type CheckboxGroupProps = {
   "errorMessage" | "hint" | "HintLinkComponent" | "isDisabled"
 > &
   AllowedProps;
-  
+
 const CheckboxGroup = ({
   children,
   errorMessage,

--- a/packages/odyssey-react-mui/src/CheckboxGroup.tsx
+++ b/packages/odyssey-react-mui/src/CheckboxGroup.tsx
@@ -16,7 +16,7 @@ import { memo, ReactElement, useCallback } from "react";
 import { Checkbox } from "./Checkbox";
 import { Field } from "./Field";
 import { FieldComponentProps } from "./FieldComponentProps";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 
 export type CheckboxGroupProps = {
   /**
@@ -37,8 +37,8 @@ export type CheckboxGroupProps = {
   FieldComponentProps,
   "errorMessage" | "hint" | "HintLinkComponent" | "isDisabled"
 > &
-  SeleniumProps;
-
+  AllowedProps;
+  
 const CheckboxGroup = ({
   children,
   errorMessage,
@@ -48,6 +48,7 @@ const CheckboxGroup = ({
   isRequired = false,
   label,
   testId,
+  translate,
 }: CheckboxGroupProps) => {
   const renderFieldComponent = useCallback(
     ({ ariaDescribedBy, errorMessageElementId, labelElementId }) => (
@@ -56,11 +57,12 @@ const CheckboxGroup = ({
         aria-errormessage={errorMessageElementId}
         aria-labelledby={labelElementId}
         data-se={testId}
+        translate={translate}
       >
         {children}
       </MuiFormGroup>
     ),
-    [children, testId]
+    [children, testId, translate]
   );
 
   return (

--- a/packages/odyssey-react-mui/src/CircularProgress.tsx
+++ b/packages/odyssey-react-mui/src/CircularProgress.tsx
@@ -12,7 +12,7 @@
 
 import { CircularProgress as MuiCircularProgress } from "@mui/material";
 
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 
 export type CircularProgressProps = {
   /**
@@ -24,7 +24,7 @@ export type CircularProgressProps = {
    * If undefined, the spinner will spin perpetually.
    */
   value?: number;
-} & SeleniumProps;
+} & AllowedProps;
 
 export const CircularProgress = ({
   ariaLabel,

--- a/packages/odyssey-react-mui/src/Dialog.tsx
+++ b/packages/odyssey-react-mui/src/Dialog.tsx
@@ -28,7 +28,7 @@ import {
   ReactElement,
 } from "react";
 
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 
 export type DialogProps = {
   /**
@@ -60,7 +60,7 @@ export type DialogProps = {
    */
   title: string;
   ariaLabel: string;
-} & SeleniumProps;
+} & AllowedProps;
 
 const Dialog = ({
   callToActionFirstComponent,
@@ -71,6 +71,7 @@ const Dialog = ({
   onClose,
   testId,
   title,
+  translate,
   ariaLabel,
 }: DialogProps) => {
   const [isContentScrollable, setIsContentScrollable] = useState(false);
@@ -107,7 +108,7 @@ const Dialog = ({
 
   return (
     <MuiDialog data-se={testId} open={isOpen} onClose={onClose}>
-      <DialogTitle>
+      <DialogTitle translate={translate}>
         {title}
         <Button
           ariaLabel={ariaLabel}

--- a/packages/odyssey-react-mui/src/FieldError.tsx
+++ b/packages/odyssey-react-mui/src/FieldError.tsx
@@ -28,7 +28,7 @@ const FieldError = ({ id, testId, text, translate }: FieldErrorProps) => {
 
   return (
     <FormHelperText data-se={testId} error id={id} translate={translate}>
-      <ScreenReaderText>{`${t(
+      <ScreenReaderText translate={translate}>{`${t(
         "fielderror.screenreader.text"
       )}:`}</ScreenReaderText>
       {text}

--- a/packages/odyssey-react-mui/src/FieldError.tsx
+++ b/packages/odyssey-react-mui/src/FieldError.tsx
@@ -16,18 +16,18 @@ import { FormHelperText } from "@mui/material";
 import { ScreenReaderText } from "./ScreenReaderText";
 import { useTranslation } from "react-i18next";
 
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 
 export type FieldErrorProps = {
   id?: string;
   text: string;
-} & SeleniumProps;
+} & AllowedProps;
 
-const FieldError = ({ id, testId, text }: FieldErrorProps) => {
+const FieldError = ({ id, testId, text, translate }: FieldErrorProps) => {
   const { t } = useTranslation();
 
   return (
-    <FormHelperText data-se={testId} error id={id}>
+    <FormHelperText data-se={testId} error id={id} translate={translate}>
       <ScreenReaderText>{`${t(
         "fielderror.screenreader.text"
       )}:`}</ScreenReaderText>

--- a/packages/odyssey-react-mui/src/FieldHint.tsx
+++ b/packages/odyssey-react-mui/src/FieldHint.tsx
@@ -15,17 +15,17 @@ import { memo } from "react";
 import { FormHelperText } from "@mui/material";
 
 import { FieldComponentProps } from "./FieldComponentProps";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 
 export type FieldHintProps = {
   LinkComponent?: FieldComponentProps["HintLinkComponent"];
   id?: string;
   text: string;
-} & SeleniumProps;
+} & AllowedProps;
 
-const FieldHint = ({ id, LinkComponent, testId, text }: FieldHintProps) => {
+const FieldHint = ({ id, LinkComponent, testId, text, translate }: FieldHintProps) => {
   return (
-    <FormHelperText data-se={testId} id={id}>
+    <FormHelperText data-se={testId} id={id} translate={translate}>
       {text}
       {LinkComponent && (
         <>

--- a/packages/odyssey-react-mui/src/FieldHint.tsx
+++ b/packages/odyssey-react-mui/src/FieldHint.tsx
@@ -23,7 +23,13 @@ export type FieldHintProps = {
   text: string;
 } & AllowedProps;
 
-const FieldHint = ({ id, LinkComponent, testId, text, translate }: FieldHintProps) => {
+const FieldHint = ({
+  id,
+  LinkComponent,
+  testId,
+  text,
+  translate,
+}: FieldHintProps) => {
   return (
     <FormHelperText data-se={testId} id={id} translate={translate}>
       {text}

--- a/packages/odyssey-react-mui/src/FieldLabel.tsx
+++ b/packages/odyssey-react-mui/src/FieldLabel.tsx
@@ -57,7 +57,7 @@ const FieldLabel = ({
   return hasVisibleLabel ? (
     inputLabel
   ) : (
-    <ScreenReaderText>{inputLabel}</ScreenReaderText>
+    <ScreenReaderText translate={translate}>{inputLabel}</ScreenReaderText>
   );
 };
 

--- a/packages/odyssey-react-mui/src/FieldLabel.tsx
+++ b/packages/odyssey-react-mui/src/FieldLabel.tsx
@@ -16,7 +16,7 @@ import { memo, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { ScreenReaderText } from "./ScreenReaderText";
 import { Subordinate } from "./Typography";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 
 export type FieldLabelProps = {
   hasVisibleLabel: boolean;
@@ -24,7 +24,7 @@ export type FieldLabelProps = {
   inputId: string;
   isOptional: boolean;
   text: string;
-} & SeleniumProps;
+} & AllowedProps;
 
 const FieldLabel = ({
   hasVisibleLabel,
@@ -32,20 +32,26 @@ const FieldLabel = ({
   inputId,
   isOptional,
   testId,
+  translate,
   text,
 }: FieldLabelProps) => {
   const { t } = useTranslation();
 
   const inputLabel = useMemo(
     () => (
-      <MuiInputLabel data-se={testId} htmlFor={inputId} id={id}>
+      <MuiInputLabel
+        data-se={testId}
+        htmlFor={inputId}
+        id={id}
+        translate={translate}
+      >
         <span>{text}</span>
         {isOptional && (
           <Subordinate>{t("fieldlabel.optional.text")}</Subordinate>
         )}
       </MuiInputLabel>
     ),
-    [id, inputId, isOptional, testId, text, t]
+    [id, inputId, isOptional, testId, translate, text, t]
   );
 
   return hasVisibleLabel ? (

--- a/packages/odyssey-react-mui/src/Fieldset.tsx
+++ b/packages/odyssey-react-mui/src/Fieldset.tsx
@@ -18,7 +18,7 @@ import { FieldsetContext } from "./FieldsetContext";
 import { Legend, Support } from "./Typography";
 import { useOdysseyDesignTokens } from "./OdysseyDesignTokensContext";
 import { useUniqueId } from "./useUniqueId";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 
 export type FieldsetProps = {
   /**
@@ -49,7 +49,7 @@ export type FieldsetProps = {
    * The name associated with the group.
    */
   name?: string;
-} & SeleniumProps;
+} & AllowedProps;
 
 const Fieldset = ({
   alert,
@@ -60,6 +60,7 @@ const Fieldset = ({
   legend,
   name,
   testId,
+  translate,
 }: FieldsetProps) => {
   const odysseyDesignTokens = useOdysseyDesignTokens();
   const id = useUniqueId(idOverride);
@@ -90,9 +91,9 @@ const Fieldset = ({
         },
       }}
     >
-      <Legend>{legend}</Legend>
+      <Legend translate={translate}>{legend}</Legend>
 
-      {description && <Support>{description}</Support>}
+      {description && <Support translate={translate}>{description}</Support>}
 
       {alert}
 

--- a/packages/odyssey-react-mui/src/Form.tsx
+++ b/packages/odyssey-react-mui/src/Form.tsx
@@ -17,7 +17,7 @@ import { Button } from "./Button";
 import { Callout } from "./Callout";
 import { Heading4, Support } from "./Typography";
 import { useUniqueId } from "./useUniqueId";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 
 export const formEncodingTypeValues = [
   "application/x-www-form-urlencoded",
@@ -85,7 +85,7 @@ export type FormProps = {
    * The title of the Form
    */
   title?: string;
-} & SeleniumProps;
+} & AllowedProps;
 
 const Form = ({
   alert,
@@ -101,6 +101,7 @@ const Form = ({
   target,
   testId,
   title,
+  translate,
 }: FormProps) => {
   const id = useUniqueId(idOverride);
 
@@ -127,8 +128,12 @@ const Form = ({
           marginBlockEnd: (theme) => theme.spacing(4),
         }}
       >
-        {title && <Heading4 component="h1">{title}</Heading4>}
-        {description && <Support>{description}</Support>}
+        {title && (
+          <Heading4 component="h1" translate={translate}>
+            {title}
+          </Heading4>
+        )}
+        {description && <Support translate={translate}>{description}</Support>}
         {alert}
       </Box>
       <Box component="div">{children}</Box>

--- a/packages/odyssey-react-mui/src/Link.tsx
+++ b/packages/odyssey-react-mui/src/Link.tsx
@@ -12,7 +12,7 @@
 
 import { memo, ReactElement } from "react";
 import { ExternalLinkIcon } from "./icons.generated";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 
 import { Link as MuiLink, LinkProps as MuiLinkProps } from "@mui/material";
 
@@ -52,7 +52,7 @@ export type LinkProps = {
    * The visual presentation of the Link (default or monochrome)
    */
   variant?: (typeof linkVariantValues)[number];
-} & SeleniumProps;
+} & AllowedProps;
 
 const Link = ({
   children,
@@ -61,6 +61,7 @@ const Link = ({
   rel,
   target,
   testId,
+  translate,
   variant,
   onClick,
 }: LinkProps) => (
@@ -69,6 +70,7 @@ const Link = ({
     href={href}
     rel={rel}
     target={target}
+    translate={translate}
     variant={variant}
     onClick={onClick}
   >

--- a/packages/odyssey-react-mui/src/MenuButton.tsx
+++ b/packages/odyssey-react-mui/src/MenuButton.tsx
@@ -28,7 +28,7 @@ import { memo, type ReactElement, useCallback, useMemo, useState } from "react";
 
 import { MenuContext, MenuContextType } from "./MenuContext";
 import { NullElement } from "./NullElement";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 
 export const menuAlignmentValues = ["left", "right"] as const;
 
@@ -109,7 +109,7 @@ export type MenuButtonProps = {
       buttonLabel?: undefined | "";
     }
 ) &
-  SeleniumProps;
+  AllowedProps;
 
 const MenuButton = ({
   ariaLabel,
@@ -126,6 +126,7 @@ const MenuButton = ({
   size,
   testId,
   tooltipText,
+  translate,
 }: MenuButtonProps) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
@@ -197,6 +198,7 @@ const MenuButton = ({
         onClick={openMenu}
         size={size}
         tooltipText={tooltipText}
+        translate={translate}
         variant={buttonVariant}
       />
 

--- a/packages/odyssey-react-mui/src/MenuItem.tsx
+++ b/packages/odyssey-react-mui/src/MenuItem.tsx
@@ -18,7 +18,7 @@ import { menuItemClasses } from "@mui/material/MenuItem";
 import { memo, useCallback, useContext, type ReactNode } from "react";
 
 import { MenuContext } from "./MenuContext";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 
 export type MenuItemProps = {
   /**
@@ -51,7 +51,7 @@ export type MenuItemProps = {
    * - "destructive": A variant indicating a destructive action.
    */
   variant?: "default" | "destructive";
-} & SeleniumProps;
+} & AllowedProps;
 
 const MenuItem = ({
   children,

--- a/packages/odyssey-react-mui/src/NativeSelect.tsx
+++ b/packages/odyssey-react-mui/src/NativeSelect.tsx
@@ -24,7 +24,7 @@ import {
 } from "@mui/material";
 import { Field } from "./Field";
 import { FieldComponentProps } from "./FieldComponentProps";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 import { getControlState, useInputValues } from "./inputUtils";
 import { ForwardRefWithType } from "./@types/react-augment";
 
@@ -89,7 +89,7 @@ export type NativeSelectProps<
   | "isFullWidth"
   | "isOptional"
 > &
-  SeleniumProps;
+  AllowedProps;
 
 const NativeSelect: ForwardRefWithType = forwardRef(
   <
@@ -112,6 +112,7 @@ const NativeSelect: ForwardRefWithType = forwardRef(
       onChange: onChangeProp,
       onFocus,
       testId,
+      translate,
       value,
       children,
     }: NativeSelectProps<Value, HasMultipleChoices>,
@@ -164,6 +165,7 @@ const NativeSelect: ForwardRefWithType = forwardRef(
           onChange={onChange}
           onFocus={onFocus}
           ref={ref}
+          translate={translate}
         />
       ),
       [
@@ -176,6 +178,7 @@ const NativeSelect: ForwardRefWithType = forwardRef(
         onFocus,
         ref,
         testId,
+        translate,
       ]
     );
 

--- a/packages/odyssey-react-mui/src/PasswordField.tsx
+++ b/packages/odyssey-react-mui/src/PasswordField.tsx
@@ -24,7 +24,7 @@ import {
 import { ShowIcon, HideIcon } from "./icons.generated";
 import { Field } from "./Field";
 import { FieldComponentProps } from "./FieldComponentProps";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 import { useTranslation } from "react-i18next";
 import { getControlState, useInputValues } from "./inputUtils";
 
@@ -72,7 +72,7 @@ export type PasswordFieldProps = {
    */
   value?: string;
 } & FieldComponentProps &
-  SeleniumProps;
+  AllowedProps;
 
 const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
   (
@@ -95,6 +95,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
       onBlur,
       placeholder,
       testId,
+      translate,
       value,
     },
     ref
@@ -169,6 +170,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
           readOnly={isReadOnly}
           ref={ref}
           required={!isOptional}
+          translate={translate}
           type={inputType}
         />
       ),
@@ -189,6 +191,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
         hasShowPassword,
         ref,
         testId,
+        translate,
       ]
     );
 

--- a/packages/odyssey-react-mui/src/Radio.tsx
+++ b/packages/odyssey-react-mui/src/Radio.tsx
@@ -19,7 +19,7 @@ import {
 import { memo, useCallback } from "react";
 
 import { FieldComponentProps } from "./FieldComponentProps";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 
 export type RadioProps = {
   /**
@@ -47,7 +47,7 @@ export type RadioProps = {
    */
   onBlur?: MuiFormControlLabelProps["onBlur"];
 } & Pick<FieldComponentProps, "isDisabled" | "name"> &
-  SeleniumProps;
+  AllowedProps;
 
 const Radio = ({
   isChecked,
@@ -56,6 +56,7 @@ const Radio = ({
   label,
   name,
   testId,
+  translate,
   value,
   onChange: onChangeProp,
   onBlur: onBlurProp,
@@ -83,6 +84,7 @@ const Radio = ({
       disabled={isDisabled}
       label={label}
       name={name}
+      translate={translate}
       value={value}
       onBlur={onBlur}
     />

--- a/packages/odyssey-react-mui/src/RadioGroup.tsx
+++ b/packages/odyssey-react-mui/src/RadioGroup.tsx
@@ -19,7 +19,7 @@ import { memo, ReactElement, useCallback, useRef } from "react";
 import { Radio, RadioProps } from "./Radio";
 import { Field } from "./Field";
 import { FieldComponentProps } from "./FieldComponentProps";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 import { getControlState, useInputValues } from "./inputUtils";
 
 export type RadioGroupProps = {
@@ -47,7 +47,7 @@ export type RadioGroupProps = {
   FieldComponentProps,
   "errorMessage" | "hint" | "HintLinkComponent" | "id" | "isDisabled" | "name"
 > &
-  SeleniumProps;
+  AllowedProps;
 
 const RadioGroup = ({
   children,
@@ -61,6 +61,7 @@ const RadioGroup = ({
   name: nameOverride,
   onChange: onChangeProp,
   testId,
+  translate,
   value,
 }: RadioGroupProps) => {
   const controlledStateRef = useRef(
@@ -89,11 +90,12 @@ const RadioGroup = ({
         id={id}
         name={nameOverride ?? id}
         onChange={onChange}
+        translate={translate}
       >
         {children}
       </MuiRadioGroup>
     ),
-    [children, inputValues, nameOverride, onChange, testId]
+    [children, inputValues, nameOverride, onChange, testId, translate]
   );
 
   return (

--- a/packages/odyssey-react-mui/src/ScreenReaderText.tsx
+++ b/packages/odyssey-react-mui/src/ScreenReaderText.tsx
@@ -13,13 +13,14 @@
 import { memo, ReactNode } from "react";
 import { Box } from "@mui/material";
 import { visuallyHidden } from "@mui/utils";
+import { AllowedProps } from "./AllowedProps";
 
 export type ScreenReaderTextProps = {
   /**
    * The visually-hidden text.
    */
   children: ReactNode;
-};
+} & AllowedProps;
 
 /**
  * MUI sx expects you pass in a CSS object, not an object with CSS.
@@ -28,8 +29,8 @@ export type ScreenReaderTextProps = {
  */
 const style = { ...visuallyHidden };
 
-const ScreenReaderText = ({ children }: ScreenReaderTextProps) => (
-  <Box sx={style} component="span">
+const ScreenReaderText = ({ children, translate }: ScreenReaderTextProps) => (
+  <Box sx={style} component="span" translate={translate}>
     {children}
   </Box>
 );

--- a/packages/odyssey-react-mui/src/SearchField.tsx
+++ b/packages/odyssey-react-mui/src/SearchField.tsx
@@ -24,7 +24,7 @@ import {
 import { CloseCircleFilledIcon, SearchIcon } from "./icons.generated";
 import { Field } from "./Field";
 import { FieldComponentProps } from "./FieldComponentProps";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 import { getControlState, useInputValues } from "./inputUtils";
 
 export type SearchFieldProps = {
@@ -79,7 +79,7 @@ export type SearchFieldProps = {
    */
   value?: string;
 } & Pick<FieldComponentProps, "id" | "isDisabled" | "name" | "isFullWidth"> &
-  SeleniumProps;
+  AllowedProps;
 
 const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
   (
@@ -98,6 +98,7 @@ const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
       onClear: onClearProp,
       placeholder,
       testId,
+      translate,
       value,
     },
     ref
@@ -161,6 +162,7 @@ const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
               <SearchIcon />
             </InputAdornment>
           }
+          translate={translate}
           type="search"
         />
       ),

--- a/packages/odyssey-react-mui/src/SearchField.tsx
+++ b/packages/odyssey-react-mui/src/SearchField.tsx
@@ -180,6 +180,7 @@ const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
         placeholder,
         ref,
         testId,
+        translate,
       ]
     );
 

--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -25,7 +25,7 @@ import { SelectProps as MuiSelectProps } from "@mui/material";
 import { Field } from "./Field";
 import { FieldComponentProps } from "./FieldComponentProps";
 import { CheckIcon } from "./icons.generated";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 import {
   ComponentControlledState,
   useInputValues,
@@ -93,7 +93,7 @@ export type SelectProps<
   | "isOptional"
   | "name"
 > &
-  SeleniumProps;
+  AllowedProps;
 
 /**
  * Options in Odyssey <Select> are passed as an array, which can contain any combination
@@ -132,6 +132,7 @@ const Select = <
   onFocus,
   options,
   testId,
+  translate,
   value,
 }: SelectProps<Value, HasMultipleChoices>) => {
   const hasMultipleChoices = useMemo(
@@ -268,6 +269,7 @@ const Select = <
         onChange={onChange}
         onFocus={onFocus}
         renderValue={hasMultipleChoices ? renderValue : undefined}
+        translate={translate}
       />
     ),
     [
@@ -280,6 +282,7 @@ const Select = <
       onFocus,
       renderValue,
       testId,
+      translate,
     ]
   );
 

--- a/packages/odyssey-react-mui/src/Status.tsx
+++ b/packages/odyssey-react-mui/src/Status.tsx
@@ -13,7 +13,7 @@
 import { Chip } from "@mui/material";
 
 import { useMuiProps } from "./MuiPropsContext";
-import type { SeleniumProps } from "./SeleniumProps";
+import type { AllowedProps } from "./AllowedProps";
 
 export const statusSeverityValues = [
   "default",
@@ -36,12 +36,13 @@ export type StatusProps = {
    * The style of the Status indicator
    */
   variant?: (typeof statusVariantValues)[number];
-} & SeleniumProps;
+} & AllowedProps;
 
 export const Status = ({
   label,
   severity,
   testId,
+  translate,
   variant = "lamp",
 }: StatusProps) => {
   const muiProps = useMuiProps();
@@ -52,6 +53,7 @@ export const Status = ({
       color={severity}
       data-se={testId}
       label={label}
+      translate={translate}
       variant={variant}
     />
   );

--- a/packages/odyssey-react-mui/src/Tabs.tsx
+++ b/packages/odyssey-react-mui/src/Tabs.tsx
@@ -25,7 +25,7 @@ import {
   useEffect,
   useState,
 } from "react";
-import { SeleniumProps } from "./SeleniumProps";
+import { AllowedProps } from "./AllowedProps";
 
 export type TabItemProps = {
   /**
@@ -48,7 +48,7 @@ export type TabItemProps = {
    * The value associated with the TabItem
    */
   value?: string;
-} & SeleniumProps;
+} & AllowedProps;
 
 export type TabsProps = {
   /**

--- a/packages/odyssey-react-mui/src/Tag.tsx
+++ b/packages/odyssey-react-mui/src/Tag.tsx
@@ -14,7 +14,7 @@ import { Chip as MuiChip, ChipProps as MuiChipProps } from "@mui/material";
 import { memo, ReactElement, useCallback, useContext } from "react";
 import { TagListContext } from "./TagListContext";
 import { MuiPropsContext } from "./MuiPropsContext";
-import { SeleniumProps } from "./SeleniumProps";
+import { AllowedProps } from "./AllowedProps";
 
 export type TagProps = {
   icon?: ReactElement;
@@ -31,7 +31,7 @@ export type TagProps = {
    * Callback fired when the remove button of the Tag is clicked
    */
   onRemove?: MuiChipProps["onDelete"];
-} & SeleniumProps;
+} & AllowedProps;
 
 const Tag = ({
   icon,
@@ -40,6 +40,7 @@ const Tag = ({
   onClick,
   onRemove,
   testId,
+  translate,
 }: TagProps) => {
   const { chipElementType } = useContext(TagListContext);
 
@@ -56,9 +57,19 @@ const Tag = ({
         label={label}
         onClick={onClick}
         onDelete={onRemove}
+        translate={translate}
       />
     ),
-    [chipElementType, icon, isDisabled, label, onClick, onRemove, testId]
+    [
+      chipElementType,
+      icon,
+      isDisabled,
+      label,
+      onClick,
+      onRemove,
+      testId,
+      translate,
+    ]
   );
 
   return <MuiPropsContext.Consumer>{renderTag}</MuiPropsContext.Consumer>;

--- a/packages/odyssey-react-mui/src/TagList.tsx
+++ b/packages/odyssey-react-mui/src/TagList.tsx
@@ -14,14 +14,14 @@ import { Tag } from "./Tag";
 import { Stack } from "@mui/material";
 import { memo, ReactElement, useMemo } from "react";
 import { ChipElementType, TagListContext } from "./TagListContext";
-import { SeleniumProps } from "./SeleniumProps";
+import { AllowedProps } from "./AllowedProps";
 
 export type TagListProps = {
   /**
    * The Tag or array of Tags within the TagList
    */
   children: ReactElement<typeof Tag> | Array<ReactElement<typeof Tag>>;
-} & SeleniumProps;
+} & AllowedProps;
 
 const TagList = ({ children, testId }: TagListProps) => {
   const providerValue = useMemo<{

--- a/packages/odyssey-react-mui/src/TextField.tsx
+++ b/packages/odyssey-react-mui/src/TextField.tsx
@@ -24,7 +24,7 @@ import { InputAdornment, InputBase } from "@mui/material";
 
 import { FieldComponentProps } from "./FieldComponentProps";
 import { Field } from "./Field";
-import { SeleniumProps } from "./SeleniumProps";
+import { AllowedProps } from "./AllowedProps";
 import { useInputValues, getControlState } from "./inputUtils";
 
 export const textFieldTypeValues = [
@@ -91,7 +91,7 @@ export type TextFieldProps = {
    */
   value?: string;
 } & FieldComponentProps &
-  SeleniumProps;
+  AllowedProps;
 
 const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
   (
@@ -117,6 +117,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       placeholder,
       startAdornment,
       testId,
+      translate,
       type = "text",
       value: value,
     },
@@ -158,7 +159,9 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
           data-se={testId}
           endAdornment={
             endAdornment && (
-              <InputAdornment position="end">{endAdornment}</InputAdornment>
+              <InputAdornment position="end" translate={translate}>
+                {endAdornment}
+              </InputAdornment>
             )
           }
           id={id}
@@ -173,10 +176,13 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
           required={!isOptional}
           startAdornment={
             startAdornment && (
-              <InputAdornment position="start">{startAdornment}</InputAdornment>
+              <InputAdornment position="start" translate={translate}>
+                {startAdornment}
+              </InputAdornment>
             )
           }
           type={type}
+          translate={translate}
         />
       ),
       [
@@ -195,6 +201,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         ref,
         startAdornment,
         testId,
+        translate,
         type,
       ]
     );

--- a/packages/odyssey-react-mui/src/Toast.tsx
+++ b/packages/odyssey-react-mui/src/Toast.tsx
@@ -17,7 +17,7 @@ import { Link } from "./Link";
 import { CloseIcon } from "./icons.generated";
 import { Button } from "./Button";
 import { useTranslation } from "react-i18next";
-import { SeleniumProps } from "./SeleniumProps";
+import { AllowedProps } from "./AllowedProps";
 
 export const toastRoleValues = ["status", "alert"] as const;
 export const toastSeverityValues = [
@@ -70,7 +70,7 @@ export type ToastProps = {
    * The text content of the Toast
    */
   text: string;
-} & SeleniumProps;
+} & AllowedProps;
 
 const ClickAwayListenerProps = { onClickAway: () => false };
 
@@ -85,6 +85,7 @@ const Toast = ({
   severity,
   testId,
   text,
+  translate,
 }: ToastProps) => {
   const { t } = useTranslation();
 
@@ -126,12 +127,12 @@ const Toast = ({
         severity={severity}
         variant="toast"
       >
-        <AlertTitle>
+        <AlertTitle translate={translate}>
           <span style={visuallyHidden}>{severity}:</span>
           {text}
         </AlertTitle>
         {linkUrl && (
-          <Link href={linkUrl} variant="monochrome">
+          <Link href={linkUrl} variant="monochrome" translate={translate}>
             {linkText}
           </Link>
         )}

--- a/packages/odyssey-react-mui/src/Tooltip.tsx
+++ b/packages/odyssey-react-mui/src/Tooltip.tsx
@@ -15,7 +15,7 @@ import type { TooltipProps as MuiTooltipProps } from "@mui/material";
 
 import { MuiPropsChild } from "./MuiPropsChild";
 import { ReactElement, memo } from "react";
-import { SeleniumProps } from "./SeleniumProps";
+import { AllowedProps } from "./AllowedProps";
 
 export type TooltipProps = {
   /**
@@ -34,7 +34,7 @@ export type TooltipProps = {
    * The text to display in the Tooltip
    */
   text: string;
-} & SeleniumProps;
+} & AllowedProps;
 
 const Tooltip = ({
   ariaType,
@@ -42,12 +42,14 @@ const Tooltip = ({
   placement = "top",
   testId,
   text,
+  translate,
 }: TooltipProps) => (
   <MuiTooltip
     data-se={testId}
     describeChild={ariaType === "description"}
     placement={placement}
     title={text}
+    translate={translate}
   >
     <MuiPropsChild>{children}</MuiPropsChild>
   </MuiTooltip>

--- a/packages/odyssey-react-mui/src/Typography.tsx
+++ b/packages/odyssey-react-mui/src/Typography.tsx
@@ -301,8 +301,7 @@ const Paragraph = ({
     children={children}
     color={color}
     component={component}
-    data-nt={testId}
-    data-se={"hello"}
+    data-se={testId}
     translate={translate}
     variant="body"
   />

--- a/packages/odyssey-react-mui/src/Typography.tsx
+++ b/packages/odyssey-react-mui/src/Typography.tsx
@@ -15,7 +15,7 @@ import {
   TypographyProps as MuiTypographyProps,
 } from "@mui/material";
 import { ElementType, ReactNode, memo, useMemo } from "react";
-import { SeleniumProps } from "./SeleniumProps";
+import { AllowedProps } from "./AllowedProps";
 
 export type TypographyVariantValue =
   | "h1"
@@ -82,7 +82,7 @@ export type TypographyProps = {
    * The variant of Typography to render.
    */
   variant?: keyof typeof typographyVariantMapping;
-} & SeleniumProps;
+} & AllowedProps;
 
 const Typography = ({
   ariaDescribedBy,
@@ -92,6 +92,7 @@ const Typography = ({
   color,
   component: componentProp,
   testId,
+  translate,
   variant = "body",
 }: TypographyProps) => {
   const component = useMemo(() => {
@@ -108,16 +109,19 @@ const Typography = ({
   }, [componentProp, variant]);
 
   return (
-    <MuiTypography
-      aria-describedby={ariaDescribedBy}
-      aria-label={ariaLabel}
-      aria-labelledby={ariaLabelledBy}
-      children={children}
-      color={color}
-      component={component}
-      data-se={testId}
-      variant={typographyVariantMapping[variant]}
-    />
+    <>
+      <MuiTypography
+        aria-describedby={ariaDescribedBy}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        children={children}
+        color={color}
+        component={component}
+        data-se={testId}
+        translate={translate}
+        variant={typographyVariantMapping[variant]}
+      />
+    </>
   );
 };
 
@@ -132,6 +136,7 @@ const Heading1 = ({
   color,
   component,
   testId,
+  translate,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -141,6 +146,7 @@ const Heading1 = ({
     color={color}
     component={component}
     data-se={testId}
+    translate={translate}
     variant="h1"
   />
 );
@@ -156,6 +162,7 @@ const Heading2 = ({
   color,
   component,
   testId,
+  translate,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -165,6 +172,7 @@ const Heading2 = ({
     color={color}
     component={component}
     data-se={testId}
+    translate={translate}
     variant="h2"
   />
 );
@@ -180,6 +188,7 @@ const Heading3 = ({
   color,
   component,
   testId,
+  translate,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -189,6 +198,7 @@ const Heading3 = ({
     color={color}
     component={component}
     data-se={testId}
+    translate={translate}
     variant="h3"
   />
 );
@@ -204,6 +214,7 @@ const Heading4 = ({
   color,
   component,
   testId,
+  translate,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -213,6 +224,7 @@ const Heading4 = ({
     color={color}
     component={component}
     data-se={testId}
+    translate={translate}
     variant="h4"
   />
 );
@@ -228,6 +240,7 @@ const Heading5 = ({
   color,
   component,
   testId,
+  translate,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -237,6 +250,7 @@ const Heading5 = ({
     color={color}
     component={component}
     data-se={testId}
+    translate={translate}
     variant="h5"
   />
 );
@@ -252,6 +266,7 @@ const Heading6 = ({
   color,
   component,
   testId,
+  translate,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -261,6 +276,7 @@ const Heading6 = ({
     color={color}
     component={component}
     data-se={testId}
+    translate={translate}
     variant="h6"
   />
 );
@@ -276,6 +292,7 @@ const Paragraph = ({
   color,
   component,
   testId,
+  translate,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -284,7 +301,9 @@ const Paragraph = ({
     children={children}
     color={color}
     component={component}
-    data-se={testId}
+    data-nt={testId}
+    data-se={"hello"}
+    translate={translate}
     variant="body"
   />
 );
@@ -300,6 +319,7 @@ const Subordinate = ({
   color,
   component,
   testId,
+  translate,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -309,6 +329,7 @@ const Subordinate = ({
     color={color}
     component={component}
     data-se={testId}
+    translate={translate}
     variant="subordinate"
   />
 );
@@ -324,6 +345,7 @@ const Support = ({
   color,
   component,
   testId,
+  translate,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -333,6 +355,7 @@ const Support = ({
     color={color}
     component={component}
     data-se={testId}
+    translate={translate}
     variant="support"
   />
 );
@@ -348,6 +371,7 @@ const Legend = ({
   color,
   component,
   testId,
+  translate,
 }: TypographyProps) => (
   <Typography
     ariaDescribedBy={ariaDescribedBy}
@@ -357,6 +381,7 @@ const Legend = ({
     color={color}
     component={component}
     data-se={testId}
+    translate={translate}
     variant="legend"
   />
 );

--- a/packages/odyssey-react-mui/src/labs/Switch.tsx
+++ b/packages/odyssey-react-mui/src/labs/Switch.tsx
@@ -30,7 +30,7 @@ import { useOdysseyDesignTokens } from "../OdysseyDesignTokensContext";
 import { Box } from "../Box";
 import { FieldComponentProps } from "../FieldComponentProps";
 import { FieldHint } from "../FieldHint";
-import type { SeleniumProps } from "../SeleniumProps";
+import type { AllowedProps } from "../AllowedProps";
 import { useUniqueId } from "../useUniqueId";
 import { ComponentControlledState, getControlState } from "../inputUtils";
 import { CheckedFieldProps } from "../FormCheckedProps";
@@ -62,7 +62,7 @@ export type SwitchProps = {
   "hint" | "id" | "isFullWidth" | "isDisabled" | "name"
 > &
   CheckedFieldProps<MuiSwitchProps> &
-  SeleniumProps;
+  AllowedProps;
 
 type SwitchLabelProps = {
   checked: boolean;

--- a/packages/odyssey-react-mui/src/labs/VirtualizedAutocomplete.tsx
+++ b/packages/odyssey-react-mui/src/labs/VirtualizedAutocomplete.tsx
@@ -21,7 +21,7 @@ import { memo, useCallback, useMemo, useRef } from "react";
 
 import { Field } from "../Field";
 import { FieldComponentProps } from "../FieldComponentProps";
-import type { SeleniumProps } from "../SeleniumProps";
+import type { AllowedProps } from "../AllowedProps";
 import {
   ComponentControlledState,
   getControlState,
@@ -170,7 +170,7 @@ export type AutocompleteProps<
   FieldComponentProps,
   "errorMessage" | "hint" | "id" | "isOptional" | "name"
 > &
-  SeleniumProps;
+  AllowedProps;
 
 const VirtualizedAutocomplete = <
   OptionType,
@@ -199,6 +199,7 @@ const VirtualizedAutocomplete = <
   value,
   getIsOptionEqualToValue,
   testId,
+  translate,
 }: AutocompleteProps<OptionType, HasMultipleChoices, IsCustomValueAllowed>) => {
   const controlledStateRef = useRef(
     getControlState({ controlledValue: value, uncontrolledValue: defaultValue })
@@ -327,6 +328,7 @@ const VirtualizedAutocomplete = <
       readOnly={isReadOnly}
       renderInput={renderInput}
       isOptionEqualToValue={getIsOptionEqualToValue}
+      translate={translate}
     />
   );
 };


### PR DESCRIPTION
[OKTA-675329](https://oktainc.atlassian.net/browse/OKTA-675329)

## Summary
- Per 12/11 Odyssey OH, the SIW team discussed supporting the global HTML `translate` attribute within `odyssey-react-mui` so that text within components can be flagged as text that should not be translated. Some examples of text that would get a `translate="no"` are proper nouns like "Okta Verify" and admin-defined strings that aren't part of a translation bunde. This is necessary for English leak detection test suites
- This PR reused the `SeleniumProps.ts` file that maps `testId` -> `data-se` but renamed it to `AllowedProps.ts` to be more generic since Odyssey will likely continue to expand its support for similar accepted props/attributes
