### PR TITLE
Fix broken Storybook story height

### DIFF
--- a/packages/odyssey-storybook/.storybook/components/MuiThemeDecorator.tsx
+++ b/packages/odyssey-storybook/.storybook/components/MuiThemeDecorator.tsx
@@ -16,12 +16,10 @@ const odysseyTheme = createOdysseyMuiTheme({ odysseyTokens });
 
 export const MuiThemeDecorator: Decorator = (Story, context) => {
   const {
-    canvasElement,
     globals: { locale },
   } = context;
-  const shadowRootElement = canvasElement.parentElement ?? undefined;
   return (
-    <OdysseyProvider languageCode={locale} shadowDomElement={shadowRootElement}>
+    <OdysseyProvider languageCode={locale}>
       {/* @ts-expect-error type mismatch on "typography" */}
       <StorybookThemeProvider theme={odysseyTheme}>
         <CssBaseline />


### PR DESCRIPTION
In the Storybook component docs, stories are clipping strangely. This is particularly visible in places where the component should overflow the story, such as the Select dropdown or the Dialog backdrop.

This issue was introduced with our recent Shadow DOM updates. To fix it, I've removed the shadow DOM element from the OdysseyProvider _in Storybook only_, which eliminates the issue. As far as I can tell, there are no unintended consequences, since we don't really need to reduce the scope of our CSS in Storybook.