### PR TITLE
fix: add official support for lists in Callout [OKTA-708136] (take 2)

### DIFF
--- a/packages/odyssey-react-mui/src/Callout.tsx
+++ b/packages/odyssey-react-mui/src/Callout.tsx
@@ -34,7 +34,7 @@ export const calloutSeverityValues = [
 
 export type CalloutProps = {
   /**
-   * @deprecated Callout content shuold be set via title, text, linkText, and linkUrl
+   * Used to optionally pass a text list to the component
    */
   children?: ReactNode;
   /**

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Callout/Callout.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Callout/Callout.stories.tsx
@@ -69,7 +69,7 @@ const storybookMeta: Meta<CalloutProps> = {
     },
     text: {
       control: "text",
-      description: "The text content of the Callout",
+      description: "The content of the Callout",
       table: {
         type: {
           summary: "string",
@@ -142,6 +142,24 @@ export const WithLink: StoryObj<CalloutProps> = {
     text: "There is an issue with the fuel mixture ratios. Reconfigure the fuel mixture and perform the safety checks again.",
     linkText: "Visit fueling console",
     linkUrl: "#",
+  },
+};
+
+export const ChildrenWithList: StoryObj<CalloutProps> = {
+  args: {
+    role: "status",
+    severity: "info",
+    title: "Delivery details needed to complete your user profile",
+    text: undefined,
+    children: (
+      <>
+        <ul>
+          <li>Secondary email</li>
+          <li>Street address</li>
+          <li>City</li>
+        </ul>
+      </>
+    ),
   },
 };
 


### PR DESCRIPTION
[DES-5074](https://oktainc.atlassian.net/browse/DES-5074)
[OKTA-708136](https://oktainc.atlassian.net/browse/OKTA-708136)

## Summary
* This PR updates Storybook documentation for Callout to correctly show that `children` is supported
* Also adds an example in Storybook showing how to add a list
* Matching Supernova and Figma example updates are ready to go pending approval of this PR.

## Testing & Screenshots
![callout-sb](https://github.com/okta/odyssey/assets/147574410/fdcd127f-a685-4785-acd7-3094aa08a5a1)
* [Figma do/don't ](https://www.figma.com/file/FwOHteDCOQHgvtMOU6LrZT/Supernova-graphics-and-templates?type=design&node-id=2477-41071&mode=design&t=42D3r4rvhHIDkylu-4)to be added to Supernova when this PR merges
- [x] I have confirmed this change with my designer and the Odyssey Design Team.


Note: I closed the [previous PR ](https://github.com/okta/odyssey/pull/2171) because of issues with the branch history breaking the build unrelated to this change. 