### PR TITLE
fix: fix listbox height when virtualized and loading state look

### DIFF
--- a/packages/odyssey-react-mui/src/Autocomplete.tsx
+++ b/packages/odyssey-react-mui/src/Autocomplete.tsx
@@ -474,6 +474,7 @@ const Autocomplete = <
       onInputChange={onInputChange}
       onFocus={onFocus}
       options={options}
+      open={true}
       readOnly={isReadOnly}
       renderInput={renderInput}
       isOptionEqualToValue={getIsOptionEqualToValue}

--- a/packages/odyssey-react-mui/src/Autocomplete.tsx
+++ b/packages/odyssey-react-mui/src/Autocomplete.tsx
@@ -474,7 +474,6 @@ const Autocomplete = <
       onInputChange={onInputChange}
       onFocus={onFocus}
       options={options}
-      open={true}
       readOnly={isReadOnly}
       renderInput={renderInput}
       isOptionEqualToValue={getIsOptionEqualToValue}

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -434,6 +434,7 @@ export const components = ({
             },
           },
           "& > ul": {
+            position: "relative",
             paddingInlineStart: 0,
             marginBlockStart: 0,
             marginBlockEnd: 0,
@@ -442,6 +443,10 @@ export const components = ({
         loading: {
           paddingBlock: odysseyTokens.Spacing3,
           paddingInline: odysseyTokens.Spacing4,
+          borderWidth: odysseyTokens.BorderWidthMain,
+          borderStyle: odysseyTokens.BorderStyleMain,
+          borderColor: odysseyTokens.HueNeutral200,
+          borderRadius: odysseyTokens.BorderRadiusMain,
         },
         popupIndicator: {
           padding: odysseyTokens.Spacing1,
@@ -452,9 +457,16 @@ export const components = ({
           paddingBlockStart: odysseyTokens.Spacing1,
           height: "100%",
         },
-        paper: {
-          height: "100%",
-        },
+        paper: ({ ownerState }) => ({
+          /**
+           * ListboxComponent is used when `isVirtualized` prop is true.
+           * This style is needed to render the virtualized window. It renders out a parent div
+           * that needs a height to be set, otherwise the height is 0 and nothing appears.
+           */
+          ...(ownerState.ListboxComponent !== undefined && {
+            height: "100%",
+          }),
+        }),
         inputRoot: ({ ownerState }) => ({
           ...(ownerState.readOnly === true && {
             backgroundColor: odysseyTokens.HueNeutral50,


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[REPLACE_WITH_JIRA_TICKET_NUMBER](https://oktainc.atlassian.net/browse/REPLACE_WITH_JIRA_TICKET_NUMBER)

## Summary
Fixes autocomplete loading state so it is visually consistent with lists of options.
Fixed height issue for all dropdowns (loading, list, virtualized list).
<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
