### PR TITLE
Bump actions/checkout to v4 in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v2

--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: main
       - name: setup node

--- a/.github/workflows/x-browser-vrt.yml
+++ b/.github/workflows/x-browser-vrt.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 3


### PR DESCRIPTION
## Summary

Bumping the version of actions/checkout used here, reference https://github.com/actions/checkout?tab=readme-ov-file#checkout-v4

This will address (part of) the deprecation notices, screenshot from https://github.com/okta/odyssey/actions/runs/8787433325

![image](https://github.com/okta/odyssey/assets/58142236/313d3a2b-67da-4985-bbce-e9ef5b8d946f)


## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
