### PR TITLE
Fix height for TextField, Select, and NativeSelect

### DIFF
--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -92,6 +92,7 @@ const NonInteractiveIcon = styled(CloseCircleFilledIcon, {
   margin-inline-start: ${({ odysseyDesignTokens }) =>
     odysseyDesignTokens.Spacing2};
   margin-inline-end: -${({ odysseyDesignTokens }) => odysseyDesignTokens.Spacing1};
+  margin-block-end: -1px;
 `;
 
 const ChipsInnerContainer = styled(MuiBox, {
@@ -104,7 +105,7 @@ const ChipsInnerContainer = styled(MuiBox, {
   display: flex;
   flex-wrap: wrap;
   gap: ${({ odysseyDesignTokens }) => odysseyDesignTokens.Spacing1};
-  pointer-events: ${({ isInteractive }) => (isInteractive ? "auto" : "none")};
+  pointer-events: none;
   opacity: ${({ isInteractive }) => (isInteractive ? 1 : 0)};
 `;
 
@@ -342,7 +343,9 @@ const Select = <
           isInteractive={isInteractive}
           odysseyDesignTokens={odysseyDesignTokens}
         >
-          <ChipsSpacer odysseyDesignTokens={odysseyDesignTokens} />
+          {selection.length <= 0 && (
+            <ChipsSpacer odysseyDesignTokens={odysseyDesignTokens} />
+          )}
           {selection.map(
             (item: string) =>
               item?.length > 0 && (

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -1839,6 +1839,7 @@ export const components = ({
         }),
         input: {
           height: "auto",
+          // We're subtracting a pixel so the total height, including borders, is 40px
           paddingBlock: `calc(${odysseyTokens.Spacing3} - 1px)`,
           paddingInline: odysseyTokens.Spacing3,
           boxShadow: "none",
@@ -2285,6 +2286,7 @@ export const components = ({
       styleOverrides: {
         select: {
           height: "auto",
+          // We're subtracting a pixel so the total height, including borders, is 40px
           paddingBlock: `calc(${odysseyTokens.Spacing3} - 1px)`,
           paddingInline: odysseyTokens.Spacing3,
           minHeight: 0,

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -1838,8 +1838,8 @@ export const components = ({
           },
         }),
         input: {
-          height: `calc(${odysseyTokens.Spacing7} - (${odysseyTokens.BorderWidthMain} * 2))`,
-          paddingBlock: odysseyTokens.Spacing3,
+          height: "auto",
+          paddingBlock: `calc(${odysseyTokens.Spacing3} - 1px)`,
           paddingInline: odysseyTokens.Spacing3,
           boxShadow: "none",
 
@@ -2284,7 +2284,8 @@ export const components = ({
       },
       styleOverrides: {
         select: {
-          paddingBlock: odysseyTokens.Spacing3,
+          height: "auto",
+          paddingBlock: `calc(${odysseyTokens.Spacing3} - 1px)`,
           paddingInline: odysseyTokens.Spacing3,
           minHeight: 0,
 

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -1840,7 +1840,7 @@ export const components = ({
         input: {
           height: "auto",
           // We're subtracting a pixel so the total height, including borders, is 40px
-          paddingBlock: `calc(${odysseyTokens.Spacing3} - 1px)`,
+          paddingBlock: `calc(${odysseyTokens.Spacing3} - ${odysseyTokens.BorderWidthMain})`,
           paddingInline: odysseyTokens.Spacing3,
           boxShadow: "none",
 
@@ -2287,7 +2287,7 @@ export const components = ({
         select: {
           height: "auto",
           // We're subtracting a pixel so the total height, including borders, is 40px
-          paddingBlock: `calc(${odysseyTokens.Spacing3} - 1px)`,
+          paddingBlock: `calc(${odysseyTokens.Spacing3} - ${odysseyTokens.BorderWidthMain})`,
           paddingInline: odysseyTokens.Spacing3,
           minHeight: 0,
 


### PR DESCRIPTION
There was some unintended text clipping in `NativeSelect` that turned out to be related to the change in how the input heights were calculated. This PR addresses that issue, along with a few related issues that cropped up during the fix:

1. Input height is now implicit. The border-width compensation is now handled by the padding, not the height.
2. Select, NativeSelect, and InputBase are all using the same height measurement
3. The multi-select chips now play nicely with the new height.