### PR TITLE
feat: support aria-describedby as prop for Field components

### DIFF
--- a/packages/odyssey-react-mui/src/Autocomplete.tsx
+++ b/packages/odyssey-react-mui/src/Autocomplete.tsx
@@ -281,6 +281,7 @@ const Autocomplete = <
       />
     ),
     [
+      ariaDescribedBy,
       errorMessage,
       errorMessageList,
       hint,

--- a/packages/odyssey-react-mui/src/Autocomplete.tsx
+++ b/packages/odyssey-react-mui/src/Autocomplete.tsx
@@ -161,6 +161,7 @@ export type AutocompleteProps<
   getIsOptionEqualToValue?: (option: OptionType, value: OptionType) => boolean;
 } & Pick<
   FieldComponentProps,
+  | "ariaDescribedBy"
   | "errorMessage"
   | "errorMessageList"
   | "hint"
@@ -177,6 +178,7 @@ const Autocomplete = <
   HasMultipleChoices extends boolean | undefined,
   IsCustomValueAllowed extends boolean | undefined
 >({
+  ariaDescribedBy,
   defaultValue,
   errorMessage,
   errorMessageList,
@@ -245,6 +247,7 @@ const Autocomplete = <
   const renderInput = useCallback(
     ({ InputLabelProps, InputProps, ...params }) => (
       <Field
+        ariaDescribedBy={ariaDescribedBy}
         errorMessage={errorMessage}
         errorMessageList={errorMessageList}
         fieldType="single"

--- a/packages/odyssey-react-mui/src/CheckboxGroup.tsx
+++ b/packages/odyssey-react-mui/src/CheckboxGroup.tsx
@@ -35,6 +35,7 @@ export type CheckboxGroupProps = {
   label: string;
 } & Pick<
   FieldComponentProps,
+  | "ariaDescribedBy"
   | "errorMessage"
   | "errorMessageList"
   | "hint"
@@ -45,6 +46,7 @@ export type CheckboxGroupProps = {
   AllowedProps;
 
 const CheckboxGroup = ({
+  ariaDescribedBy,
   children,
   errorMessage,
   errorMessageList,
@@ -75,6 +77,7 @@ const CheckboxGroup = ({
 
   return (
     <Field
+      ariaDescribedBy={ariaDescribedBy}
       errorMessage={errorMessage}
       errorMessageList={errorMessageList}
       fieldType="group"

--- a/packages/odyssey-react-mui/src/Field.tsx
+++ b/packages/odyssey-react-mui/src/Field.tsx
@@ -80,6 +80,7 @@ export type FieldProps = {
 };
 
 const Field = ({
+  ariaDescribedBy,
   errorMessage,
   errorMessageList,
   fieldType,
@@ -96,6 +97,7 @@ const Field = ({
 }: FieldProps &
   Pick<
     FieldComponentProps,
+    | "ariaDescribedBy"
     | "errorMessage"
     | "errorMessageList"
     | "hint"
@@ -113,9 +115,11 @@ const Field = ({
     errorMessage || errorMessageList ? `${id}-error` : undefined;
   const labelElementId = `${id}-label`;
 
-  const ariaDescribedBy = useMemo(
-    () => [hintId, errorMessageElementId].join(" ").trim() || undefined,
-    [errorMessageElementId, hintId]
+  const localAriaDescribedBy = useMemo(
+    () =>
+      [hintId, errorMessageElementId, ariaDescribedBy].join(" ").trim() ||
+      undefined,
+    [ariaDescribedBy, errorMessageElementId, hintId]
   );
 
   const { isDisabled: isFieldsetDisabled } = useFieldset();
@@ -160,7 +164,7 @@ const Field = ({
       )}
 
       {renderFieldComponent({
-        ariaDescribedBy,
+        ariaDescribedBy: localAriaDescribedBy,
         errorMessageElementId,
         id,
         labelElementId,

--- a/packages/odyssey-react-mui/src/FieldComponentProps.ts
+++ b/packages/odyssey-react-mui/src/FieldComponentProps.ts
@@ -16,6 +16,10 @@ import { HintLink } from "./HintLink";
 
 export type FieldComponentProps = {
   /**
+   * The ID of the element that describes the Field
+   */
+  ariaDescribedBy?: string;
+  /**
    * If `error` is not undefined, the `input` will indicate an error.
    */
   errorMessage?: string;

--- a/packages/odyssey-react-mui/src/NativeSelect.tsx
+++ b/packages/odyssey-react-mui/src/NativeSelect.tsx
@@ -93,6 +93,7 @@ export type NativeSelectProps<
   value?: Value;
 } & Pick<
   FieldComponentProps,
+  | "ariaDescribedBy"
   | "errorMessage"
   | "errorMessageList"
   | "hint"
@@ -110,6 +111,7 @@ const NativeSelect: ForwardRefWithType = forwardRef(
     HasMultipleChoices extends boolean
   >(
     {
+      ariaDescribedBy,
       autoCompleteType,
       defaultValue,
       errorMessage,
@@ -217,6 +219,7 @@ const NativeSelect: ForwardRefWithType = forwardRef(
 
     return (
       <Field
+        ariaDescribedBy={ariaDescribedBy}
         errorMessage={errorMessage}
         errorMessageList={errorMessageList}
         fieldType="single"

--- a/packages/odyssey-react-mui/src/PasswordField.tsx
+++ b/packages/odyssey-react-mui/src/PasswordField.tsx
@@ -82,6 +82,7 @@ export type PasswordFieldProps = {
 const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
   (
     {
+      ariaDescribedBy,
       autoCompleteType,
       defaultValue,
       errorMessage,
@@ -220,6 +221,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
 
     return (
       <Field
+        ariaDescribedBy={ariaDescribedBy}
         errorMessage={errorMessage}
         errorMessageList={errorMessageList}
         fieldType="single"

--- a/packages/odyssey-react-mui/src/RadioGroup.tsx
+++ b/packages/odyssey-react-mui/src/RadioGroup.tsx
@@ -45,6 +45,7 @@ export type RadioGroupProps = {
   value?: RadioProps["value"];
 } & Pick<
   FieldComponentProps,
+  | "ariaDescribedBy"
   | "errorMessage"
   | "errorMessageList"
   | "hint"
@@ -56,6 +57,7 @@ export type RadioGroupProps = {
   AllowedProps;
 
 const RadioGroup = ({
+  ariaDescribedBy,
   children,
   defaultValue,
   errorMessage,
@@ -107,6 +109,7 @@ const RadioGroup = ({
 
   return (
     <Field
+      ariaDescribedBy={ariaDescribedBy}
       errorMessage={errorMessage}
       errorMessageList={errorMessageList}
       fieldType="group"

--- a/packages/odyssey-react-mui/src/SearchField.tsx
+++ b/packages/odyssey-react-mui/src/SearchField.tsx
@@ -78,12 +78,16 @@ export type SearchFieldProps = {
    * The value of the `input` element, to use when controlled.
    */
   value?: string;
-} & Pick<FieldComponentProps, "id" | "isDisabled" | "name" | "isFullWidth"> &
+} & Pick<
+  FieldComponentProps,
+  "ariaDescribedBy" | "id" | "isDisabled" | "name" | "isFullWidth"
+> &
   AllowedProps;
 
 const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
   (
     {
+      ariaDescribedBy,
       autoCompleteType,
       defaultValue,
       hasInitialFocus,
@@ -186,6 +190,7 @@ const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
 
     return (
       <Field
+        ariaDescribedBy={ariaDescribedBy}
         fieldType="single"
         hasVisibleLabel={false}
         id={idOverride}

--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -97,6 +97,7 @@ export type SelectProps<
   value?: Value;
 } & Pick<
   FieldComponentProps,
+  | "ariaDescribedBy"
   | "errorMessage"
   | "errorMessageList"
   | "hint"
@@ -129,6 +130,7 @@ const Select = <
   Value extends SelectValueType<HasMultipleChoices>,
   HasMultipleChoices extends boolean
 >({
+  ariaDescribedBy,
   defaultValue,
   errorMessage,
   errorMessageList,
@@ -318,6 +320,7 @@ const Select = <
 
   return (
     <Field
+      ariaDescribedBy={ariaDescribedBy}
       errorMessage={errorMessage}
       errorMessageList={errorMessageList}
       fieldType="single"

--- a/packages/odyssey-react-mui/src/TextField.tsx
+++ b/packages/odyssey-react-mui/src/TextField.tsx
@@ -106,6 +106,7 @@ export type TextFieldProps = {
 const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
   (
     {
+      ariaDescribedBy,
       autoCompleteType,
       defaultValue,
       hasInitialFocus,
@@ -237,6 +238,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
 
     return (
       <Field
+        ariaDescribedBy={ariaDescribedBy}
         errorMessage={errorMessage}
         errorMessageList={errorMessageList}
         fieldType="single"

--- a/packages/odyssey-react-mui/src/labs/VirtualizedAutocomplete.tsx
+++ b/packages/odyssey-react-mui/src/labs/VirtualizedAutocomplete.tsx
@@ -283,6 +283,7 @@ const VirtualizedAutocomplete = <
       />
     ),
     [
+      ariaDescribedBy,
       errorMessage,
       errorMessageList,
       hint,

--- a/packages/odyssey-react-mui/src/labs/VirtualizedAutocomplete.tsx
+++ b/packages/odyssey-react-mui/src/labs/VirtualizedAutocomplete.tsx
@@ -168,7 +168,13 @@ export type AutocompleteProps<
   getIsOptionEqualToValue?: (option: OptionType, value: OptionType) => boolean;
 } & Pick<
   FieldComponentProps,
-  "errorMessage" | "errorMessageList" | "hint" | "id" | "isOptional" | "name"
+  | "ariaDescribedBy"
+  | "errorMessage"
+  | "errorMessageList"
+  | "hint"
+  | "id"
+  | "isOptional"
+  | "name"
 > &
   AllowedProps;
 
@@ -177,6 +183,7 @@ const VirtualizedAutocomplete = <
   HasMultipleChoices extends boolean | undefined,
   IsCustomValueAllowed extends boolean | undefined
 >({
+  ariaDescribedBy,
   defaultValue,
   errorMessage,
   errorMessageList,
@@ -243,6 +250,7 @@ const VirtualizedAutocomplete = <
   const renderInput = useCallback(
     ({ InputLabelProps, InputProps, ...params }) => (
       <Field
+        ariaDescribedBy={ariaDescribedBy}
         errorMessage={errorMessage}
         errorMessageList={errorMessageList}
         fieldType="single"


### PR DESCRIPTION
## Summary
- Supports passing in an `ariaDescribedBy` prop to any `Field` components and joins that value with other relevant describedby values within `Field`
