### PR TITLE
Storybook Roadmap page update (take 4)

### DIFF
--- a/packages/odyssey-storybook/src/guidelines/Roadmap/RoadmapTable.tsx
+++ b/packages/odyssey-storybook/src/guidelines/Roadmap/RoadmapTable.tsx
@@ -12,7 +12,7 @@
 
 import { DataFilter } from "@okta/odyssey-react-mui/labs";
 import { DataTable, DataTableSortingState } from "@okta/odyssey-react-mui";
-import { columns, data as incomingData, OdysseyComponent } from "./roadmapData";
+import { columns, data, OdysseyComponent } from "./roadmapData";
 import {
   Callout,
   CssBaseline,
@@ -26,7 +26,7 @@ import * as odysseyTokens from "@okta/odyssey-design-tokens";
 const processData = ({
   initialData,
   page = 1,
-  resultsPerPage = 20,
+  resultsPerPage = 100,
   search,
   filters,
   sort,
@@ -116,7 +116,6 @@ const processData = ({
       return 0;
     });
   }
-
   // Implement pagination
   const startIdx = (page - 1) * resultsPerPage;
   const endIdx = startIdx + resultsPerPage;
@@ -126,7 +125,32 @@ const processData = ({
 };
 
 export const InnerRoadmapTable = () => {
-  const data = incomingData;
+  // Constants for filter options
+
+  const typeOptions = [
+    { label: "Component", value: "Component" },
+    { label: "Pattern", value: "Pattern" },
+  ];
+
+  const statusOptions = [
+    { label: "In Progress", value: "In progress" },
+    { label: "In Labs", value: "In labs" },
+    { label: "Released", value: "Released" },
+    { label: "Not Started", value: "Not started" },
+  ];
+
+  const expectedOptions = [
+    { label: "FY24", value: "FY24" },
+    { label: "TBD", value: "TBD" },
+    { label: "Q1 FY25", value: "Q1 FY25" },
+    { label: "Q2 FY25", value: "Q2 FY25" },
+    { label: "Q3 FY25", value: "Q3 FY25" },
+    { label: "Q4 FY25", value: "Q4 FY25" },
+    { label: "Q1 FY26", value: "Q1 FY26" },
+    { label: "Q2 FY26", value: "Q2 FY26" },
+    { label: "Q3 FY26", value: "Q3 FY26" },
+    { label: "Q4 FY26", value: "Q4 FY26" },
+  ];
 
   const fetchData = ({
     page,
@@ -157,10 +181,31 @@ export const InnerRoadmapTable = () => {
       totalRows={data.length}
       getRowId={({ name }) => name}
       getData={fetchData}
-      hasChangeableDensity
-      hasColumnResizing
-      hasColumnVisibility
-      hasFilters={false}
+      hasChangeableDensity={false}
+      hasColumnResizing={false}
+      hasColumnVisibility={false}
+      hasFilters
+      filters={[
+        {
+          id: "type",
+          label: "Type",
+          variant: "select",
+          options: typeOptions,
+        },
+        {
+          id: "status",
+          label: "Status",
+          variant: "select",
+          options: statusOptions,
+        },
+        {
+          id: "deliverableTiming",
+          label: "Deliverable timing",
+          variant: "autocomplete",
+          options: expectedOptions,
+        },
+      ]}
+      resultsPerPage={100}
       hasPagination={false}
       hasRowSelection={false}
       hasRowReordering={false}
@@ -181,7 +226,12 @@ const WrappedRoadmapTable = () => {
         <CssBaseline />
         <ScopedCssBaseline>
           <Callout severity="info">
-            Dates in the future are projected and may change.
+            Any products, features or functionality referenced in this
+            presentation that are not currently generally available may not be
+            delivered on time or at all. Product roadmaps do not represent a
+            commitment, obligation or promise to deliver any product, feature or
+            functionality, and you should not rely on them to make your purchase
+            decisions.
           </Callout>
           <InnerRoadmapTable />
         </ScopedCssBaseline>

--- a/packages/odyssey-storybook/src/guidelines/Roadmap/roadmap.json
+++ b/packages/odyssey-storybook/src/guidelines/Roadmap/roadmap.json
@@ -1,0 +1,389 @@
+[
+  {
+    "name": "Accordion",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "In progress",
+    "deliverableTiming": "Q2 FY25"
+  },
+  {
+    "name": "Autocomplete",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "Q1 FY25"
+  },
+  {
+    "name": "Badge",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "Q2 FY25"
+  },
+  {
+    "name": "Banner",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "Q2 FY25"
+  },
+  {
+    "name": "Breadcrumbs",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "FY24"
+  },
+  {
+    "name": "Button",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "FY24"
+  },
+  {
+    "name": "Callout",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "Q1 FY25"
+  },
+  {
+    "name": "Card",
+    "type": "Component",
+    "status": "In Labs",
+    "define": "In Labs",
+    "design": "In Labs",
+    "develop": "In Labs",
+    "deliverableTiming": "TBD"
+  },
+  {
+    "name": "Checkbox and checkbox group",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "FY24"
+  },
+  {
+    "name": "Circular progress",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "FY24"
+  },
+  {
+    "name": "Dashboard",
+    "type": "Component",
+    "status": "Not started",
+    "define": "Not started",
+    "design": "Not started",
+    "develop": "Not started",
+    "deliverableTiming": "Q2 FY25"
+  },
+  {
+    "name": "Data stack (data list, resource list?)",
+    "type": "Component",
+    "status": "In progress",
+    "define": "In progress",
+    "design": "Not started",
+    "develop": "Not started",
+    "deliverableTiming": "Q2 FY25"
+  },
+  {
+    "name": "Data table",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "Q1 FY25"
+  },
+  {
+    "name": "Date picker",
+    "type": "Component",
+    "status": "In Labs",
+    "define": "Complete",
+    "design": "In progress",
+    "develop": "In progress",
+    "deliverableTiming": "Q2 FY25"
+  },
+  {
+    "name": "Dialog",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "FY24"
+  },
+  {
+    "name": "Drawer",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "Q1 FY25"
+  },
+  {
+    "name": "Duration picker\n(or fieldset)",
+    "type": "Component",
+    "status": "Not started",
+    "define": "Not started",
+    "design": "Not started",
+    "develop": "Not started",
+    "deliverableTiming": "Q2 FY25"
+  },
+  {
+    "name": "Empty states v1 (no illustration)",
+    "type": "Component",
+    "status": "In progress",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "Q2 FY25"
+  },
+  {
+    "name": "Empty states v2 (illustration)",
+    "type": "Component",
+    "status": "Not started",
+    "define": "Not started",
+    "design": "Not started",
+    "develop": "Not started",
+    "deliverableTiming": "Q3 FY25"
+  },
+  {
+    "name": "Fieldset",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "FY24"
+  },
+  {
+    "name": "File uploader",
+    "type": "Component",
+    "status": "In Labs",
+    "define": "In Labs",
+    "design": "In Labs",
+    "develop": "In Labs",
+    "deliverableTiming": "Q2 FY25"
+  },
+  {
+    "name": "Form",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "FY24"
+  },
+  {
+    "name": "Form Layout (Advanced)",
+    "type": "Component",
+    "status": "In progress",
+    "define": "In progress",
+    "design": "-",
+    "develop": "-",
+    "deliverableTiming": "Q2 FY25"
+  },
+  {
+    "name": "Link",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "FY24"
+  },
+  {
+    "name": "Log Investigator \n(AI Pattern)",
+    "type": "Pattern",
+    "status": "Not started",
+    "define": "Not started",
+    "design": "Not started",
+    "develop": "Not started",
+    "deliverableTiming": "Q3 FY25"
+  },
+  {
+    "name": "Menu button",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "FY24"
+  },
+  {
+    "name": "Multi-select dropdown",
+    "type": "Component",
+    "status": "-",
+    "define": "-",
+    "design": "-",
+    "develop": "-",
+    "deliverableTiming": "TBD"
+  },
+  {
+    "name": "Navigation",
+    "type": "Pattern",
+    "status": "In progress",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "In progress",
+    "deliverableTiming": "Q2 FY25"
+  },
+  {
+    "name": "Policy Recommender\n(AI Pattern)",
+    "type": "Pattern",
+    "status": "Not started",
+    "define": "Not started",
+    "design": "Not started",
+    "develop": "Not started",
+    "deliverableTiming": "Q3 FY25"
+  },
+  {
+    "name": "Progress Bar",
+    "type": "Component",
+    "status": "Not started",
+    "define": "Not started",
+    "design": "Not started",
+    "develop": "Not started",
+    "deliverableTiming": "Q3 FY25"
+  },
+  {
+    "name": "Radio group",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "FY24"
+  },
+  {
+    "name": "Search field",
+    "type": "Pattern",
+    "status": "Not started",
+    "define": "Not started",
+    "design": "Not started",
+    "develop": "Not started",
+    "deliverableTiming": "TBD"
+  },
+  {
+    "name": "Select",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "FY24"
+  },
+  {
+    "name": "Show all",
+    "type": "Component",
+    "status": "Not started",
+    "define": "Not started",
+    "design": "Not started",
+    "develop": "Not started",
+    "deliverableTiming": "Q3 FY25"
+  },
+  {
+    "name": "Status",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "FY24"
+  },
+  {
+    "name": "Switch",
+    "type": "Component",
+    "status": "In Labs",
+    "define": "In Labs",
+    "design": "In Labs",
+    "develop": "In Labs",
+    "deliverableTiming": "Q1 FY25"
+  },
+  {
+    "name": "Tabs",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "FY24"
+  },
+  {
+    "name": "Tag",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "FY24"
+  },
+  {
+    "name": "Text field",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "FY24"
+  },
+  {
+    "name": "Time Picker\n(or field set)",
+    "type": "Component",
+    "status": "Not started",
+    "define": "Not started",
+    "design": "Not started",
+    "develop": "Not started",
+    "deliverableTiming": "Q2 FY25"
+  },
+  {
+    "name": "Toast",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "FY24"
+  },
+  {
+    "name": "Tooltip",
+    "type": "Component",
+    "status": "Released",
+    "define": "Complete",
+    "design": "Complete",
+    "develop": "Complete",
+    "deliverableTiming": "FY24"
+  },
+  {
+    "name": "Wizard",
+    "type": "Pattern",
+    "status": "Not started",
+    "define": "Not started",
+    "design": "Not started",
+    "develop": "Not started",
+    "deliverableTiming": "Q3 FY25"
+  }
+]

--- a/packages/odyssey-storybook/src/guidelines/Roadmap/roadmapData.tsx
+++ b/packages/odyssey-storybook/src/guidelines/Roadmap/roadmapData.tsx
@@ -10,15 +10,25 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { DataTableRowData, Status } from "@okta/odyssey-react-mui";
+import {
+  DataTableRowData,
+  Status,
+  statusSeverityValues,
+  Tooltip,
+} from "@okta/odyssey-react-mui";
 import { DataTableColumn } from "@okta/odyssey-react-mui";
+
+import rawData from "./roadmap.json";
+export const data: OdysseyComponent[] = rawData as OdysseyComponent[];
 
 export type OdysseyComponent = {
   name: string;
-  status: "Fully released" | "In Labs" | "In progress" | "Not started";
-  startDate: string;
-  labsRelease: string;
-  fullRelease: string;
+  type: string;
+  status: "" | "Released" | "In Labs" | "In progress" | "Not started";
+  define: string;
+  design: string;
+  develop: string;
+  deliverableTiming: string;
 };
 
 export const columns: DataTableColumn<DataTableRowData>[] = [
@@ -26,198 +36,81 @@ export const columns: DataTableColumn<DataTableRowData>[] = [
     accessorKey: "name",
     header: "Name",
     enableHiding: false,
+    size: 325,
+  },
+  {
+    accessorKey: "type",
+    header: "Type",
+    enableHiding: true,
+    size: 200,
   },
   {
     accessorKey: "status",
     header: "Status",
-    Cell: ({ cell }) => {
-      const value = cell.getValue<string>();
-      const severity =
-        value === "Fully released"
-          ? "success"
-          : value === "In Labs"
-            ? "warning"
-            : value === "In progress"
-              ? "default"
-              : value === "Not started"
-                ? "error"
-                : "default";
-      return <Status label={value} severity={severity} />;
-    },
-  },
-  {
-    accessorKey: "startDate",
-    header: "Start date",
-    //@ts-expect-error need to address typing here
-    Cell: ({ cell }) => {
-      return cell.getValue() ? cell.getValue() : "—";
-    },
-  },
-  {
-    accessorKey: "labsRelease",
-    header: "Available in Odyssey Labs",
-    //@ts-expect-error need to address typing here
-    Cell: ({ cell }) => {
-      return cell.getValue() ? cell.getValue() : "—";
-    },
-  },
-  {
-    accessorKey: "fullRelease",
-    header: "Available in full release",
-    //@ts-expect-error need to address typing here
-    Cell: ({ cell }) => {
-      return cell.getValue() ? cell.getValue() : "—";
-    },
-  },
-];
+    size: 200,
+    Cell: ({ cell, row }) => {
+      const statusValue = cell.getValue<string>();
+      const defineValue = row.original.define;
+      const designValue = row.original.design;
+      const developValue = row.original.develop;
+      const severityMap = new Map<
+        string,
+        (typeof statusSeverityValues)[number]
+      >([
+        ["Released", "success"],
+        ["In Labs", "warning"],
+        ["In progress", "default"],
+        ["Not started", "error"],
+      ]);
+      const severity = severityMap.get(statusValue) || "default";
 
-export const data: OdysseyComponent[] = [
-  {
-    name: "Date picker",
-    status: "In Labs",
-    startDate: "Oct '22",
-    labsRelease: "Oct '22",
-    fullRelease: "",
-  },
-  {
-    name: "Data filters",
-    status: "In Labs",
-    startDate: "Sep '23",
-    labsRelease: "Nov '23",
-    fullRelease: "Jan '24",
-  },
-  {
-    name: "Data table",
-    status: "In Labs",
-    startDate: "Sep '23",
-    labsRelease: "Nov '23",
-    fullRelease: "Jan '24",
-  },
-  {
-    name: "Accordion",
-    status: "In Labs",
-    startDate: "Oct '23",
-    labsRelease: "Oct '23",
-    fullRelease: "Dec '23",
+      // First priority: Check if the define stage is "In Progress"
+      if (defineValue === "In Progress") {
+        // Return a Tooltip specifically for this condition and do nothing else
+        return (
+          <Tooltip
+            ariaType="label"
+            placement="top"
+            text="Planning and research in progress"
+          >
+            <Status
+              label="Planning and research in progress"
+              severity={severity}
+            />
+          </Tooltip>
+        );
+      }
+
+      // If defineValue is not "In Progress", then proceed with this logic:
+      let tooltipText = "";
+      if (defineValue === "In progress") {
+        tooltipText += "Project definition in progress";
+      }
+      if (["Complete", "In progress"].includes(designValue)) {
+        tooltipText += "Design: " + designValue + " ";
+      }
+      if (["Complete", "In progress"].includes(developValue)) {
+        tooltipText += "Develop: " + developValue;
+      }
+
+      // Only show the tooltip if there's relevant information to display
+      if (tooltipText && statusValue !== "Released") {
+        return (
+          <Tooltip ariaType="label" placement="top" text={tooltipText.trim()}>
+            <Status label={statusValue} severity={severity} />
+          </Tooltip>
+        );
+      }
+
+      // If there is no relevant tooltip text, just show the status without any tooltip
+      return <Status label={statusValue} severity={severity} />;
+    },
   },
 
   {
-    name: "Badge",
-    status: "In progress",
-    startDate: "Oct '23",
-    labsRelease: "Dec '23",
-    fullRelease: "",
-  },
-  {
-    name: "Tile",
-    status: "In progress",
-    startDate: "Oct '23",
-    labsRelease: "Dec '23",
-    fullRelease: "",
-  },
-  {
-    name: "Hint text for checkbox/radio",
-    status: "In progress",
-    startDate: "Nov '23",
-    labsRelease: "",
-    fullRelease: "Dec '23",
-  },
-  {
-    name: "Links in hint text",
-    status: "In progress",
-    startDate: "Nov '23",
-    labsRelease: "",
-    fullRelease: "Dec '23",
-  },
-  {
-    name: "Drawer",
-    status: "In progress",
-    startDate: "Dec '23",
-    labsRelease: "Jan '24",
-    fullRelease: "",
-  },
-  {
-    name: "Inline inputs",
-    status: "In progress",
-    startDate: "Dec '23",
-    labsRelease: "",
-    fullRelease: "",
-  },
-  {
-    name: "Gray background",
-    status: "In progress",
-    startDate: "Dec '23",
-    labsRelease: "",
-    fullRelease: "",
-  },
-  {
-    name: "Navigation",
-    status: "Not started",
-    startDate: "Dec '23",
-    labsRelease: "",
-    fullRelease: "",
-  },
-  {
-    name: "Toggle",
-    status: "Not started",
-    startDate: "Dec '23",
-    labsRelease: "Dec '23",
-    fullRelease: "Jan '23",
-  },
-  {
-    name: "Data list",
-    status: "Not started",
-    startDate: "Jan '24",
-    labsRelease: "Feb '24",
-    fullRelease: "",
-  },
-  {
-    name: "Horizontal stepper/wizard pattern",
-    status: "Not started",
-    startDate: "Jan '24",
-    labsRelease: "",
-    fullRelease: "",
-  },
-  {
-    name: "Vertical stepper pattern",
-    status: "Not started",
-    startDate: "Jan '24",
-    labsRelease: "",
-    fullRelease: "",
-  },
-  {
-    name: "Configuration screen pattern",
-    status: "Not started",
-    startDate: "",
-    labsRelease: "",
-    fullRelease: "",
-  },
-  {
-    name: "Help/support pattern",
-    status: "Not started",
-    startDate: "",
-    labsRelease: "",
-    fullRelease: "",
-  },
-  {
-    name: "Page templates",
-    status: "Not started",
-    startDate: "",
-    labsRelease: "",
-    fullRelease: "",
-  },
-  {
-    name: "Panel",
-    status: "Not started",
-    startDate: "",
-    labsRelease: "",
-    fullRelease: "",
-  },
-  {
-    name: "Primary actions area",
-    status: "Not started",
-    startDate: "",
-    labsRelease: "",
-    fullRelease: "",
+    accessorKey: "deliverableTiming",
+    header: "Deliverable timing",
+    enableHiding: false,
+    size: 200,
   },
 ];


### PR DESCRIPTION
**Notes:** I closed the [last PR](https://github.com/okta/odyssey/pull/2242) because I did not have my GPG set up to verify commits and it got messy. [the original PR](https://github.com/okta/odyssey/pull/2230) was unintentionally closed and re-opening caused CI issues. [See the previous PR](https://github.com/okta/odyssey/pull/2230) for past comments.


[DES-5467](https://oktainc.atlassian.net/browse/DES-5467)

## Summary
Updates existing [Roadmap page](https://odyssey-storybook.okta.design/?path=/docs/welcome-roadmap--docs) in Storybook with new data structure, statuses with tooltips, filters, and easier method for updating data via separate JSON file.

## Testing & Screenshots
![CleanShot 2024-05-14 at 16 06 13@2x](https://github.com/okta/odyssey/assets/147574410/b50e299e-9e99-4ec3-af6f-31dcd032396b)