### PR TITLE
Change how mui tooltip ref is assigned

### DIFF
--- a/packages/odyssey-react-mui/src/Button.tsx
+++ b/packages/odyssey-react-mui/src/Button.tsx
@@ -164,7 +164,7 @@ const Button = ({
   // We're deprecating the "tertiary" variant, so map it to
   // "secondary" in lieu of making a breaking change
   const variant = variantProp === "tertiary" ? "secondary" : variantProp;
-  const localButtonRef = useRef<HTMLButtonElement | null>(null);
+  const localButtonRef = useRef<HTMLButtonElement>();
   const buttonContext = useButton();
   const isFullWidth = useMemo(
     () =>
@@ -202,9 +202,11 @@ const Button = ({
           id={id}
           onClick={onClick}
           ref={(element) => {
-            localButtonRef.current = element;
-            //@ts-expect-error ref is not an optional prop on the props context type
-            muiProps?.ref?.(element);
+            if (element) {
+              localButtonRef.current = element;
+              //@ts-expect-error ref is not an optional prop on the props context type
+              muiProps?.ref?.(element);
+            }
           }}
           size={size}
           startIcon={startIcon}

--- a/packages/odyssey-react-mui/src/Button.tsx
+++ b/packages/odyssey-react-mui/src/Button.tsx
@@ -164,7 +164,7 @@ const Button = ({
   // We're deprecating the "tertiary" variant, so map it to
   // "secondary" in lieu of making a breaking change
   const variant = variantProp === "tertiary" ? "secondary" : variantProp;
-  const localButtonRef = useRef<HTMLButtonElement>(null);
+  const localButtonRef = useRef<HTMLButtonElement | null>(null);
   const buttonContext = useButton();
   const isFullWidth = useMemo(
     () =>
@@ -186,9 +186,6 @@ const Button = ({
 
   const renderButton = useCallback(
     (muiProps: MuiPropsContextType) => {
-      //@ts-expect-error ref is not an optional prop on the props context type
-      muiProps?.ref?.(localButtonRef.current);
-
       return (
         <MuiButton
           {...muiProps}
@@ -204,7 +201,11 @@ const Button = ({
           fullWidth={isFullWidth}
           id={id}
           onClick={onClick}
-          ref={localButtonRef}
+          ref={(element) => {
+            localButtonRef.current = element;
+            //@ts-expect-error ref is not an optional prop on the props context type
+            muiProps?.ref?.(element);
+          }}
           size={size}
           startIcon={startIcon}
           tabIndex={tabIndex}


### PR DESCRIPTION
fixes bad setState call inside MUI

<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[OKTA-716418](https://oktainc.atlassian.net/browse/OKTA-716418)

## Summary
- Chang how MUI's tooltip ref is assigned to fix bad setState warning.

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
