### PR TITLE
fix: re-add support for "callToAction" button usage

### DIFF
--- a/packages/odyssey-react-mui/src/Dialog.tsx
+++ b/packages/odyssey-react-mui/src/Dialog.tsx
@@ -31,51 +31,56 @@ import {
 
 import type { HtmlProps } from "./HtmlProps";
 
-// Mutually exclusive types for the action buttons
-type NewActionProps = {
-  primaryCallToActionComponent?: ReactElement<typeof Button>;
-  secondaryCallToActionComponent?: ReactElement<typeof Button>;
-  tertiaryCallToActionComponent?: ReactElement<typeof Button>;
-  callToActionFirstComponent?: never;
-  callToActionSecondComponent?: never;
-  callToActionLastComponent?: never;
-};
-
-type DeprecatedActionProps = {
-  primaryCallToActionComponent?: never;
-  secondaryCallToActionComponent?: never;
-  tertiaryCallToActionComponent?: never;
-  /** @deprecated Will be removed in a future Odyssey version. Use `PrimaryCallToActionComponent` instead. */
-  callToActionFirstComponent?: ReactElement<typeof Button>;
-  /** @deprecated Will be removed in a future Odyssey version. Use `SecondryCallToActionComponent` instead. */
-  callToActionSecondComponent?: ReactElement<typeof Button>;
-  /** @deprecated Will be removed in a future Odyssey version. Use `TertiaryCallToActionComponent` instead. */
-  callToActionLastComponent?: ReactElement<typeof Button>;
-};
-
 export type DialogProps = {
   /**
    * @deprecated `aria-label` for close button comes from translation file
    */
   ariaLabel?: string;
+
+  /**
+   * An optional Button object to be situated in the Dialog footer as the primary call to action.
+   */
+  primaryCallToActionComponent?: ReactElement<typeof Button>;
+  /**
+   * @deprecated Will be removed in a future Odyssey version. Use `primaryCallToActionComponent` instead.
+   */
+  callToActionFirstComponent?: ReactElement<typeof Button>;
+  /**
+   * An optional Button object to be situated in the Dialog footer as the secondary call to action, alongside the `primaryCallToActionComponent`.
+   */
+  secondaryCallToActionComponent?: ReactElement<typeof Button>;
+  /**
+   * @deprecated Will be removed in a future Odyssey version. Use `secondaryCallToActionComponent` instead.
+   */
+  callToActionSecondComponent?: ReactElement<typeof Button>;
+  /**
+   * An optional Button object to be situated in the Dialog footer as the tertiary call to action, alongside the other `callToAction` components.
+   */
+  tertiaryCallToActionComponent?: ReactElement<typeof Button>;
+  /**
+   * @deprecated Will be removed in a future Odyssey version. Use `tertiaryCallToActionComponent` instead.
+   */
+  callToActionLastComponent?: ReactElement<typeof Button>;
   /**
    * The content of the Dialog. May be a `string` or any other `ReactNode` or array of `ReactNode`s.
    */
   children: ReactNode;
+
   /**
    * When set to `true`, the Dialog will be visible.
    */
   isOpen: boolean;
+
   /**
-   * Callback that controls what happens when the Dialog is dismissed
+   * Callback that controls what happens when the Dialog is dismissed.
    */
   onClose: () => void;
+
   /**
-   * The title of the Dialog
+   * The title of the Dialog.
    */
   title: string;
-} & Pick<HtmlProps, "testId" | "translate"> &
-  (NewActionProps | DeprecatedActionProps);
+} & Pick<HtmlProps, "testId" | "translate">;
 
 const Dialog = ({
   primaryCallToActionComponent,
@@ -124,7 +129,7 @@ const Dialog = ({
     ) : (
       children
     );
-  //Ensure new action button format is prioritized (uses || as a fallback)
+  //Prioritize new action button format (|| used as a fallback)
   const actionButtons = [
     tertiaryCallToActionComponent || callToActionLastComponent,
     secondaryCallToActionComponent || callToActionSecondComponent,
@@ -145,7 +150,7 @@ const Dialog = ({
       </DialogTitle>
       <DialogContent
         {...(isContentScrollable && {
-          //Sets tabIndex on content element if scrollable so content is easier to navigate with the keyboard
+          // Sets tabIndex on content element if scrollable so content is easier to navigate with the keyboard
           tabIndex: 0,
         })}
         dividers={isContentScrollable}

--- a/packages/odyssey-react-mui/src/Dialog.tsx
+++ b/packages/odyssey-react-mui/src/Dialog.tsx
@@ -31,30 +31,33 @@ import {
 
 import type { HtmlProps } from "./HtmlProps";
 
+// Mutually exclusive types for the action buttons
+type NewActionProps = {
+  primaryCallToActionComponent?: ReactElement<typeof Button>;
+  secondaryCallToActionComponent?: ReactElement<typeof Button>;
+  tertiaryCallToActionComponent?: ReactElement<typeof Button>;
+  callToActionFirstComponent?: never;
+  callToActionSecondComponent?: never;
+  callToActionLastComponent?: never;
+};
+
+type DeprecatedActionProps = {
+  primaryCallToActionComponent?: never;
+  secondaryCallToActionComponent?: never;
+  tertiaryCallToActionComponent?: never;
+  /** @deprecated Will be removed in a future Odyssey version. Use `PrimaryCallToActionComponent` instead. */
+  callToActionFirstComponent?: ReactElement<typeof Button>;
+  /** @deprecated Will be removed in a future Odyssey version. Use `SecondryCallToActionComponent` instead. */
+  callToActionSecondComponent?: ReactElement<typeof Button>;
+  /** @deprecated Will be removed in a future Odyssey version. Use `TertiaryCallToActionComponent` instead. */
+  callToActionLastComponent?: ReactElement<typeof Button>;
+};
+
 export type DialogProps = {
   /**
    * @deprecated `aria-label` for close button comes from translation file
    */
   ariaLabel?: string;
-  /**
-   * An optional Button object to be situated in the Dialog footer. Should almost always be of variant `primary`.
-   */
-  primaryCallToActionComponent?: ReactElement<typeof Button>;
-  /** @deprecated Will be removed in a future Odyssey version. Use `primaryCallToActionComponent` instead. */
-  callToActionFirstComponent?: ReactElement<typeof Button>;
-  /**
-   * An optional Button object to be situated in the Dialog footer, alongside the `callToActionPrimaryComponent`.
-   */
-  secondaryCallToActionComponent?: ReactElement<typeof Button>;
-  /** @deprecated Will be removed in a future Odyssey version. Use `secondaryCallToActionComponent` instead. */
-  callToActionSecondComponent?: ReactElement<typeof Button>;
-
-  /**
-   * An optional Button object to be situated in the Dialog footer, alongside the other two `callToAction` components.
-   */
-  tertiaryCallToActionComponent?: ReactElement<typeof Button>;
-  /** @deprecated Will be removed in a future Odyssey version. Use `tertiaryCallToActionComponent` instead. */
-  callToActionLastComponent?: ReactElement<typeof Button>;
   /**
    * The content of the Dialog. May be a `string` or any other `ReactNode` or array of `ReactNode`s.
    */
@@ -71,7 +74,8 @@ export type DialogProps = {
    * The title of the Dialog
    */
   title: string;
-} & Pick<HtmlProps, "testId" | "translate">;
+} & Pick<HtmlProps, "testId" | "translate"> &
+  (NewActionProps | DeprecatedActionProps);
 
 const Dialog = ({
   primaryCallToActionComponent,

--- a/packages/odyssey-react-mui/src/Dialog.tsx
+++ b/packages/odyssey-react-mui/src/Dialog.tsx
@@ -124,7 +124,7 @@ const Dialog = ({
     ) : (
       children
     );
-
+  //Ensure new action button format is prioritized (uses || as a fallback)
   const actionButtons = [
     tertiaryCallToActionComponent || callToActionLastComponent,
     secondaryCallToActionComponent || callToActionSecondComponent,

--- a/packages/odyssey-react-mui/src/Dialog.tsx
+++ b/packages/odyssey-react-mui/src/Dialog.tsx
@@ -40,14 +40,21 @@ export type DialogProps = {
    * An optional Button object to be situated in the Dialog footer. Should almost always be of variant `primary`.
    */
   primaryCallToActionComponent?: ReactElement<typeof Button>;
+  /** @deprecated Will be removed in a future Odyssey version. Use `primaryCallToActionComponent` instead. */
+  callToActionFirstComponent?: ReactElement<typeof Button>;
   /**
    * An optional Button object to be situated in the Dialog footer, alongside the `callToActionPrimaryComponent`.
    */
   secondaryCallToActionComponent?: ReactElement<typeof Button>;
+  /** @deprecated Will be removed in a future Odyssey version. Use `secondaryCallToActionComponent` instead. */
+  callToActionSecondComponent?: ReactElement<typeof Button>;
+
   /**
    * An optional Button object to be situated in the Dialog footer, alongside the other two `callToAction` components.
    */
   tertiaryCallToActionComponent?: ReactElement<typeof Button>;
+  /** @deprecated Will be removed in a future Odyssey version. Use `tertiaryCallToActionComponent` instead. */
+  callToActionLastComponent?: ReactElement<typeof Button>;
   /**
    * The content of the Dialog. May be a `string` or any other `ReactNode` or array of `ReactNode`s.
    */
@@ -70,6 +77,9 @@ const Dialog = ({
   primaryCallToActionComponent,
   secondaryCallToActionComponent,
   tertiaryCallToActionComponent,
+  callToActionFirstComponent,
+  callToActionSecondComponent,
+  callToActionLastComponent,
   children,
   isOpen,
   onClose,
@@ -111,6 +121,12 @@ const Dialog = ({
       children
     );
 
+  const actionButtons = [
+    tertiaryCallToActionComponent || callToActionLastComponent,
+    secondaryCallToActionComponent || callToActionSecondComponent,
+    primaryCallToActionComponent || callToActionFirstComponent,
+  ].filter(Boolean);
+
   return (
     <MuiDialog data-se={testId} open={isOpen} onClose={onClose}>
       <DialogTitle translate={translate}>
@@ -134,14 +150,8 @@ const Dialog = ({
         {content}
       </DialogContent>
 
-      {(primaryCallToActionComponent ||
-        secondaryCallToActionComponent ||
-        tertiaryCallToActionComponent) && (
-        <DialogActions>
-          {tertiaryCallToActionComponent}
-          {secondaryCallToActionComponent}
-          {primaryCallToActionComponent}
-        </DialogActions>
+      {actionButtons.length > 0 && (
+        <DialogActions>{actionButtons}</DialogActions>
       )}
     </MuiDialog>
   );

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Dialog/Dialog.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Dialog/Dialog.stories.tsx
@@ -20,10 +20,10 @@ import {
 import { useCallback, useState } from "react";
 import { userEvent, within, screen } from "@storybook/testing-library";
 import type { PlaywrightProps } from "../storybookTypes";
-
 import { MuiThemeDecorator } from "../../../../.storybook/components";
 
-const storybookMeta: Meta<DialogProps> = {
+// Explicitly type the Meta object
+const storybookMeta: Meta<typeof Dialog> = {
   title: "MUI Components/Dialog",
   component: Dialog,
   argTypes: {
@@ -31,41 +31,25 @@ const storybookMeta: Meta<DialogProps> = {
       control: null,
       description:
         "An optional Button object to be situated in the Dialog footer. Should almost always be of variant `primary`.",
-      table: {
-        type: {
-          summary: "<Button />",
-        },
-      },
+      table: { type: { summary: "<Button />" } },
     },
     secondaryCallToActionComponent: {
       control: null,
       description:
         "An optional Button object to be situated in the Dialog footer, alongside the `callToActionPrimaryComponent`.",
-      table: {
-        type: {
-          summary: "<Button />",
-        },
-      },
+      table: { type: { summary: "<Button />" } },
     },
     tertiaryCallToActionComponent: {
       control: null,
       description:
         "An optional Button object to be situated in the Dialog footer, alongside the other two `callToAction` components.",
-      table: {
-        type: {
-          summary: "<Button />",
-        },
-      },
+      table: { type: { summary: "<Button />" } },
     },
     children: {
       control: "text",
       description:
         "The content of the Dialog. May be a `string` or any other `ReactNode` or array of `ReactNode`s.",
-      table: {
-        type: {
-          summary: "ReactNode | Array<ReactNode>",
-        },
-      },
+      table: { type: { summary: "ReactNode | Array<ReactNode>" } },
       type: {
         required: true,
         name: "other",
@@ -75,37 +59,19 @@ const storybookMeta: Meta<DialogProps> = {
     isOpen: {
       control: "boolean",
       description: "When set to `true`, the Dialog will be visible.",
-      table: {
-        type: {
-          summary: "boolean",
-        },
-      },
-      type: {
-        required: true,
-        name: "boolean",
-      },
+      table: { type: { summary: "boolean" } },
+      type: { required: true, name: "boolean" },
     },
     onClose: {
       control: "function",
       description:
         "Callback that controls what happens when the dialog is dismissed",
-      table: {
-        type: {
-          summary: "func",
-        },
-      },
+      table: { type: { summary: "func" } },
     },
     title: {
       control: "text",
-      table: {
-        type: {
-          summary: "string",
-        },
-      },
-      type: {
-        required: true,
-        name: "string",
-      },
+      table: { type: { summary: "string" } },
+      type: { required: true, name: "string" },
     },
   },
   args: {

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Dialog/Dialog.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Dialog/Dialog.stories.tsx
@@ -132,7 +132,7 @@ const findDialogElement = async ({
 };
 
 const DefaultTemplate: StoryObj<DialogProps> = {
-  render: function C(props) {
+  render: function C(props: DialogProps) {
     const [isVisible, setIsVisible] = useState(false);
 
     const onOpen = useCallback(() => {
@@ -180,7 +180,7 @@ export const Default: StoryObj<DialogProps> = {
       "You are initiating this ship's self-destruct protocol. This ship, and its occupants, will be destroyed.",
     title: "Initiate self-destruct protocol",
   },
-  play: async ({ canvasElement, step }) => {
+  play: async ({ canvasElement, step }: PlaywrightProps<DialogProps>) => {
     await findDialogElement({ canvasElement, step });
   },
 };
@@ -337,13 +337,13 @@ export const Long: StoryObj<DialogProps> = {
     ),
     title: "Cryosleep liability waiver",
   },
-  play: async ({ canvasElement, step }) => {
+  play: async ({ canvasElement, step }: PlaywrightProps<DialogProps>) => {
     await findDialogElement({ canvasElement, step });
   },
 };
 
 export const NoButtons: StoryObj<DialogProps> = {
-  render: function C(props) {
+  render: function C(props: DialogProps) {
     const [isVisible, setIsVisible] = useState(false);
 
     const onOpen = useCallback(() => {
@@ -366,7 +366,7 @@ export const NoButtons: StoryObj<DialogProps> = {
       "By closing this Dialog you agree to adhere to the Ceres Station terms of use.",
     title: "Ceres Station docking terms",
   },
-  play: async ({ canvasElement, step }) => {
+  play: async ({ canvasElement, step }: PlaywrightProps<DialogProps>) => {
     await findDialogElement({ canvasElement, step });
   },
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Dialog/Dialog.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Dialog/Dialog.stories.tsx
@@ -113,7 +113,9 @@ const DefaultTemplate: StoryObj<DialogProps> = {
       <>
         <Button label="Open dialog" onClick={onOpen} variant="primary" />
         <Dialog
-          {...props}
+          isOpen={isVisible}
+          onClose={onClose}
+          title={props.title}
           primaryCallToActionComponent={
             <Button
               label="Primary action"
@@ -131,9 +133,9 @@ const DefaultTemplate: StoryObj<DialogProps> = {
           tertiaryCallToActionComponent={
             <Button label="Cancel" onClick={onClose} variant="floating" />
           }
-          onClose={onClose}
-          isOpen={isVisible}
-        />
+        >
+          {props.children}
+        </Dialog>
       </>
     );
   },

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Dialog/Dialog.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Dialog/Dialog.stories.tsx
@@ -113,9 +113,7 @@ const DefaultTemplate: StoryObj<DialogProps> = {
       <>
         <Button label="Open dialog" onClick={onOpen} variant="primary" />
         <Dialog
-          isOpen={isVisible}
-          onClose={onClose}
-          title={props.title}
+          {...props}
           primaryCallToActionComponent={
             <Button
               label="Primary action"
@@ -133,9 +131,9 @@ const DefaultTemplate: StoryObj<DialogProps> = {
           tertiaryCallToActionComponent={
             <Button label="Cancel" onClick={onClose} variant="floating" />
           }
-        >
-          {props.children}
-        </Dialog>
+          onClose={onClose}
+          isOpen={isVisible}
+        />
       </>
     );
   },


### PR DESCRIPTION
[OKTA-728883](https://oktainc.atlassian.net/browse/OKTA-728883)

## Summary
Resolves breaking change by adding support back in for 
` callToActionFirstComponent,
  callToActionSecondComponent,
  callToActionLastComponent`

Changes also include a deprecation warning for these props in favor of ` primaryCallToActionComponent,
  secondaryCallToActionComponent,
  tertiaryCallToActionComponent,`
