### PR TITLE
fix: change spacing on checkbox label and hint

### DIFF
--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -1583,7 +1583,7 @@ export const components = ({
           alignItems: "center",
           fontSize: odysseyTokens.TypographySizeSubordinate,
           lineHeight: odysseyTokens.TypographyLineHeightBody,
-          marginBlockStart: odysseyTokens.Spacing2,
+          marginBlockStart: odysseyTokens.Spacing1,
           [`.${formLabelClasses.root} + &`]: {
             marginBlockStart: `-${odysseyTokens.Spacing1}`,
             color: odysseyTokens.TypographyColorSubordinate,


### PR DESCRIPTION

[OKTA-691345](https://oktainc.atlassian.net/browse/OKTA-691345)

## Summary
Changes spacing between hint text and checkbox label from 8px to 4px (Spacing 2 > Spacing 1) to match design conventions.

## Testing & Screenshots

Note: Figma change for this bug has already merged (as of 2/1/24 @ 1:20 PT).

- [ x] I have confirmed this change with my designer and the Odyssey Design Team.

![checkbox-hint](https://github.com/okta/odyssey/assets/147574410/0a472000-c02f-4c91-85cf-8715d707830f)
