### PR TITLE
Truncate long breadcrumbs

### DIFF
--- a/packages/odyssey-react-mui/src/Breadcrumbs.tsx
+++ b/packages/odyssey-react-mui/src/Breadcrumbs.tsx
@@ -30,6 +30,7 @@ import { GroupIcon, HomeIcon, UserIcon } from "./icons.generated";
 import { Subordinate } from "./Typography";
 import { useTranslation } from "react-i18next";
 import { HtmlProps } from "./HtmlProps";
+import styled from "@emotion/styled";
 
 export type BreadcrumbType = "listItem" | "menuItem" | "currentPage";
 
@@ -53,6 +54,13 @@ export const BreadcrumbContext = createContext<BreadcrumbContextType>({
   breadcrumbType: "listItem",
 });
 
+const BreadcrumbContent = styled.span`
+  white-space: nowrap;
+  overflow: hidden;
+  max-width: 10rem;
+  text-overflow: ellipsis;
+`;
+
 export const Breadcrumb = ({ children, href, iconName }: BreadcrumbProps) => {
   const { breadcrumbType } = useContext(BreadcrumbContext);
 
@@ -63,7 +71,7 @@ export const Breadcrumb = ({ children, href, iconName }: BreadcrumbProps) => {
       ) : iconName === "user" ? (
         <UserIcon />
       ) : null}
-      {children}
+      <BreadcrumbContent>{children}</BreadcrumbContent>
     </>
   );
 

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -84,3 +84,29 @@ export const Default: StoryObj<BreadcrumbsProps> = {
     </BreadcrumbList>
   ),
 };
+
+export const Truncation: StoryObj<BreadcrumbsProps> = {
+  args: {
+    homeHref: "#home",
+  },
+  render: (args) => (
+    <BreadcrumbList {...args}>
+      <Breadcrumb href="#one">
+        This is a very long title that should be truncated
+      </Breadcrumb>
+      <Breadcrumb href="#two">Two</Breadcrumb>
+      <Breadcrumb href="#three" iconName="user">
+        This is a very long title with an icon
+      </Breadcrumb>
+      <Breadcrumb href="#four">Four</Breadcrumb>
+      <Breadcrumb href="#five" iconName="group">
+        Five
+      </Breadcrumb>
+      <Breadcrumb href="#six">Six</Breadcrumb>
+      <Breadcrumb href="#seven">Seven</Breadcrumb>
+      <Breadcrumb href="#eight">Eight</Breadcrumb>
+      <Breadcrumb href="#nine">Nine</Breadcrumb>
+      <Breadcrumb href="#ten">Ten</Breadcrumb>
+    </BreadcrumbList>
+  ),
+};


### PR DESCRIPTION
Long titles in `<Breadcrumbs>` looked unwieldy; this PR truncates them automatically at 10rem (a reasonable length). We're using a wrapping element to do this so that the overflow styles don't interfere with the icons or other existing layout.