### PR TITLE
Add hint text to Radio and RadioGroup

### DIFF
--- a/packages/odyssey-react-mui/src/Radio.tsx
+++ b/packages/odyssey-react-mui/src/Radio.tsx
@@ -84,18 +84,18 @@ const Radio = ({
     [],
   );
 
-  const label = useMemo(() => {
-    return (
+  const label = useMemo(
+    () => (
       <>
         <Typography component="span">{labelProp}</Typography>
         {hint && <FormHelperText translate={translate}>{hint}</FormHelperText>}
       </>
-    );
-  }, [labelProp, hint, translate]);
+    ),
+    [labelProp, hint, translate],
+  );
+
   const onChange = useCallback<NonNullable<MuiRadioProps["onChange"]>>(
-    (event, checked) => {
-      onChangeProp?.(event, checked);
-    },
+    (event, checked) => onChangeProp?.(event, checked),
     [onChangeProp],
   );
 

--- a/packages/odyssey-react-mui/src/Radio.tsx
+++ b/packages/odyssey-react-mui/src/Radio.tsx
@@ -13,14 +13,17 @@
 import {
   FormControlLabel,
   FormControlLabelProps as MuiFormControlLabelProps,
+  FormHelperText,
   Radio as MuiRadio,
   RadioProps as MuiRadioProps,
 } from "@mui/material";
-import { memo, useCallback, useRef, useImperativeHandle } from "react";
+import { useTranslation } from "react-i18next";
+import { memo, useCallback, useMemo, useRef, useImperativeHandle } from "react";
 
 import { FieldComponentProps } from "./FieldComponentProps";
 import type { HtmlProps } from "./HtmlProps";
 import { FocusHandle } from "./inputUtils";
+import { Typography } from "./Typography";
 
 export type RadioProps = {
   /**
@@ -51,15 +54,16 @@ export type RadioProps = {
    * Callback fired when the blur event happens. Provides event value.
    */
   onBlur?: MuiFormControlLabelProps["onBlur"];
-} & Pick<FieldComponentProps, "isDisabled" | "name"> &
+} & Pick<FieldComponentProps, "hint" | "id" | "isDisabled" | "name"> &
   Pick<HtmlProps, "testId" | "translate">;
 
 const Radio = ({
+  hint,
   inputRef,
   isChecked,
   isDisabled,
   isInvalid,
-  label,
+  label: labelProp,
   name,
   testId,
   translate,
@@ -67,6 +71,7 @@ const Radio = ({
   onChange: onChangeProp,
   onBlur: onBlurProp,
 }: RadioProps) => {
+  const { t } = useTranslation();
   const localInputRef = useRef<HTMLInputElement>(null);
   useImperativeHandle(
     inputRef,
@@ -80,6 +85,20 @@ const Radio = ({
     [],
   );
 
+  const label = useMemo(() => {
+    return (
+      <>
+        <Typography component="span">{labelProp}</Typography>
+        <>
+          {" "}
+          <Typography component="span" color="textSecondary">
+            ({t("fieldlabel.required.text")})
+          </Typography>
+        </>
+        {hint && <FormHelperText translate={translate}>{hint}</FormHelperText>}
+      </>
+    );
+  }, [labelProp, hint, t, translate]);
   const onChange = useCallback<NonNullable<MuiRadioProps["onChange"]>>(
     (event, checked) => {
       onChangeProp?.(event, checked);

--- a/packages/odyssey-react-mui/src/Radio.tsx
+++ b/packages/odyssey-react-mui/src/Radio.tsx
@@ -17,7 +17,7 @@ import {
   Radio as MuiRadio,
   RadioProps as MuiRadioProps,
 } from "@mui/material";
-import { useTranslation } from "react-i18next";
+
 import { memo, useCallback, useMemo, useRef, useImperativeHandle } from "react";
 
 import { FieldComponentProps } from "./FieldComponentProps";
@@ -71,7 +71,6 @@ const Radio = ({
   onChange: onChangeProp,
   onBlur: onBlurProp,
 }: RadioProps) => {
-  const { t } = useTranslation();
   const localInputRef = useRef<HTMLInputElement>(null);
   useImperativeHandle(
     inputRef,
@@ -92,7 +91,7 @@ const Radio = ({
         {hint && <FormHelperText translate={translate}>{hint}</FormHelperText>}
       </>
     );
-  }, [labelProp, hint, t, translate]);
+  }, [labelProp, hint, translate]);
   const onChange = useCallback<NonNullable<MuiRadioProps["onChange"]>>(
     (event, checked) => {
       onChangeProp?.(event, checked);

--- a/packages/odyssey-react-mui/src/Radio.tsx
+++ b/packages/odyssey-react-mui/src/Radio.tsx
@@ -89,12 +89,6 @@ const Radio = ({
     return (
       <>
         <Typography component="span">{labelProp}</Typography>
-        <>
-          {" "}
-          <Typography component="span" color="textSecondary">
-            ({t("fieldlabel.required.text")})
-          </Typography>
-        </>
         {hint && <FormHelperText translate={translate}>{hint}</FormHelperText>}
       </>
     );

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Radio/Radio.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Radio/Radio.stories.tsx
@@ -133,7 +133,7 @@ export const Hint: StoryObj<typeof Radio> = {
   parameters: {
     docs: {
       description: {
-        story: "hint provides helper text to the Radio",
+        story: "A `hint` provides helper text to the Radio",
       },
     },
   },

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Radio/Radio.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Radio/Radio.stories.tsx
@@ -42,15 +42,6 @@ const storybookMeta: Meta<RadioProps> = {
         },
       },
     },
-    hint: {
-      control: "text",
-      description: "The helper text content",
-      table: {
-        type: {
-          summary: "string",
-        },
-      },
-    },
     label: {
       control: "text",
       description: "The label text for the radio button",
@@ -129,19 +120,7 @@ export const Disabled: StoryObj<typeof Radio> = {
     isDisabled: true,
   },
 };
-export const Hint: StoryObj<typeof Radio> = {
-  parameters: {
-    docs: {
-      description: {
-        story: "hint provides helper text to the Radio",
-      },
-    },
-  },
-  args: {
-    label: "Automatically assign Okta Admin Console",
-    hint: "All admin roles get access when the role is assigned.",
-  },
-};
+
 export const Invalid: StoryObj<typeof Radio> = {
   args: {
     isChecked: true,

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Radio/Radio.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Radio/Radio.stories.tsx
@@ -42,6 +42,15 @@ const storybookMeta: Meta<RadioProps> = {
         },
       },
     },
+    hint: {
+      control: "text",
+      description: "The helper text content",
+      table: {
+        type: {
+          summary: "string",
+        },
+      },
+    },
     label: {
       control: "text",
       description: "The label text for the radio button",
@@ -120,7 +129,19 @@ export const Disabled: StoryObj<typeof Radio> = {
     isDisabled: true,
   },
 };
-
+export const Hint: StoryObj<typeof Radio> = {
+  parameters: {
+    docs: {
+      description: {
+        story: "hint provides helper text to the Radio",
+      },
+    },
+  },
+  args: {
+    label: "Automatically assign Okta Admin Console",
+    hint: "All admin roles get access when the role is assigned.",
+  },
+};
 export const Invalid: StoryObj<typeof Radio> = {
   args: {
     isChecked: true,

--- a/packages/odyssey-storybook/src/components/odyssey-mui/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/RadioGroup/RadioGroup.stories.tsx
@@ -242,7 +242,7 @@ export const ControlledRadioGroupWithRadioHints: StoryObj<typeof RadioGroup> = {
       [],
     );
     return (
-      <RadioGroup {...{ ...props, value, onChange }}>
+      <RadioGroup {...props} onChange={onChange} value={value}>
         <Radio label="Snail Speed" value="Snail Speed" hint="Hint text" />
         <Radio label="Turtle Speed" value="Turtle Speed" hint="Hint text" />
         <Radio label="Rabbit Speed" value="Rabbit Speed" hint="Hint text" />

--- a/packages/odyssey-storybook/src/components/odyssey-mui/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/RadioGroup/RadioGroup.stories.tsx
@@ -223,3 +223,46 @@ export const ControlledRadioGroup: StoryObj<typeof RadioGroup> = {
     });
   },
 };
+
+export const ControlledRadioGroupWithRadioHints: StoryObj<typeof RadioGroup> = {
+  parameters: {
+    docs: {
+      description: {
+        story: "A controlled Radio Group with Radio-level hints.",
+      },
+    },
+  },
+  args: {
+    value: "Ludicrous Speed",
+  },
+  render: function C(props) {
+    const [value, setValue] = useState("Ludicrous Speed");
+    const onChange = useCallback(
+      (_event: ChangeEvent<HTMLInputElement>, value: string) => setValue(value),
+      [],
+    );
+    return (
+      <RadioGroup {...{ ...props, value, onChange }}>
+        <Radio label="Light Speed" value="Light Speed" hint="Hint text" />
+        <Radio label="Warp Speed" value="Warp Speed" hint="Hint text" />
+        <Radio
+          label="Ludicrous Speed"
+          value="Ludicrous Speed"
+          hint="Hint text"
+        />
+      </RadioGroup>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    await step("select uncontrolled radio button", async () => {
+      const canvas = within(canvasElement);
+      const radiogroup = canvas.getByRole("radiogroup") as HTMLInputElement;
+      const radio = canvas.getByLabelText("Warp Speed") as HTMLInputElement;
+      if (radiogroup && radio) {
+        await userEvent.click(radio);
+      }
+      await expect(radio).toBeChecked();
+      await axeRun("select uncontrolled radio button");
+    });
+  },
+};

--- a/packages/odyssey-storybook/src/components/odyssey-mui/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/RadioGroup/RadioGroup.stories.tsx
@@ -243,26 +243,10 @@ export const ControlledRadioGroupWithRadioHints: StoryObj<typeof RadioGroup> = {
     );
     return (
       <RadioGroup {...{ ...props, value, onChange }}>
-        <Radio label="Light Speed" value="Light Speed" hint="Hint text" />
-        <Radio label="Warp Speed" value="Warp Speed" hint="Hint text" />
-        <Radio
-          label="Ludicrous Speed"
-          value="Ludicrous Speed"
-          hint="Hint text"
-        />
+        <Radio label="Snail Speed" value="Snail Speed" hint="Hint text" />
+        <Radio label="Turtle Speed" value="Turtle Speed" hint="Hint text" />
+        <Radio label="Rabbit Speed" value="Rabbit Speed" hint="Hint text" />
       </RadioGroup>
     );
-  },
-  play: async ({ canvasElement, step }) => {
-    await step("select uncontrolled radio button", async () => {
-      const canvas = within(canvasElement);
-      const radiogroup = canvas.getByRole("radiogroup") as HTMLInputElement;
-      const radio = canvas.getByLabelText("Warp Speed") as HTMLInputElement;
-      if (radiogroup && radio) {
-        await userEvent.click(radio);
-      }
-      await expect(radio).toBeChecked();
-      await axeRun("select uncontrolled radio button");
-    });
   },
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/RadioGroup/RadioGroup.stories.tsx
@@ -223,30 +223,3 @@ export const ControlledRadioGroup: StoryObj<typeof RadioGroup> = {
     });
   },
 };
-
-export const ControlledRadioGroupWithRadioHints: StoryObj<typeof RadioGroup> = {
-  parameters: {
-    docs: {
-      description: {
-        story: "A controlled Radio Group with Radio-level hints.",
-      },
-    },
-  },
-  args: {
-    value: "Ludicrous Speed",
-  },
-  render: function C(props) {
-    const [value, setValue] = useState("Ludicrous Speed");
-    const onChange = useCallback(
-      (_event: ChangeEvent<HTMLInputElement>, value: string) => setValue(value),
-      [],
-    );
-    return (
-      <RadioGroup {...{ ...props, value, onChange }}>
-        <Radio label="Snail Speed" value="Snail Speed" hint="Hint text" />
-        <Radio label="Turtle Speed" value="Turtle Speed" hint="Hint text" />
-        <Radio label="Rabbit Speed" value="Rabbit Speed" hint="Hint text" />
-      </RadioGroup>
-    );
-  },
-};

--- a/packages/odyssey-storybook/src/components/odyssey-mui/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/RadioGroup/RadioGroup.stories.tsx
@@ -223,3 +223,30 @@ export const ControlledRadioGroup: StoryObj<typeof RadioGroup> = {
     });
   },
 };
+
+export const ControlledRadioGroupWithRadioHints: StoryObj<typeof RadioGroup> = {
+  parameters: {
+    docs: {
+      description: {
+        story: "A controlled Radio Group with Radio-level hints.",
+      },
+    },
+  },
+  args: {
+    value: "Ludicrous Speed",
+  },
+  render: function C(props) {
+    const [value, setValue] = useState("Ludicrous Speed");
+    const onChange = useCallback(
+      (_event: ChangeEvent<HTMLInputElement>, value: string) => setValue(value),
+      [],
+    );
+    return (
+      <RadioGroup {...{ ...props, value, onChange }}>
+        <Radio label="Snail Speed" value="Snail Speed" hint="Hint text" />
+        <Radio label="Turtle Speed" value="Turtle Speed" hint="Hint text" />
+        <Radio label="Rabbit Speed" value="Rabbit Speed" hint="Hint text" />
+      </RadioGroup>
+    );
+  },
+};


### PR DESCRIPTION
[OKTA-722356](https://oktainc.atlassian.net/browse/OKTA-722356)

## Summary
Adds hint text to `Radio` and `RadioGroup` (storybook). This implementation mirrors our `hint` implementation in `Checkbox`.

I am also updated this in Figma and working with Gretchen on copy updates that will be synced when this merges.


## Testing & Screenshots

- [x] I have confirmed this change with my designer and the Odyssey Design Team.
![CleanShot 2024-04-23 at 17 20 32@2x](https://github.com/okta/odyssey/assets/147574410/bd01e77f-2f57-46fc-819f-dd8ac7b343ca)
![CleanShot 2024-04-23 at 17 21 17@2x](https://github.com/okta/odyssey/assets/147574410/7c27e637-6e5c-4414-8439-14f3d7e4baa5)
