### PR TITLE
Add displayName to table components

### DIFF
--- a/packages/odyssey-react-mui/src/DataTable/DataTableEmptyState.tsx
+++ b/packages/odyssey-react-mui/src/DataTable/DataTableEmptyState.tsx
@@ -59,4 +59,6 @@ const DataTableEmptyState = ({
 };
 
 const MemoizedDataTableEmptyState = memo(DataTableEmptyState);
+MemoizedDataTableEmptyState.displayName = "DataTableEmptyState";
+
 export { MemoizedDataTableEmptyState as DataTableEmptyState };

--- a/packages/odyssey-react-mui/src/DataTable/DataTablePagination.tsx
+++ b/packages/odyssey-react-mui/src/DataTable/DataTablePagination.tsx
@@ -286,4 +286,6 @@ const DataTablePagination = ({
 };
 
 const MemoizedDataTablePagination = memo(DataTablePagination);
+MemoizedDataTablePagination.displayName = "DataTablePagination";
+
 export { MemoizedDataTablePagination as DataTablePagination };

--- a/packages/odyssey-react-mui/src/DataTable/DataTableRowActions.tsx
+++ b/packages/odyssey-react-mui/src/DataTable/DataTableRowActions.tsx
@@ -119,4 +119,6 @@ const DataTableRowActions = ({
 };
 
 const MemoizedDataTableRowActions = memo(DataTableRowActions);
+MemoizedDataTableRowActions.displayName = "DataTableRowActions";
+
 export { MemoizedDataTableRowActions as DataTableRowActions };

--- a/packages/odyssey-react-mui/src/DataTable/DataTableSettings.tsx
+++ b/packages/odyssey-react-mui/src/DataTable/DataTableSettings.tsx
@@ -132,4 +132,6 @@ const DataTableSettings = ({
 };
 
 const MemoizedDataTableSettings = memo(DataTableSettings);
+MemoizedDataTableSettings.displayName = "DataTableSettings";
+
 export { MemoizedDataTableSettings as DataTableSettings };

--- a/packages/odyssey-react-mui/src/labs/StaticTable.tsx
+++ b/packages/odyssey-react-mui/src/labs/StaticTable.tsx
@@ -124,7 +124,7 @@ const StaticTable = <TData extends DefaultMaterialReactTableData>({
   return <MaterialReactTable table={table} />;
 };
 
-// Need the `typeof StaticTable` because generics don't get passed through
+// Need the `typeof StaticTable` because generics don't get passed through `memo`.
 const MemoizedStaticTable = memo(StaticTable) as typeof StaticTable;
 
 // @ts-expect-error displayName is expected to not be on `typeof StaticTable`

--- a/packages/odyssey-react-mui/src/labs/StaticTable.tsx
+++ b/packages/odyssey-react-mui/src/labs/StaticTable.tsx
@@ -124,6 +124,10 @@ const StaticTable = <TData extends DefaultMaterialReactTableData>({
   return <MaterialReactTable table={table} />;
 };
 
+// Need the `typeof StaticTable` because generics don't get passed through
 const MemoizedStaticTable = memo(StaticTable) as typeof StaticTable;
+
+// @ts-expect-error displayName is expected to not be on `typeof StaticTable`
+MemoizedStaticTable.displayName = "StaticTable";
 
 export { MemoizedStaticTable as StaticTable };


### PR DESCRIPTION
StaticTable and other table components needed a displayName.