### PR TITLE
OKTA-726384 : feat : Adds functionality to reset password visibility when shown for >=30secs

### DIFF
--- a/packages/odyssey-react-mui/src/PasswordField.tsx
+++ b/packages/odyssey-react-mui/src/PasswordField.tsx
@@ -88,7 +88,7 @@ type FieldRenderProps = Partial<
 > &
   Pick<FieldComponentRenderProps, "id" | "labelElementId">;
 
-export const PASSWORD_VISIBILITY_TIMEOUT = 30000;
+export const PASSWORD_VISIBILITY_TIMEOUT = 30_000;
 
 const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
   (

--- a/packages/odyssey-react-mui/src/PasswordField.tsx
+++ b/packages/odyssey-react-mui/src/PasswordField.tsx
@@ -17,6 +17,7 @@ import {
   forwardRef,
   memo,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useRef,
   useState,
@@ -116,8 +117,25 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
     },
     ref,
   ) => {
+    const TEXT_TYPE_TIMEOUT = 30000;
     const { t } = useTranslation();
     const [inputType, setInputType] = useState("password");
+
+    useEffect(() => {
+      let timeout: NodeJS.Timeout;
+
+      // If current inputType is text (cleartext password),
+      // for security set a 30-second timeout to toggle back to password
+      if (inputType === "text") {
+        timeout = setTimeout(() => {
+          setInputType("password");
+        }, TEXT_TYPE_TIMEOUT);
+      }
+
+      return () => {
+        clearTimeout(timeout);
+      };
+    }, [inputType]);
 
     const togglePasswordVisibility = useCallback(() => {
       setInputType((inputType) =>

--- a/packages/odyssey-react-mui/src/PasswordField.tsx
+++ b/packages/odyssey-react-mui/src/PasswordField.tsx
@@ -88,6 +88,8 @@ type FieldRenderProps = Partial<
 > &
   Pick<FieldComponentRenderProps, "id" | "labelElementId">;
 
+export const PASSWORD_VISIBILITY_TIMEOUT = 30000;
+
 const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
   (
     {
@@ -117,24 +119,21 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
     },
     ref,
   ) => {
-    const TEXT_TYPE_TIMEOUT = 30000;
     const { t } = useTranslation();
     const [inputType, setInputType] = useState("password");
 
     useEffect(() => {
-      let timeout: NodeJS.Timeout;
+      let timeoutId: NodeJS.Timeout;
 
       // If current inputType is text (cleartext password),
       // for security set a 30-second timeout to toggle back to password
       if (inputType === "text") {
-        timeout = setTimeout(() => {
+        timeoutId = setTimeout(() => {
           setInputType("password");
-        }, TEXT_TYPE_TIMEOUT);
+        }, PASSWORD_VISIBILITY_TIMEOUT);
       }
 
-      return () => {
-        clearTimeout(timeout);
-      };
+      return () => clearTimeout(timeoutId);
     }, [inputType]);
 
     const togglePasswordVisibility = useCallback(() => {

--- a/packages/odyssey-react-mui/src/PasswordField.tsx
+++ b/packages/odyssey-react-mui/src/PasswordField.tsx
@@ -88,7 +88,8 @@ type FieldRenderProps = Partial<
 > &
   Pick<FieldComponentRenderProps, "id" | "labelElementId">;
 
-export const PASSWORD_VISIBILITY_TIMEOUT = 30_000;
+// 5 minute timeout
+export const PASSWORD_VISIBILITY_TIMEOUT = 5 * 60 * 1_000;
 
 const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
   (
@@ -126,7 +127,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
       let timeoutId: NodeJS.Timeout;
 
       // If current inputType is text (cleartext password),
-      // for security set a 30-second timeout to toggle back to password
+      // for security set a 5 minute timeout to toggle back to password
       if (inputType === "text") {
         timeoutId = setTimeout(() => {
           setInputType("password");


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[OKTA-726384](https://oktainc.atlassian.net/browse/OKTA-726384)

## Summary

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->
The Sign-In Widget requires that if a user toggles the password visibility (to display the password in plain text) that after 30 seconds the password field should re-display masked characters instead of the plain text password. This was a security feature and has been implemented since Gen 2 of the Sign-In widget. 

Once we migrated Gen 3 to Odyssey v1.x we regressed on this feature and had to disable tests. The purpose of this PR is to introduce the feature into the PasswordField component so the Sign-In Widget can consume it.  

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
