### PR TITLE
Display empty values in Select

### DIFF
--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -291,6 +291,7 @@ const Select = <
            * set an empty string to `value` in the normalized option so that the select component
            * can potentially set it as the selected one in the text input
            */
+          console.log(option);
           const value =
             option?.value === "" ? option.value : option.value || option.text;
           return {
@@ -433,6 +434,7 @@ const Select = <
           {...inputValues}
           aria-describedby={ariaDescribedBy}
           aria-errormessage={errorMessageElementId}
+          displayEmpty
           id={id}
           inputProps={{ "data-se": testId }}
           inputRef={localInputRef}

--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -291,7 +291,6 @@ const Select = <
            * set an empty string to `value` in the normalized option so that the select component
            * can potentially set it as the selected one in the text input
            */
-          console.log(option);
           const value =
             option?.value === "" ? option.value : option.value || option.text;
           return {


### PR DESCRIPTION
In the `Select` component, if an option had defined text but an empty value, the text wouldn't display when the option was selected.

For example, in a Select with this option:

```
{
  text: "Nothing here",
  value: ""
}
```

if that option were selected, the `Select` would _**not**_ show "Nothing here" as the text... the text would simply be empty.

It turns out this was due to a MUI option being set to `false`. I changed it to `true` and now it works.