### PR TITLE
Fix checkbox alignment issue

### DIFF
--- a/packages/odyssey-react-mui/src/Checkbox.tsx
+++ b/packages/odyssey-react-mui/src/Checkbox.tsx
@@ -115,7 +115,7 @@ const Checkbox = ({
   const label = useMemo(() => {
     return (
       <>
-        {labelProp}
+        <Typography component="span">{labelProp}</Typography>
         {isRequired && (
           <>
             {" "}
@@ -166,9 +166,9 @@ const Checkbox = ({
           }}
           disabled={isDisabled}
           inputRef={localInputRef}
-          sx={() => ({
+          sx={{
             marginBlockStart: "2px",
-          })}
+          }}
         />
       }
       disabled={isDisabled}

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -1623,9 +1623,6 @@ export const components = ({
           [`:has(> .${radioClasses.root})`]: {
             alignItems: "flex-start",
           },
-          [`& .${checkboxClasses.root}`]: {
-            marginBlockStart: 0,
-          },
           [`&:hover .${radioClasses.root}, &:hover .${checkboxClasses.root}`]: {
             color: odysseyTokens.TypographyColorBody,
           },


### PR DESCRIPTION
The checkbox label was misaligned by a few pixels when the `(Required)` span was appended to the label.

Two things needed to change to fix this:
1. The non-`(Required)` portion of the label needed to be wrapped in a `span`. There were some style differences between the Required and the rest of the label due to the fact that one was wrapped in a Typography component and the other wasn't.
2. Removed a `marginBlockStart: 0` that nixed an older alignment fix to make the checkbox positioning match the label line-height