### PR TITLE
fix: moves Applitools server URL to in-repo config rather than GitHub Secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,5 +116,4 @@ jobs:
         env:
           APPLITOOLS_API_KEY: ${{ secrets.OKTA_474937 }}
           APPLITOOLS_BATCH_ID: ${{ github.event.pull_request.head.sha }}
-          APPLITOOLS_SERVER_URL: ${{ secrets.APPLITOOLS_SERVER_URL }}
         run: yarn workspace @okta/odyssey-storybook eyes-storybook -u ${{ env.URL_STORYBOOK }}

--- a/packages/odyssey-storybook/applitools.config.js
+++ b/packages/odyssey-storybook/applitools.config.js
@@ -25,6 +25,7 @@ module.exports = {
   exitcode: true,
   matchLevel: "Strict",
   parentBranchName,
+  serverUrl: "https://oktaeyes.applitools.com",
   showStorybookOutput: true,
   testConcurrency: 10,
 };


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

[OKTA-683702](https://oktainc.atlassian.net/browse/OKTA-683702)

## Summary

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

I moved the Applitools URL to the config because I was having issues with GitHub Secrets. This fixes the issue today, and we can address GitHub Secrets in the future or just not use that method altogether.

## Testing & Screenshots

- [X] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
