### PR TITLE
fix: allow empty string value for option value and value prop

### DIFF
--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -213,7 +213,7 @@ const Select = <
         typeof option === "object"
           ? {
               text: option.text,
-              value: option.value || option.text,
+              value: option.value,
               type: option.type === "heading" ? "heading" : "option",
             }
           : { text: option, value: option, type: "option" }
@@ -228,7 +228,6 @@ const Select = <
       if (typeof selected === "string") {
         return undefined;
       }
-
       // Convert the selected options array into <Chip>s
       const renderedChips = selected
         .map((item: string) => {
@@ -267,7 +266,10 @@ const Select = <
           <MenuItem key={option.value} value={option.value}>
             {hasMultipleChoices && (
               <MuiCheckbox
-                checked={internalSelectedValues?.includes(option.value)}
+                checked={
+                  option.value !== undefined &&
+                  internalSelectedValues?.includes(option.value)
+                }
               />
             )}
             {option.text}
@@ -289,6 +291,10 @@ const Select = <
         aria-describedby={ariaDescribedBy}
         aria-errormessage={errorMessageElementId}
         children={children}
+        data-se={testId}
+        displayEmpty={
+          controlledStateRef.current === CONTROLLED && inputValues?.value === ""
+        }
         id={id}
         inputProps={{ "data-se": testId }}
         inputRef={localInputRef}

--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -228,6 +228,7 @@ const Select = <
       if (typeof selected === "string") {
         return undefined;
       }
+
       // Convert the selected options array into <Chip>s
       const renderedChips = selected
         .map((item: string) => {

--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -40,6 +40,7 @@ import {
   useInputValues,
   getControlState,
 } from "./inputUtils";
+import { normalizedKey } from "./useNormalizedKey";
 
 export type SelectOption = {
   text: string;
@@ -213,7 +214,10 @@ const Select = <
         typeof option === "object"
           ? {
               text: option.text,
-              value: option.value,
+              value:
+                option?.value === ""
+                  ? option.value
+                  : option.value || option.text,
               type: option.type === "heading" ? "heading" : "option",
             }
           : { text: option, value: option, type: "option" }
@@ -259,12 +263,15 @@ const Select = <
   // that will populate the <Select>
   const children = useMemo(
     () =>
-      normalizedOptions.map((option) => {
+      normalizedOptions.map((option, index) => {
         if (option.type === "heading") {
           return <ListSubheader key={option.text}>{option.text}</ListSubheader>;
         }
         return (
-          <MenuItem key={option.value} value={option.value}>
+          <MenuItem
+            key={normalizedKey(option.text, index.toString())}
+            value={option.value}
+          >
             {hasMultipleChoices && (
               <MuiCheckbox
                 checked={
@@ -274,7 +281,7 @@ const Select = <
               />
             )}
             {option.text}
-            {internalSelectedValues === option.value && (
+            {internalSelectedValues === option?.value && (
               <ListItemSecondaryAction>
                 <CheckIcon />
               </ListItemSecondaryAction>

--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -293,7 +293,7 @@ const Select = <
         children={children}
         data-se={testId}
         displayEmpty={
-          controlledStateRef.current === CONTROLLED && inputValues?.value === ""
+          inputValues?.value === "" || inputValues?.defaultValue === ""
         }
         id={id}
         inputProps={{ "data-se": testId }}

--- a/packages/odyssey-react-mui/src/useNormalizedKey.ts
+++ b/packages/odyssey-react-mui/src/useNormalizedKey.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright (c) 2024-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+export const normalizedKey = (...keyParts: string[]): string => {
+  const SEPARATOR = "-";
+  // Joins all strings together with SEPARATOR, replaces any non-alphanumeric character with SEPARATOR and casts all to lowercase
+  return keyParts.join(SEPARATOR).replace(/\W+/g, SEPARATOR).toLowerCase();
+};

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Select/Select.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Select/Select.stories.tsx
@@ -386,3 +386,22 @@ export const ControlledPreselectedMultipleSelect: StoryObj<typeof Select> = {
     return <Select {...props} value={localValue} onChange={onChange} />;
   },
 };
+
+export const ControlledEmptyValue: StoryObj<typeof Select> = {
+  args: {
+    value: "",
+    options: [
+      { value: "", text: "Default option" },
+      { value: "value1", text: "Value 1" },
+      { value: "value2", text: "Value 2" },
+    ],
+  },
+  render: function C(props) {
+    const [localValue, setLocalValue] = useState("");
+    const onChange = useCallback(
+      (event) => setLocalValue(event.target.value),
+      []
+    );
+    return <Select {...props} value={localValue} onChange={onChange} />;
+  },
+};


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

[OKTA-690467](https://oktainc.atlassian.net/browse/OKTA-690467)

## Summary
Allow users to pass in an empty string for `value` prop if an option item has an empty `value` property. Allows an option with an empty string for `value` to be selected.

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
