### PR TITLE
Rename "Tile" to "Card"

### DIFF
--- a/packages/odyssey-react-mui/src/Card.tsx
+++ b/packages/odyssey-react-mui/src/Card.tsx
@@ -10,8 +10,13 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { MouseEventHandler, ReactElement, memo, useMemo } from "react";
-
+import {
+  MouseEventHandler,
+  ReactElement,
+  memo,
+  useMemo,
+  useEffect,
+} from "react";
 import {
   Card as MuiCard,
   CardActions as MuiCardActions,
@@ -29,44 +34,22 @@ import {
 } from "./OdysseyDesignTokensContext";
 import { Heading5, Paragraph, Support } from "./Typography";
 
-export const TILE_IMAGE_HEIGHT = "64px";
+export const CARD_IMAGE_HEIGHT = "64px";
 
-export type TileProps = {
-  /**
-   * The body text of the tile. The consumer is responsible for truncating this string.
-   */
+export type CardProps = {
   description?: string;
-  /**
-   * An optional image or icon at the top of the tile, preferably as an <img> or <svg> element.
-   */
-  image?: ReactElement; // Icon or image
-  /**
-   * The "eyebrow" text above the tile title.
-   */
+  image?: ReactElement;
   overline?: string;
-  /**
-   * The heading of the tile.
-   */
   title?: string;
-} & ( // You can't have actions and onClick at the same time
+} & (
   | {
-      /**
-       * The event handler for when the user clicks the tile.
-       */
       onClick: MouseEventHandler;
       button?: never;
       menuButtonChildren?: never;
     }
   | {
       onClick?: never;
-      /**
-       * The main action button for the tile. Not valid if the tile itself is clickable.
-       */
       button?: ReactElement<typeof Button>;
-      /**
-       * Menu items to be rendered in the tile's optional menu button. If this prop is undefined, the
-       * menu button will not be shown. Not valid if the tile itself is clickable.
-       */
       menuButtonChildren?: MenuButtonProps["children"];
     }
 );
@@ -80,7 +63,7 @@ const ImageContainer = styled("div", {
 }>(({ odysseyDesignTokens, hasMenuButtonChildren }) => ({
   display: "flex",
   alignItems: "flex-start",
-  maxHeight: `${TILE_IMAGE_HEIGHT}`,
+  maxHeight: `${CARD_IMAGE_HEIGHT}`,
   marginBlockEnd: odysseyDesignTokens.Spacing5,
   paddingRight: hasMenuButtonChildren ? odysseyDesignTokens.Spacing5 : 0,
 }));
@@ -95,7 +78,7 @@ const MenuButtonContainer = styled("div", {
 
 const buttonProviderValue = { isFullWidth: true };
 
-const Tile = ({
+const Card = ({
   button,
   description,
   image,
@@ -103,7 +86,7 @@ const Tile = ({
   onClick,
   overline,
   title,
-}: TileProps) => {
+}: CardProps) => {
   const odysseyDesignTokens = useOdysseyDesignTokens();
 
   const cardContent = useMemo(
@@ -156,7 +139,7 @@ const Tile = ({
         <MenuButtonContainer odysseyDesignTokens={odysseyDesignTokens}>
           <MenuButton
             endIcon={<MoreIcon />}
-            ariaLabel="Tile menu"
+            ariaLabel="Card menu"
             buttonVariant="floating"
             menuAlignment="right"
             size="small"
@@ -170,7 +153,19 @@ const Tile = ({
   );
 };
 
-const MemoizedTile = memo(Tile);
-MemoizedTile.displayName = "Tile";
+const MemoizedCard = memo(Card);
+MemoizedCard.displayName = "Card";
 
-export { MemoizedTile as Tile };
+const Tile = (props: CardProps) => {
+  useEffect(() => {
+    console.warn(
+      "Warning: The 'Tile' component is now called 'Card'. Please update your references as 'Tile' will be deprecated soon.",
+    );
+  }, []);
+
+  return <MemoizedCard {...props} />;
+};
+
+Tile.displayName = "Tile";
+
+export { MemoizedCard as Card, Tile };

--- a/packages/odyssey-react-mui/src/Card.tsx
+++ b/packages/odyssey-react-mui/src/Card.tsx
@@ -156,6 +156,9 @@ const Card = ({
 const MemoizedCard = memo(Card);
 MemoizedCard.displayName = "Card";
 
+/**
+ * @deprecated The 'Tile' component is now called 'Card'. Please update your references as 'Tile' will be deprecated soon.
+ */
 const Tile = (props: CardProps) => {
   useEffect(() => {
     console.warn(

--- a/packages/odyssey-react-mui/src/Card.tsx
+++ b/packages/odyssey-react-mui/src/Card.tsx
@@ -169,6 +169,7 @@ const Tile = (props: CardProps) => {
   return <MemoizedCard {...props} />;
 };
 
-Tile.displayName = "Tile";
+const MemoizedTile = memo(Tile);
+MemoizedTile.displayName = "Tile";
 
-export { MemoizedCard as Card, Tile };
+export { MemoizedCard as Card, MemoizedTile as Tile };

--- a/packages/odyssey-react-mui/src/index.ts
+++ b/packages/odyssey-react-mui/src/index.ts
@@ -63,7 +63,7 @@ export * from "./Banner";
 export * from "./Box";
 export * from "./Breadcrumbs";
 export * from "./Button";
-export * from "./Tile";
+export * from "./Card";
 export * from "./Callout";
 export * from "./Checkbox";
 export * from "./CheckboxGroup";

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -37,7 +37,7 @@ import { tableCellClasses } from "@mui/material/TableCell";
 import { tooltipClasses } from "@mui/material/Tooltip";
 import { typographyClasses } from "@mui/material/Typography";
 
-import { TILE_IMAGE_HEIGHT } from "../Tile";
+import { CARD_IMAGE_HEIGHT } from "../Card";
 
 import {
   CheckCircleFilledIcon,
@@ -783,7 +783,7 @@ export const components = ({
           transition: `all ${odysseyTokens.TransitionDurationMain} ${odysseyTokens.TransitionTimingMain}`,
 
           "& img": {
-            height: TILE_IMAGE_HEIGHT,
+            height: CARD_IMAGE_HEIGHT,
           },
 
           "&.isClickable:hover": {

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Card/Card.mdx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Card/Card.mdx
@@ -9,7 +9,7 @@ import {
   Stories,
 } from "@storybook/addon-docs";
 import { Story } from "@storybook/blocks";
-import * as TileStories from "./Tile.stories";
+import * as TileStories from "./Card.stories";
 
 <Meta of={TileStories} />
 
@@ -18,7 +18,7 @@ import * as TileStories from "./Tile.stories";
 <Description of={TileStories} />
 <Primary of={TileStories} />
 
-`<Tile>` can either be clickable (via the `onClick` prop), or can include a button and/or menu (via the `button` and `menuItems` props).
+`<Card>` can either be clickable (via the `onClick` prop), or can include a button and/or menu (via the `button` and `menuItems` props).
 
 <Controls />
 <Stories />

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Card/Card.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Card/Card.stories.tsx
@@ -26,7 +26,7 @@ const storybookMeta: Meta<CardProps> = {
   argTypes: {
     title: {
       control: "text",
-      description: "The heading of the Card.",
+      description: "The heading of the card.",
       table: {
         type: {
           summary: "string",
@@ -37,7 +37,7 @@ const storybookMeta: Meta<CardProps> = {
     description: {
       control: "text",
       description:
-        "The body text of the Card. The consumer is responsible for truncating this string.",
+        "The body text of the card. The consumer is responsible for truncating this string.",
       table: {
         type: {
           summary: "string",
@@ -47,7 +47,7 @@ const storybookMeta: Meta<CardProps> = {
     },
     overline: {
       control: "text",
-      description: 'The "eyebrow" text above the Card title.',
+      description: 'The "eyebrow" text above the card title.',
       table: {
         type: {
           summary: "string",
@@ -58,7 +58,7 @@ const storybookMeta: Meta<CardProps> = {
     image: {
       control: null,
       description:
-        "An optional image or icon at the top of the Card, preferably as an img or svg element.",
+        "An optional image or icon at the top of the card, preferably as an img or svg element.",
       table: {
         type: {
           summary: "ReactElement",
@@ -68,7 +68,7 @@ const storybookMeta: Meta<CardProps> = {
     },
     onClick: {
       control: null,
-      description: "The event handler for when the user clicks the Card.",
+      description: "The event handler for when the user clicks the card.",
       table: {
         type: {
           summary: "MouseEventHandler",
@@ -79,7 +79,7 @@ const storybookMeta: Meta<CardProps> = {
     button: {
       control: null,
       description:
-        "The main action button for the Card. Not valid if the Card itself is clickable.",
+        "The main action button for the card. Not valid if the card itself is clickable.",
       table: {
         type: {
           summary: "ReactElement<typeof Button>",
@@ -90,7 +90,7 @@ const storybookMeta: Meta<CardProps> = {
     menuButtonChildren: {
       control: null,
       description:
-        "Menu items to be rendered in the Card's optional menu button. If this prop is undefined, the menu button will not be shown. Not valid if the Card itself is clickable.",
+        "Menu items to be rendered in the card's optional menu button. If this prop is undefined, the menu button will not be shown. Not valid if the card itself is clickable.",
       table: {
         type: {
           summary: "[MenuItem | Divider | ListSubheader]",
@@ -102,7 +102,7 @@ const storybookMeta: Meta<CardProps> = {
   args: {
     title: "Title",
     description:
-      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor...",
+      "Identity can create great user experiences, increase customer sign-ups, and...",
     overline: "Overline",
     onClick: undefined,
   },

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Card/Card.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Card/Card.stories.tsx
@@ -15,18 +15,18 @@ import { MuiThemeDecorator } from "../../../../.storybook/components";
 import {
   Box,
   Button,
-  Tile,
+  Card,
   MenuItem,
-  TileProps,
+  CardProps,
 } from "@okta/odyssey-react-mui";
 
-const storybookMeta: Meta<TileProps> = {
-  title: "Labs Components/Tile",
-  component: Tile,
+const storybookMeta: Meta<CardProps> = {
+  title: "MUI Components/Card",
+  component: Card,
   argTypes: {
     title: {
       control: "text",
-      description: "The heading of the tile.",
+      description: "The heading of the Card.",
       table: {
         type: {
           summary: "string",
@@ -37,7 +37,7 @@ const storybookMeta: Meta<TileProps> = {
     description: {
       control: "text",
       description:
-        "The body text of the tile. The consumer is responsible for truncating this string.",
+        "The body text of the Card. The consumer is responsible for truncating this string.",
       table: {
         type: {
           summary: "string",
@@ -47,7 +47,7 @@ const storybookMeta: Meta<TileProps> = {
     },
     overline: {
       control: "text",
-      description: 'The "eyebrow" text above the tile title.',
+      description: 'The "eyebrow" text above the Card title.',
       table: {
         type: {
           summary: "string",
@@ -58,7 +58,7 @@ const storybookMeta: Meta<TileProps> = {
     image: {
       control: null,
       description:
-        "An optional image or icon at the top of the tile, preferably as an img or svg element.",
+        "An optional image or icon at the top of the Card, preferably as an img or svg element.",
       table: {
         type: {
           summary: "ReactElement",
@@ -68,7 +68,7 @@ const storybookMeta: Meta<TileProps> = {
     },
     onClick: {
       control: null,
-      description: "The event handler for when the user clicks the tile.",
+      description: "The event handler for when the user clicks the Card.",
       table: {
         type: {
           summary: "MouseEventHandler",
@@ -79,7 +79,7 @@ const storybookMeta: Meta<TileProps> = {
     button: {
       control: null,
       description:
-        "The main action button for the tile. Not valid if the tile itself is clickable.",
+        "The main action button for the Card. Not valid if the Card itself is clickable.",
       table: {
         type: {
           summary: "ReactElement<typeof Button>",
@@ -90,7 +90,7 @@ const storybookMeta: Meta<TileProps> = {
     menuButtonChildren: {
       control: null,
       description:
-        "Menu items to be rendered in the tile's optional menu button. If this prop is undefined, the menu button will not be shown. Not valid if the tile itself is clickable.",
+        "Menu items to be rendered in the Card's optional menu button. If this prop is undefined, the menu button will not be shown. Not valid if the Card itself is clickable.",
       table: {
         type: {
           summary: "[MenuItem | Divider | ListSubheader]",
@@ -120,10 +120,10 @@ const storybookMeta: Meta<TileProps> = {
 
 export default storybookMeta;
 
-export const Default: StoryObj<TileProps> = {
+export const Default: StoryObj<CardProps> = {
   render: ({ ...props }) => (
     <Box sx={{ maxWidth: 262 }}>
-      <Tile
+      <Card
         {...props}
         image={<img src="https://placehold.co/128" alt="Example logo" />}
         menuButtonChildren={
@@ -139,7 +139,7 @@ export const Default: StoryObj<TileProps> = {
   ),
 };
 
-export const Clickable: StoryObj<TileProps> = {
+export const Clickable: StoryObj<CardProps> = {
   render: ({ ...props }) => {
     const onClick = () => {
       alert("Clicked!");
@@ -147,7 +147,7 @@ export const Clickable: StoryObj<TileProps> = {
 
     return (
       <Box sx={{ maxWidth: 262 }}>
-        <Tile
+        <Card
           {...props}
           image={<img src="https://placehold.co/128" alt="Example logo" />}
           onClick={onClick}
@@ -157,7 +157,7 @@ export const Clickable: StoryObj<TileProps> = {
   },
 };
 
-export const ClickableWithoutImage: StoryObj<TileProps> = {
+export const ClickableWithoutImage: StoryObj<CardProps> = {
   render: ({ ...props }) => {
     const onClick = () => {
       alert("Clicked!");
@@ -165,16 +165,16 @@ export const ClickableWithoutImage: StoryObj<TileProps> = {
 
     return (
       <Box sx={{ maxWidth: 262 }}>
-        <Tile {...props} onClick={onClick} />
+        <Card {...props} onClick={onClick} />
       </Box>
     );
   },
 };
 
-export const ButtonWithoutImage: StoryObj<typeof Tile> = {
+export const ButtonWithoutImage: StoryObj<typeof Card> = {
   render: ({ ...props }) => (
     <Box sx={{ maxWidth: 262 }}>
-      <Tile {...props} />
+      <Card {...props} />
     </Box>
   ),
 };


### PR DESCRIPTION
[DES-5647](https://oktainc.atlassian.net/browse/DES-5647)

## Summary

Renames `Tile` to `Card` to align with design + storybook changes.

Also adds support for importing the component as `Tile` along with a `@deprecated` annotation and console warning  
