### PR TITLE
Fix wonky input height

### DIFF
--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -1838,7 +1838,7 @@ export const components = ({
           },
         }),
         input: {
-          height: "auto",
+          height: `calc(${odysseyTokens.Spacing7} - (${odysseyTokens.BorderWidthMain} * 2))`,
           paddingBlock: odysseyTokens.Spacing3,
           paddingInline: odysseyTokens.Spacing3,
           boxShadow: "none",


### PR DESCRIPTION
During the MUI upgrade, the `MuiInputBase` shifted how it calculates height. Previously it used `box-sizing: content-box`; now it uses `box-sizing: border-box`.

This change was entirely on MUI's end, but causes us to need to change how we calculate input heights. Thanks to our token system, this is as easy as changing from `Spacing4` to `Spacing7`.