### PR TITLE
test: fixed test issues from playwright upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,10 @@ jobs:
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           env_url: ${{ env.URL_STORYBOOK }}
 
+      - name: setup playwright dependencies
+        if: steps.changes.outputs.deploy == 'true'
+        run: yarn workspace @okta/odyssey-storybook playwright install --with-deps chromium
+
       - name: a11y test
         if: steps.changes.outputs.deploy == 'true'
         run: yarn workspace @okta/odyssey-storybook test:storybook --url ${{ env.URL_STORYBOOK }}

--- a/packages/odyssey-storybook/src/components/odyssey-labs/Switch/Switch.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/Switch/Switch.stories.tsx
@@ -89,11 +89,11 @@ export const Default: StoryObj<typeof Switch> = {
       const canvas = within(canvasElement);
       const switchCheckbox = canvas.getByRole("checkbox") as HTMLInputElement;
       if (switchCheckbox) {
-        userEvent.click(switchCheckbox);
+        await userEvent.click(switchCheckbox);
       }
-      expect(switchCheckbox).toBeChecked();
-      axeRun("Switch Default");
-      userEvent.tab();
+      await expect(switchCheckbox).toBeChecked();
+      await axeRun("Switch Default");
+      await userEvent.tab();
     });
   },
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
@@ -185,35 +185,35 @@ export const Default: StoryObj<AutocompleteType> = {
     const canvas = within(canvasElement);
     const comboBoxElement = canvas.getByRole("combobox") as HTMLInputElement;
     await step("Filter and Select from listbox", async () => {
-      userEvent.click(comboBoxElement);
+      await userEvent.click(comboBoxElement);
       const listboxElement = screen.getByRole("listbox");
-      expect(listboxElement).toBeVisible();
+      await expect(listboxElement).toBeVisible();
     });
     await step("Check for 'No options' in the list", async () => {
       await axeRun("Autocomplete Default");
-      waitFor(() => {
-        userEvent.type(comboBoxElement, "q");
+      await waitFor(async () => {
+        await userEvent.type(comboBoxElement, "q");
         const noOptionsElement = screen.getByText("No options");
-        expect(noOptionsElement).toBeVisible();
+        await expect(noOptionsElement).toBeVisible();
       });
     });
     await step("Check for Filtered item from the list", async () => {
-      userEvent.clear(comboBoxElement);
-      userEvent.type(comboBoxElement, "z");
+      await userEvent.clear(comboBoxElement);
+      await userEvent.type(comboBoxElement, "z");
       const listItem = screen.getByRole("listbox").firstChild as HTMLLIElement;
-      expect(listItem?.textContent).toBe("Shirazi-Ma Complex");
-      userEvent.click(listItem);
-      expect(comboBoxElement.value).toBe("Shirazi-Ma Complex");
+      await expect(listItem?.textContent).toBe("Shirazi-Ma Complex");
+      await userEvent.click(listItem);
+      await expect(comboBoxElement.value).toBe("Shirazi-Ma Complex");
     });
     await step("Clear the selected item", async () => {
       const clearButton = canvas.getByTitle("Clear");
-      userEvent.click(clearButton);
-      expect(comboBoxElement.value).toBe("");
-      userEvent.tab();
+      await userEvent.click(clearButton);
+      await expect(comboBoxElement.value).toBe("");
+      await userEvent.tab();
     });
-    step("Check id and name", () => {
-      expect(comboBoxElement.getAttribute("id")).toBe("testId");
-      expect(comboBoxElement.getAttribute("name")).toBe("testId");
+    await step("Check id and name", async () => {
+      await expect(comboBoxElement.getAttribute("id")).toBe("testId");
+      await expect(comboBoxElement.getAttribute("name")).toBe("testId");
     });
   },
 };
@@ -232,7 +232,7 @@ export const Error: StoryObj<AutocompleteType> = {
   },
   play: async ({ step }) => {
     await step("Check for a11y errors on Select Error", async () => {
-      await waitFor(() => axeRun("Select Error"));
+      await waitFor(async () => await axeRun("Select Error"));
     });
   },
 };
@@ -254,10 +254,10 @@ export const IsCustomValueAllowed: StoryObj<AutocompleteType> = {
     await step("Enter custom value", async () => {
       const canvas = within(canvasElement);
       const comboBoxElement = canvas.getByRole("combobox") as HTMLInputElement;
-      userEvent.click(comboBoxElement);
-      userEvent.type(comboBoxElement, "qwerty");
-      userEvent.tab();
-      expect(comboBoxElement.value).toBe("qwerty");
+      await userEvent.click(comboBoxElement);
+      await userEvent.type(comboBoxElement, "qwerty");
+      await userEvent.tab();
+      await expect(comboBoxElement.value).toBe("qwerty");
     });
   },
 };
@@ -278,29 +278,33 @@ export const Multiple: StoryObj<AutocompleteType> = {
     const canvas = within(canvasElement);
     const comboBoxElement = canvas.getByRole("combobox") as HTMLInputElement;
     await step("Check for list box to be visible", async () => {
-      userEvent.click(comboBoxElement);
+      await userEvent.click(comboBoxElement);
       const listboxElement = screen.getByRole("listbox");
-      expect(listboxElement).toBeVisible();
+      await expect(listboxElement).toBeVisible();
     });
     await step("Select multiple items", async () => {
-      userEvent.type(comboBoxElement, "z");
-      userEvent.click(screen.getByRole("listbox").firstChild as HTMLLIElement);
-      userEvent.clear(comboBoxElement);
-      userEvent.type(comboBoxElement, "w");
-      userEvent.click(screen.getByRole("listbox").firstChild as HTMLLIElement);
+      await userEvent.type(comboBoxElement, "z");
+      await userEvent.click(
+        screen.getByRole("listbox").firstChild as HTMLLIElement,
+      );
+      await userEvent.clear(comboBoxElement);
+      await userEvent.type(comboBoxElement, "w");
+      await userEvent.click(
+        screen.getByRole("listbox").firstChild as HTMLLIElement,
+      );
       await axeRun("Autocomplete Multiple");
     });
     await step("Clear the selected items", async () => {
-      waitFor(() => {
+      await waitFor(async () => {
         const clearButton = canvas.getByTitle("Clear");
-        userEvent.click(clearButton);
-        expect(comboBoxElement.value).toBe("");
-        userEvent.tab();
+        await userEvent.click(clearButton);
+        await expect(comboBoxElement.value).toBe("");
+        await userEvent.tab();
       });
     });
-    step("Check id and name", () => {
-      expect(comboBoxElement.getAttribute("id")).toBe("testId");
-      expect(comboBoxElement.getAttribute("name")).toBe("testName");
+    await step("Check id and name", async () => {
+      await expect(comboBoxElement.getAttribute("id")).toBe("testId");
+      await expect(comboBoxElement.getAttribute("name")).toBe("testName");
     });
   },
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Banner/Banner.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Banner/Banner.stories.tsx
@@ -142,8 +142,8 @@ export const Linked: StoryObj<BannerProps> = {
     await step("check for the link text", async () => {
       const canvas = within(canvasElement);
       const link = canvas.getByText("View report") as HTMLAnchorElement;
-      expect(link?.tagName).toBe("A");
-      expect(link?.href).toBe(`${link?.baseURI}#anchor`);
+      await expect(link?.tagName).toBe("A");
+      await expect(link?.href).toBe(`${link?.baseURI}#anchor`);
     });
   },
 };
@@ -156,9 +156,9 @@ export const Dismissible: StoryObj<BannerProps> = {
     await step("dismiss the banner on click", async () => {
       const canvas = within(canvasElement);
       const button = canvas.getByTitle("Close");
-      userEvent.click(button);
-      userEvent.tab();
-      expect(args.onClose).toHaveBeenCalled();
+      await userEvent.click(button);
+      await userEvent.tab();
+      await expect(args.onClose).toHaveBeenCalled();
       await axeRun("Dismissible Banner");
     });
   },

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Radio/Radio.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Radio/Radio.stories.tsx
@@ -104,12 +104,12 @@ export const Default: StoryObj<typeof Radio> = {
       const canvas = within(canvasElement);
       const radio = canvas.getByRole("radio") as HTMLInputElement;
       if (radio) {
-        userEvent.click(radio);
+        await userEvent.click(radio);
       }
-      expect(radio).toBeChecked();
-      userEvent.click(canvasElement);
-      expect(args.onBlur).toHaveBeenCalled();
-      axeRun("Radio Default");
+      await expect(radio).toBeChecked();
+      await userEvent.click(canvasElement);
+      await expect(args.onBlur).toHaveBeenCalled();
+      await axeRun("Radio Default");
     });
   },
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/RadioGroup/RadioGroup.stories.tsx
@@ -158,10 +158,10 @@ export const UncontrolledRadioGroup: StoryObj<typeof RadioGroup> = {
         "Ludicrous Speed",
       ) as HTMLInputElement;
       if (radiogroup && radio) {
-        userEvent.click(radio);
+        await userEvent.click(radio);
       }
-      expect(radio).toBeChecked();
-      axeRun("select controlled radio button");
+      await expect(radio).toBeChecked();
+      await axeRun("select controlled radio button");
     });
   },
 };
