### PR TITLE
Add href prop and "Floating Action" variant to button

### DIFF
--- a/packages/odyssey-react-mui/src/Button.tsx
+++ b/packages/odyssey-react-mui/src/Button.tsx
@@ -40,6 +40,7 @@ export const buttonVariantValues = [
   "danger",
   "dangerSecondary",
   "floating",
+  "floatingAction",
 ] as const;
 
 export type ButtonProps = {

--- a/packages/odyssey-react-mui/src/Button.tsx
+++ b/packages/odyssey-react-mui/src/Button.tsx
@@ -61,10 +61,6 @@ export type ButtonProps = {
    */
   isFullWidth?: boolean;
   /**
-   * The click event handler for the Button
-   */
-  onClick?: MuiButtonProps["onClick"];
-  /**
    * The size of the button
    */
   size?: (typeof buttonSizeValues)[number];
@@ -81,6 +77,14 @@ export type ButtonProps = {
    * The variant of the Button
    */
   variant: (typeof buttonVariantValues)[number] | "tertiary";
+  /**
+   * Optional href to render the button as a link
+   */
+  href?: string;
+  /**
+   * The click event handler for the Button
+   */
+  onClick?: MuiButtonProps["onClick"];
 } & (
   | {
       /**
@@ -147,6 +151,7 @@ const Button = ({
   ariaLabelledBy,
   buttonRef,
   endIcon,
+  href,
   id,
   isDisabled,
   isFullWidth: isFullWidthProp,
@@ -166,7 +171,7 @@ const Button = ({
   // We're deprecating the "tertiary" variant, so map it to
   // "secondary" in lieu of making a breaking change
   const variant = variantProp === "tertiary" ? "secondary" : variantProp;
-  const localButtonRef = useRef<HTMLButtonElement>();
+  const localButtonRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null);
   const buttonContext = useButton();
   const isFullWidth = useMemo(
     () =>
@@ -176,13 +181,11 @@ const Button = ({
 
   useImperativeHandle(
     buttonRef,
-    () => {
-      return {
-        focus: () => {
-          localButtonRef.current?.focus();
-        },
-      };
-    },
+    () => ({
+      focus: () => {
+        localButtonRef.current?.focus();
+      },
+    }),
     [],
   );
 
@@ -201,11 +204,16 @@ const Button = ({
           disabled={isDisabled}
           endIcon={endIcon}
           fullWidth={isFullWidth}
+          href={href}
           id={id}
           onClick={onClick}
           ref={(element) => {
             if (element) {
-              localButtonRef.current = element;
+              (
+                localButtonRef as React.MutableRefObject<
+                  HTMLButtonElement | HTMLAnchorElement
+                >
+              ).current = element;
               //@ts-expect-error ref is not an optional prop on the props context type
               muiProps?.ref?.(element);
             }
@@ -229,6 +237,7 @@ const Button = ({
       ariaLabel,
       ariaLabelledBy,
       endIcon,
+      href,
       id,
       isDisabled,
       isFullWidth,

--- a/packages/odyssey-react-mui/src/Button.tsx
+++ b/packages/odyssey-react-mui/src/Button.tsx
@@ -49,6 +49,10 @@ export type ButtonProps = {
    */
   buttonRef?: React.RefObject<FocusHandle>;
   /**
+   * Optional href to render the button as a link
+   */
+  href?: string;
+  /**
    * The ID of the Button
    */
   id?: string;
@@ -77,10 +81,6 @@ export type ButtonProps = {
    * The variant of the Button
    */
   variant: (typeof buttonVariantValues)[number] | "tertiary";
-  /**
-   * Optional href to render the button as a link
-   */
-  href?: string;
   /**
    * The click event handler for the Button
    */

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -686,6 +686,23 @@ export const components = ({
               color: odysseyTokens.TypographyColorDisabled,
             },
           }),
+          ...(ownerState.variant === "floatingAction" && {
+            backgroundColor: "transparent",
+            color: odysseyTokens.TypographyColorAction,
+
+            "&:hover": {
+              backgroundColor: odysseyTokens.HueNeutral100,
+            },
+
+            "&:active": {
+              backgroundColor: odysseyTokens.HueNeutral200,
+            },
+
+            "&:disabled": {
+              backgroundColor: "transparent",
+              color: odysseyTokens.TypographyColorDisabled,
+            },
+          }),
           ...(ownerState.size === "small" && {
             height: odysseyTokens.Spacing6,
             paddingBlock: odysseyTokens.Spacing2,

--- a/packages/odyssey-react-mui/src/theme/components.types.ts
+++ b/packages/odyssey-react-mui/src/theme/components.types.ts
@@ -25,15 +25,16 @@ declare module "@mui/material/Alert" {
 
 declare module "@mui/material/Button" {
   interface ButtonPropsVariantOverrides {
-    floating: true;
-    primary: true;
-    secondary: true;
+    contained: false;
     danger: true;
     dangerSecondary: true;
+    floating: true;
+    floatingAction: true;
+    outlined: false;
+    primary: true;
+    secondary: true;
     tertiary: true;
     text: false;
-    contained: false;
-    outlined: false;
   }
   interface ButtonPropsColorOverrides {
     inherit: false;

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
@@ -292,7 +292,20 @@ export const ButtonFloating: StoryObj<ButtonProps> = {
     });
   },
 };
-
+export const ButtonFloatingAction: StoryObj<ButtonProps> = {
+  name: "Floating Action",
+  args: {
+    label: "Add crew",
+    variant: "floatingAction",
+  },
+  play: async ({ args, canvasElement, step }: playType) => {
+    await interactWithButton({ canvasElement, step })({
+      args,
+      actionName: "Button Floating Action",
+      hoverState: false,
+    });
+  },
+};
 export const ButtonFloatingDisabled: StoryObj<ButtonProps> = {
   name: "Floating, Disabled",
   args: {
@@ -406,6 +419,7 @@ export const KitchenSink: StoryObj<ButtonProps> = {
       <Button label="Danger Secondary" variant="dangerSecondary" />
       <Button label="Danger" variant="danger" />
       <Button label="Floating" variant="floating" />
+      <Button label="Floating Action" variant="floatingAction" />
       <Button ariaLabel="Add" startIcon={<AddIcon />} variant="primary" />
     </Box>
   ),

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
@@ -328,15 +328,8 @@ export const ButtonSecondaryAsLink: StoryObj<ButtonProps> = {
   args: {
     label: "Visit okta.com",
     variant: "floatingAction",
-    href: "http://okta.com",
+    href: "https://okta.com",
     onClick: undefined,
-  },
-  play: async ({ args, canvasElement, step }: playType) => {
-    await interactWithButton({ canvasElement, step })({
-      args,
-      actionName: "Button Secondary with Link",
-      hoverState: false,
-    });
   },
 };
 export const ButtonSmall: StoryObj<ButtonProps> = {

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
@@ -51,6 +51,15 @@ const storybookMeta: Meta<ButtonProps> = {
         },
       },
     },
+    href: {
+      control: "text",
+      description: "Optional href to render the button as a link",
+      table: {
+        type: {
+          summary: "string",
+        },
+      },
+    },
     id: {
       control: null,
       description: "An optional ID for the button",
@@ -314,7 +323,22 @@ export const ButtonFloatingDisabled: StoryObj<ButtonProps> = {
     variant: "floating",
   },
 };
-
+export const ButtonSecondaryAsLink: StoryObj<ButtonProps> = {
+  name: "Button as a link",
+  args: {
+    label: "Visit okta.com",
+    variant: "floatingAction",
+    href: "http://okta.com",
+    onClick: undefined,
+  },
+  play: async ({ args, canvasElement, step }: playType) => {
+    await interactWithButton({ canvasElement, step })({
+      args,
+      actionName: "Button Secondary with Link",
+      hoverState: false,
+    });
+  },
+};
 export const ButtonSmall: StoryObj<ButtonProps> = {
   name: "Small",
   args: {


### PR DESCRIPTION
[OKTA-729832](https://oktainc.atlassian.net/browse/OKTA-729832)

## Summary

-  Adds `href` prop to `Button` to enable consumers to optionally render `Button` as a link
-  Adds new `floatingAction` variant (existing floating button style but with blue text)

### Notes
- `href` can be applied to any button style that needs to be rendered as a link (i.e., takes a user to a new URL)
- `href` and `onClick` can _technically_ both be passed into `Button` at the same time. If this happens, the element renders as and behaves like a link. I went back and forth on whether to show a warning but concluded there may be valid use cases like if the onClick was used for additional functionality, like link tracking.
- There isn't currently a `target` prop because I didn't want to add more stuff to the API not knowing if people would need it. I am happy to discuss if you think this should be added (would also be easy add later if requested someone).

## Testing & Screenshots

- [x] I have confirmed this change with my designer and the Odyssey Design Team. The `floatingAction` is currently published in Figma

![button-ask-link-floating-blue](https://github.com/okta/odyssey/assets/147574410/961b565e-e25f-44cd-99e8-e560b2c6e33a)
