### PR TITLE
fix: expose "filled" variant of search

### DIFF
--- a/packages/odyssey-storybook/src/components/odyssey-mui/SearchField/SearchField.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/SearchField/SearchField.stories.tsx
@@ -11,7 +11,7 @@
  */
 
 import { Meta, StoryObj } from "@storybook/react";
-import { SearchField } from "@okta/odyssey-react-mui";
+import { SearchField, searchVariantValues } from "@okta/odyssey-react-mui";
 
 import { fieldComponentPropsMetaData } from "../../../fieldComponentPropsMetaData";
 import { MuiThemeDecorator } from "../../../../.storybook/components";
@@ -133,6 +133,24 @@ const storybookMeta: Meta<typeof SearchField> = {
         },
       },
     },
+    variant: {
+      options: searchVariantValues,
+      control: { type: "radio" },
+      description: "The color and style of the button",
+      table: {
+        type: {
+          summary: searchVariantValues.join(" | "),
+        },
+        defaultValue: {
+          summary: "outline",
+        },
+      },
+      type: {
+        required: true,
+        name: "other",
+        value: "radio",
+      },
+    },
   },
   args: {
     label: "Search",
@@ -149,7 +167,12 @@ export const Default: StoryObj<typeof SearchField> = {
     defaultValue: "",
   },
 };
-
+export const FilledVariant: StoryObj<typeof SearchField> = {
+  args: {
+    defaultValue: "",
+    variant: "filled",
+  },
+};
 export const Disabled: StoryObj<typeof SearchField> = {
   args: {
     isDisabled: true,


### PR DESCRIPTION
[DES-5625](https://oktainc.atlassian.net/browse/DES-5625)

## Summary

This PR exposes the existing "outline" (gray) variant in the `Search` component. It was likely not exposed previously because it is used for very specific things, but with the upcoming layout updates we will need to offer this to engineers.

## Testing & Screenshots

![filled](https://github.com/okta/odyssey/assets/147574410/2bf9d7b6-40d5-4eb0-a465-7eabc57e24ab)