@@ -198,10 +198,10 @@ export const ControlledRadioGroup: StoryObj<typeof RadioGroup> = {
       const radiogroup = canvas.getByRole("radiogroup") as HTMLInputElement;
       const radio = canvas.getByLabelText("Warp Speed") as HTMLInputElement;
       if (radiogroup && radio) {
-        userEvent.click(radio);
+        await userEvent.click(radio);
       }
-      expect(radio).toBeChecked();
-      axeRun("select uncontrolled radio button");
+      await expect(radio).toBeChecked();
+      await axeRun("select uncontrolled radio button");
     });
   },
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Select/Select.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Select/Select.stories.tsx
@@ -227,15 +227,15 @@ export const Default: StoryObj<typeof Select> = {
         '[aria-haspopup="listbox"]',
       );
       if (comboBoxElement) {
-        userEvent.click(comboBoxElement);
+        await userEvent.click(comboBoxElement);
         const listboxElement = screen.getByRole("listbox");
-        expect(listboxElement).toBeInTheDocument();
+        await expect(listboxElement).toBeInTheDocument();
         const listItem = listboxElement.children[0];
-        userEvent.click(listItem);
-        userEvent.tab();
+        await userEvent.click(listItem);
+        await userEvent.tab();
         await waitFor(() => expect(listboxElement).not.toBeInTheDocument());
         const inputElement = canvasElement.querySelector("input");
-        expect(inputElement?.value).toBe("Earth");
+        await expect(inputElement?.value).toBe("Earth");
         await waitFor(() => axeRun("Select Default"));
       }
     });
