### PR TITLE
revert height change. pass full width prop

### DIFF
--- a/packages/odyssey-react-mui/src/Autocomplete.tsx
+++ b/packages/odyssey-react-mui/src/Autocomplete.tsx
@@ -298,6 +298,7 @@ const Autocomplete = <
         hasVisibleLabel
         //@ts-expect-error htmlFor does not exist ont he InputLabelProps for autocomplete
         id={InputLabelProps.htmlFor}
+        isFullWidth={isFullWidth}
         hint={hint}
         HintLinkComponent={HintLinkComponent}
         label={label}

--- a/packages/odyssey-react-mui/src/Autocomplete.tsx
+++ b/packages/odyssey-react-mui/src/Autocomplete.tsx
@@ -332,6 +332,7 @@ const Autocomplete = <
       errorMessageList,
       hint,
       HintLinkComponent,
+      isFullWidth,
       isOptional,
       label,
       nameOverride,

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -1838,8 +1838,7 @@ export const components = ({
           },
         }),
         input: {
-          // Set total height to 40px, factoring in borders on outer container
-          height: `calc(${odysseyTokens.Spacing4} - (${odysseyTokens.BorderWidthMain} * 2))`,
+          height: "auto",
           paddingBlock: odysseyTokens.Spacing3,
           paddingInline: odysseyTokens.Spacing3,
           boxShadow: "none",

--- a/packages/odyssey-storybook/.storybook/components/MuiThemeDecorator.tsx
+++ b/packages/odyssey-storybook/.storybook/components/MuiThemeDecorator.tsx
@@ -1,8 +1,9 @@
 import {
   createOdysseyMuiTheme,
+  CssBaseline,
   OdysseyProvider,
 } from "@okta/odyssey-react-mui";
-import { CssBaseline, ScopedCssBaseline } from "@mui/material";
+import { ScopedCssBaseline } from "@mui/material";
 import { ThemeProvider as StorybookThemeProvider } from "@storybook/theming";
 import type { Decorator } from "@storybook/react";
 import * as odysseyTokens from "@okta/odyssey-design-tokens";


### PR DESCRIPTION
…om autocomplete

<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[OKTA-705987](https://oktainc.atlassian.net/browse/OKTA-705987)

## Summary
- Passes `isFullWidth` prop from `AutoComplete` to `Field`
- Fixes regression on inputs height
<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
