### PR TITLE
Dialog action button missing keys issue [OKTA-735371]

### DIFF
--- a/packages/odyssey-react-mui/src/Dialog.tsx
+++ b/packages/odyssey-react-mui/src/Dialog.tsx
@@ -20,7 +20,7 @@ import {
 } from "@mui/material";
 import { Button } from "./Button";
 import { CloseIcon } from "./icons.generated";
-import React, {
+import {
   cloneElement,
   memo,
   useState,

--- a/packages/odyssey-react-mui/src/Dialog.tsx
+++ b/packages/odyssey-react-mui/src/Dialog.tsx
@@ -21,6 +21,7 @@ import {
 import { Button } from "./Button";
 import { CloseIcon } from "./icons.generated";
 import React, {
+  cloneElement,
   memo,
   useState,
   useEffect,
@@ -162,11 +163,9 @@ const Dialog = ({
 
       {actionButtons.length > 0 && (
         <DialogActions>
-          {actionButtons.map((actionButton, index) => {
-            return actionButton
-              ? React.cloneElement(actionButton, { key: index })
-              : null;
-          })}
+          {actionButtons.map((actionButton, index) =>
+            actionButton ? cloneElement(actionButton, { key: index }) : null,
+          )}
         </DialogActions>
       )}
     </MuiDialog>

--- a/packages/odyssey-react-mui/src/Dialog.tsx
+++ b/packages/odyssey-react-mui/src/Dialog.tsx
@@ -20,13 +20,13 @@ import {
 } from "@mui/material";
 import { Button } from "./Button";
 import { CloseIcon } from "./icons.generated";
-import {
+import React, {
   memo,
-  ReactNode,
   useState,
   useEffect,
   useRef,
   ReactElement,
+  ReactNode,
 } from "react";
 
 import type { HtmlProps } from "./HtmlProps";
@@ -129,7 +129,8 @@ const Dialog = ({
     ) : (
       children
     );
-  //Prioritize new action button format (|| used as a fallback)
+
+  // Prioritize new action button format (|| used as a fallback)
   const actionButtons = [
     tertiaryCallToActionComponent || callToActionLastComponent,
     secondaryCallToActionComponent || callToActionSecondComponent,
@@ -160,7 +161,13 @@ const Dialog = ({
       </DialogContent>
 
       {actionButtons.length > 0 && (
-        <DialogActions>{actionButtons}</DialogActions>
+        <DialogActions>
+          {actionButtons.map((actionButton, index) => {
+            return actionButton
+              ? React.cloneElement(actionButton, { key: index })
+              : null;
+          })}
+        </DialogActions>
       )}
     </MuiDialog>
   );


### PR DESCRIPTION
[OKTA-735371](https://oktainc.atlassian.net/browse/OKTA-735371)

## Summary

For legacy action usage, missing keys were causing errors and breaking the dialog

[Context from Slack](https://okta.slack.com/archives/C7T2H3KNJ/p1717437120893959)