### PR TITLE
Fix error in README file instructing users to download 'Public Sans'. Swapped to include correct request of 'Inter' fonts

### DIFF
--- a/packages/odyssey-react-mui/README.md
+++ b/packages/odyssey-react-mui/README.md
@@ -24,14 +24,11 @@ yarn add @okta/odyssey-react-mui
 Include fonts:
 
 ```html
-<link rel="preconnect" href="https://fonts.gstatic.com" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap"
   rel="stylesheet"
-  href="https://fonts.googleapis.com/css2?family=Public+Sans:ital,wght@0,400;0,600;1,400;1,600&display=swap"
-/>
-<link
-  rel="stylesheet"
-  href="https://fonts.googleapis.com/css2?family=Inconsolata&display=swap"
 />
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

[OKTA-678659](https://oktainc.atlassian.net/browse/OKTA-678659)

## Summary
- Fix error in README file instructing users to download 'Public Sans'. Swapped to include correct request of 'Inter' fonts
<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
