### PR TITLE
feat: Support id for Accordion

### DIFF
--- a/packages/odyssey-react-mui/src/Accordion.tsx
+++ b/packages/odyssey-react-mui/src/Accordion.tsx
@@ -99,7 +99,9 @@ const Accordion = ({
           {label}
         </Support>
       </MuiAccordionSummary>
-      <MuiAccordionDetails>{children}</MuiAccordionDetails>
+      <MuiAccordionDetails
+        aria-labelledby={headerId}
+      >{children}</MuiAccordionDetails>
     </MuiAccordion>
   );
 };

--- a/packages/odyssey-react-mui/src/Accordion.tsx
+++ b/packages/odyssey-react-mui/src/Accordion.tsx
@@ -28,6 +28,10 @@ export type AccordionProps = {
    */
   children: ReactNode;
   /**
+   * Defines IDs for the header and the content of the Accordion
+   */
+  id?: string;
+  /**
    * The label text for the AccordionSummary
    */
   label: string;
@@ -51,10 +55,6 @@ export type AccordionProps = {
    * Event fired when the expansion state of the accordion is changed
    */
   onChange?: MuiAccordionProps["onChange"];
-  /**
-   * Defines IDs for the header and the content of the Accordion
-   */
-  id?: string;
 } & (
   | {
       isExpanded: boolean;
@@ -71,12 +71,12 @@ const Accordion = ({
   children,
   label,
   hasShadow = true,
+  id: idOverride,
   isDefaultExpanded,
   isDisabled,
   isExpanded,
   onChange,
   translate,
-  id: idOverride,
 }: AccordionProps) => {
   const id = useUniqueId(idOverride);
   const headerId = `${id}-header`;
@@ -91,17 +91,17 @@ const Accordion = ({
       className={hasShadow ? `hasShadow` : undefined}
     >
       <MuiAccordionSummary
+        aria-controls={contentId}
         expandIcon={<ChevronDownIcon />}
         id={headerId}
-        aria-controls={contentId}
       >
         <Support component="div" translate={translate}>
           {label}
         </Support>
       </MuiAccordionSummary>
-      <MuiAccordionDetails
-        aria-labelledby={headerId}
-      >{children}</MuiAccordionDetails>
+      <MuiAccordionDetails aria-labelledby={headerId}>
+        {children}
+      </MuiAccordionDetails>
     </MuiAccordion>
   );
 };

--- a/packages/odyssey-react-mui/src/Accordion.tsx
+++ b/packages/odyssey-react-mui/src/Accordion.tsx
@@ -20,6 +20,7 @@ import {
 } from "@mui/material";
 import { ChevronDownIcon } from "./icons.generated";
 import { Support } from "./Typography";
+import { useUniqueId } from "./useUniqueId";
 
 export type AccordionProps = {
   /**
@@ -50,6 +51,10 @@ export type AccordionProps = {
    * Event fired when the expansion state of the accordion is changed
    */
   onChange?: MuiAccordionProps["onChange"];
+  /**
+   * Defines IDs for the header and the content of the Accordion
+   */
+  id?: string;
 } & (
   | {
       isExpanded: boolean;
@@ -71,7 +76,11 @@ const Accordion = ({
   isExpanded,
   onChange,
   translate,
+  id: idOverride,
 }: AccordionProps) => {
+  const id = useUniqueId(idOverride);
+  const headerId = `${id}-header`;
+  const contentId = `${id}-content`;
   return (
     <MuiAccordion
       defaultExpanded={isDefaultExpanded}
@@ -81,7 +90,11 @@ const Accordion = ({
       onChange={onChange}
       className={hasShadow ? `hasShadow` : undefined}
     >
-      <MuiAccordionSummary expandIcon={<ChevronDownIcon />}>
+      <MuiAccordionSummary
+        expandIcon={<ChevronDownIcon />}
+        id={headerId}
+        aria-controls={contentId}
+      >
         <Support component="div" translate={translate}>
           {label}
         </Support>


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->


## Summary

- Adds support of `id` prop for `Accordion`. If `id` is not passed, it will be auto generated using hook `useUniqueId`.
- `MuiAccordionSummary` will always have `id` and [`aria-controls`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls) props required for accessibility (see [Accessibility for Accordion](https://mui.com/material-ui/react-accordion/#accessibility)).
Thus in resulted HML an accordion header would have `id` attribute with value `${accordionId}-header` and `aria-controls` attribute with value `${accordionId}-content` and an accordion content would have `id` attribute with value `${accordionId}-content`.

(Changes are needed for SIW migration to Odyssey 1.x, task [OKTA-678802](https://oktainc.atlassian.net/browse/OKTA-678802))