@@ -303,17 +303,18 @@ export const MultiSelect: StoryObj<typeof Select> = {
         '[aria-haspopup="listbox"]',
       );
       if (comboBoxElement) {
-        userEvent.click(comboBoxElement);
+        await userEvent.click(comboBoxElement);
         const listboxElement = screen.getByRole("listbox");
-        expect(listboxElement).toBeInTheDocument();
+        await expect(listboxElement).toBeInTheDocument();
 
-        userEvent.click(listboxElement.children[0]);
-        userEvent.click(listboxElement.children[1]);
-        userEvent.tab();
+        await userEvent.click(listboxElement.children[0]);
+        await userEvent.click(listboxElement.children[1]);
+        await userEvent.tab();
         await waitFor(() => expect(listboxElement).not.toBeInTheDocument());
+
         const inputElement = canvasElement.querySelector("input");
-        expect(inputElement?.value).toBe("Earth,Mars");
-        userEvent.click(canvasElement);
+        await expect(inputElement?.value).toBe("Earth,Mars");
+        await userEvent.click(canvasElement);
         await waitFor(() => axeRun("Select Multiple"));
       }
     });

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
@@ -141,9 +141,9 @@ export const Removable: StoryObj<TagProps> = {
       const tagElement = canvasElement.querySelector('[role="button"]');
       const removeIcon = tagElement?.querySelector("svg");
       if (removeIcon) {
-        userEvent.click(removeIcon);
-        userEvent.tab();
-        expect(args.onRemove).toHaveBeenCalled();
+        await userEvent.click(removeIcon);
+        await userEvent.tab();
+        await expect(args.onRemove).toHaveBeenCalled();
       }
       await axeRun("Removable Tag");
     });


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

[OKTA-699489](https://oktainc.atlassian.net/browse/OKTA-699489)

## Summary
Fixes the `a11y` tests and sets up chromium for playwright to use to run the tests against. 

Test fixes:
- The main fix was to `await` async functions we were calling, as well as steps
- Turn non-async callbacks into async ones where we need to await anything within them

Playwright fixes:
- It appears that after the upgrades we made to the monorepo, `playwright` doesn't have a chromium binary to use to run the tests against
- [Add a step](https://playwright.dev/docs/ci-intro#on-pushpull_request:~:text=Install%20Playwright%20Browsers-,run%3A%20npx%20playwright%20install%20%2D%2Dwith%2Ddeps,-%2D%20name%3A) before we launch the `a11y` tests to [install `chromium` and any OS dependencies](https://playwright.dev/docs/browsers#:~:text=npx%20playwright%20install%20%2D%2Dwith%2Ddeps%20chromium) needed by playwright

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
