### PR TITLE
Move primary actions in Form to end

### DIFF
--- a/packages/odyssey-react-mui/src/Form.tsx
+++ b/packages/odyssey-react-mui/src/Form.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { FormEvent, FormEventHandler, memo, ReactElement } from "react";
+import { FormEventHandler, memo, ReactElement } from "react";
 import { Box } from "@mui/material";
 
 import { Button } from "./Button";
@@ -80,7 +80,7 @@ export type FormProps = {
   /**
    * Callback that passes the submit event to the consumer
    */
-  onSubmit?: (event: FormEvent, formattedData: FormData) => void;
+  onSubmit?: FormEventHandler<HTMLFormElement>;
   /**
    * Indicates where to display the response after submitting the form. It is a name/keyword for a browsing context (for example, tab, window, or iframe).
    * This value can be overridden by a formtarget attribute on a <button>, <input type="submit">, or <input type="image"> element.
@@ -113,13 +113,6 @@ const Form = ({
 }: FormProps) => {
   const id = useUniqueId(idOverride);
 
-  const onFormSubmit: FormEventHandler = (event) => {
-    const formElement = event.target as HTMLFormElement;
-    const formData = new FormData(formElement);
-
-    onSubmit?.(event, formData);
-  };
-
   return (
     <Box
       autoComplete={autoCompleteType}
@@ -130,7 +123,7 @@ const Form = ({
       method={method}
       name={name}
       noValidate={noValidate}
-      onSubmit={onFormSubmit}
+      onSubmit={onSubmit}
       target={target}
       sx={{
         maxWidth: (theme) => (isFullWidth ? "100%" : theme.mixins.maxWidth),

--- a/packages/odyssey-react-mui/src/Form.tsx
+++ b/packages/odyssey-react-mui/src/Form.tsx
@@ -10,14 +10,15 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { memo, ReactElement } from "react";
-
+import { FormEvent, FormEventHandler, memo, ReactElement } from "react";
 import { Box } from "@mui/material";
+
 import { Button } from "./Button";
 import { Callout } from "./Callout";
+import { FieldComponentProps } from "./FieldComponentProps";
+import type { HtmlProps } from "./HtmlProps";
 import { Heading4, Support } from "./Typography";
 import { useUniqueId } from "./useUniqueId";
-import type { HtmlProps } from "./HtmlProps";
 
 export const formEncodingTypeValues = [
   "application/x-www-form-urlencoded",
@@ -77,6 +78,10 @@ export type FormProps = {
    */
   noValidate?: boolean;
   /**
+   * Callback that passes the submit event to the consumer
+   */
+  onSubmit?: (event: FormEvent, formattedData: FormData) => void;
+  /**
    * Indicates where to display the response after submitting the form. It is a name/keyword for a browsing context (for example, tab, window, or iframe).
    * This value can be overridden by a formtarget attribute on a <button>, <input type="submit">, or <input type="image"> element.
    */
@@ -85,7 +90,8 @@ export type FormProps = {
    * The title of the Form
    */
   title?: string;
-} & HtmlProps;
+} & Pick<FieldComponentProps, "isFullWidth"> &
+  HtmlProps;
 
 const Form = ({
   alert,
@@ -95,15 +101,24 @@ const Form = ({
   encodingType,
   formActions,
   id: idOverride,
+  isFullWidth,
   method,
   name,
   noValidate = false,
+  onSubmit,
   target,
   testId,
   title,
   translate,
 }: FormProps) => {
   const id = useUniqueId(idOverride);
+
+  const onFormSubmit: FormEventHandler = (event) => {
+    const formElement = event.target as HTMLFormElement;
+    const formData = new FormData(formElement);
+
+    onSubmit?.(event, formData);
+  };
 
   return (
     <Box
@@ -115,9 +130,10 @@ const Form = ({
       method={method}
       name={name}
       noValidate={noValidate}
+      onSubmit={onFormSubmit}
       target={target}
       sx={{
-        maxWidth: (theme) => theme.mixins.maxWidth,
+        maxWidth: (theme) => (isFullWidth ? "100%" : theme.mixins.maxWidth),
         margin: (theme) => theme.spacing(0),
         padding: (theme) => theme.spacing(0),
       }}
@@ -142,7 +158,7 @@ const Form = ({
           component="div"
           sx={{
             display: "flex",
-            justifyContent: "flex-start",
+            justifyContent: "flex-end",
             gap: (theme) => theme.spacing(1),
             marginBlockStart: (theme) => theme.spacing(7),
           }}

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Form/Form.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Form/Form.stories.tsx
@@ -175,8 +175,8 @@ const storybookMeta: Meta<FormProps> = {
     ),
     formActions: (
       <>
-        <Button type="submit" label="Submit" variant="primary" />
         <Button label="Reset" variant="secondary" />
+        <Button type="submit" label="Submit" variant="primary" />
       </>
     ),
   },
@@ -188,23 +188,8 @@ export default storybookMeta;
 
 const Template: StoryObj<FormProps> = {
   render: function (args) {
-    return (
-      <Form
-        alert={args.alert}
-        autoCompleteType={args.autoCompleteType}
-        description={args.description}
-        encodingType={args.encodingType}
-        formActions={args.formActions}
-        id={args.id}
-        method={args.method}
-        name={args.name}
-        noValidate={args.noValidate}
-        target={args.target}
-        title={args.title}
-      >
-        {args.children}
-      </Form>
-    );
+    const { children } = args;
+    return <Form {...args}>{children}</Form>;
   },
 };
 
@@ -254,6 +239,19 @@ export const Alert: StoryObj<FormProps> = {
       <Callout severity="error" role="alert" title="Something went wrong">
         Please try your request again later.
       </Callout>
+    ),
+  },
+};
+
+export const FullWidth: StoryObj<FormProps> = {
+  ...Template,
+  args: {
+    isFullWidth: true,
+    children: (
+      <>
+        <TextField isFullWidth label="Vessel name" />
+        <TextField isFullWidth isMultiline label="Reason for visit" />
+      </>
     ),
   },
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Form/Form.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Form/Form.stories.tsx
@@ -186,13 +186,6 @@ const storybookMeta: Meta<FormProps> = {
 
 export default storybookMeta;
 
-// const Template: StoryObj<FormProps> = {
-//   render: function (args) {
-//     const { children } = args;
-//     return <Form {...args}>{children}</Form>;
-//   },
-// };
-
 // States
 
 export const Simple: StoryObj<FormProps> = {

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Form/Form.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Form/Form.stories.tsx
@@ -26,7 +26,9 @@ import {
   Paragraph,
   TextField,
 } from "@okta/odyssey-react-mui";
+
 import { MuiThemeDecorator } from "../../../../.storybook/components";
+import { fieldComponentPropsMetaData } from "../../../fieldComponentPropsMetaData";
 
 const storybookMeta: Meta<FormProps> = {
   title: "MUI Components/Forms/Form",
@@ -84,6 +86,7 @@ const storybookMeta: Meta<FormProps> = {
         },
       },
     },
+    isFullWidth: fieldComponentPropsMetaData.isFullWidth,
     name: {
       control: "text",
       description:
@@ -172,7 +175,7 @@ const storybookMeta: Meta<FormProps> = {
     ),
     formActions: (
       <>
-        <Button label="Submit" variant="primary" />
+        <Button type="submit" label="Submit" variant="primary" />
         <Button label="Reset" variant="secondary" />
       </>
     ),
@@ -187,17 +190,17 @@ const Template: StoryObj<FormProps> = {
   render: function (args) {
     return (
       <Form
-        title={args.title}
-        name={args.name}
-        description={args.description}
-        formActions={args.formActions}
         alert={args.alert}
         autoCompleteType={args.autoCompleteType}
+        description={args.description}
         encodingType={args.encodingType}
+        formActions={args.formActions}
+        id={args.id}
         method={args.method}
+        name={args.name}
         noValidate={args.noValidate}
         target={args.target}
-        id={args.id}
+        title={args.title}
       >
         {args.children}
       </Form>

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Form/Form.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Form/Form.stories.tsx
@@ -186,17 +186,16 @@ const storybookMeta: Meta<FormProps> = {
 
 export default storybookMeta;
 
-const Template: StoryObj<FormProps> = {
-  render: function (args) {
-    const { children } = args;
-    return <Form {...args}>{children}</Form>;
-  },
-};
+// const Template: StoryObj<FormProps> = {
+//   render: function (args) {
+//     const { children } = args;
+//     return <Form {...args}>{children}</Form>;
+//   },
+// };
 
 // States
 
 export const Simple: StoryObj<FormProps> = {
-  ...Template,
   args: {
     children: (
       <>
@@ -208,7 +207,6 @@ export const Simple: StoryObj<FormProps> = {
 };
 
 export const Fieldsets: StoryObj<FormProps> = {
-  ...Template,
   args: {
     children: (
       <>
@@ -226,14 +224,12 @@ export const Fieldsets: StoryObj<FormProps> = {
 };
 
 export const Description: StoryObj<FormProps> = {
-  ...Template,
   args: {
     description: "Register your ship before docking with the station.",
   },
 };
 
 export const Alert: StoryObj<FormProps> = {
-  ...Template,
   args: {
     alert: (
       <Callout severity="error" role="alert" title="Something went wrong">
@@ -244,7 +240,6 @@ export const Alert: StoryObj<FormProps> = {
 };
 
 export const FullWidth: StoryObj<FormProps> = {
-  ...Template,
   args: {
     isFullWidth: true,
     children: (
@@ -257,7 +252,6 @@ export const FullWidth: StoryObj<FormProps> = {
 };
 
 export const KitchenSink: StoryObj<FormProps> = {
-  ...Template,
   args: {
     alert: (
       <Callout severity="error" role="alert" title="Something went wrong">


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

[OKTA-691121](https://oktainc.atlassian.net/browse/OKTA-691121)
[OKTA-692737](https://oktainc.atlassian.net/browse/OKTA-692737)


## Summary
- Moves the actions container to flex-end to align with Odyssey decision on placement of actions
<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [x] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
