### PR TITLE
Add status lamp [DES-5591] (pr2)

### DIFF
--- a/packages/odyssey-react-mui/src/Status.tsx
+++ b/packages/odyssey-react-mui/src/Status.tsx
@@ -23,6 +23,7 @@ export const statusSeverityValues = [
   "success",
   "warning",
 ] as const;
+export const statusVariantValues = ["lamp", "pill"] as const;
 
 export type StatusProps = {
   /**
@@ -33,9 +34,19 @@ export type StatusProps = {
    * Determine the color and icon of the Status
    */
   severity: (typeof statusSeverityValues)[number];
+  /**
+   * The style of the Status indicator
+   */
+  variant?: (typeof statusVariantValues)[number];
 } & Pick<HtmlProps, "testId" | "translate">;
 
-const Status = ({ label, severity, testId, translate }: StatusProps) => {
+const Status = ({
+  label,
+  severity,
+  testId,
+  translate,
+  variant = "pill",
+}: StatusProps) => {
   const muiProps = useMuiProps();
 
   return (
@@ -45,7 +56,7 @@ const Status = ({ label, severity, testId, translate }: StatusProps) => {
       data-se={testId}
       label={label}
       translate={translate}
-      variant="pill"
+      variant={variant}
     />
   );
 };

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -979,6 +979,44 @@ export const components = ({
             marginInlineEnd: odysseyTokens.Spacing1,
           },
 
+          ...(ownerState.variant === "lamp" && {
+            paddingBlock: 0,
+            paddingInline: 0,
+            borderRadius: 0,
+            border: 0,
+            backgroundColor: "transparent",
+            color: odysseyTokens.TypographyColorBody,
+
+            "&::before": {
+              content: "''",
+              width: odysseyTokens.Spacing2,
+              height: odysseyTokens.Spacing2,
+              marginInlineEnd: odysseyTokens.Spacing2,
+              borderRadius: "100%",
+              backgroundColor: odysseyTokens.HueNeutral600,
+            },
+
+            [`&.${chipClasses.colorError}`]: {
+              "&::before": {
+                border: 0,
+                backgroundColor: odysseyTokens.PaletteDangerMain,
+              },
+            },
+
+            [`&.${chipClasses.colorSuccess}`]: {
+              "&::before": {
+                border: 0,
+                backgroundColor: odysseyTokens.PaletteSuccessMain,
+              },
+            },
+
+            [`&.${chipClasses.colorWarning}`]: {
+              "&::before": {
+                border: 0,
+                backgroundColor: odysseyTokens.HueYellow200,
+              },
+            },
+          }),
           ...(ownerState.variant === "pill" && {
             paddingBlock: odysseyTokens.Spacing1,
             paddingInline: odysseyTokens.Spacing2,

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Status/Status.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Status/Status.stories.tsx
@@ -15,6 +15,7 @@ import {
   Status,
   StatusProps,
   statusSeverityValues,
+  statusVariantValues,
 } from "@okta/odyssey-react-mui";
 import { MuiThemeDecorator } from "../../../../.storybook/components";
 
@@ -48,6 +49,20 @@ const storybookMeta: Meta<StatusProps> = {
         value: "radio",
       },
     },
+    variant: {
+      control: "radio",
+      options: statusVariantValues,
+      description:
+        "Whether the Status is displayed uncontained (`lamp`) or contained (`pill`)",
+      table: {
+        type: {
+          summary: statusVariantValues.join(" | "),
+        },
+        defaultValue: {
+          summary: "pill",
+        },
+      },
+    },
   },
   args: {
     label: "Warp drive in standby",
@@ -59,13 +74,13 @@ const storybookMeta: Meta<StatusProps> = {
 
 export default storybookMeta;
 
-export const Default: StoryObj<StatusProps> = {
+export const DefaultPill: StoryObj<StatusProps> = {
   args: {
     label: "Warp drive in standby",
   },
 };
 
-export const Error: StoryObj<StatusProps> = {
+export const ErrorPill: StoryObj<StatusProps> = {
   args: {
     label: "Warp drive unstable",
     severity: "error",
@@ -86,9 +101,40 @@ export const Success: StoryObj<StatusProps> = {
   },
 };
 
-export const Warning: StoryObj<StatusProps> = {
+export const WarningPill: StoryObj<StatusProps> = {
   args: {
     label: "Warp fuel low",
     severity: "warning",
+  },
+};
+
+export const DefaultLamp: StoryObj<StatusProps> = {
+  args: {
+    label: "Warp drive in standby",
+    variant: "lamp",
+  },
+};
+
+export const ErrorLamp: StoryObj<StatusProps> = {
+  args: {
+    label: "Warp drive unstable",
+    severity: "error",
+    variant: "lamp",
+  },
+};
+
+export const SuccessLamp: StoryObj<StatusProps> = {
+  args: {
+    label: "Warp drive online",
+    severity: "success",
+    variant: "lamp",
+  },
+};
+
+export const WarningLamp: StoryObj<StatusProps> = {
+  args: {
+    label: "Warp fuel low",
+    severity: "warning",
+    variant: "lamp",
   },
 };


### PR DESCRIPTION
**NOTE:** This take 2 after messing up the history of [my original PR](https://github.com/okta/odyssey/pull/2224) fixing commit signing issues. Please refer to the original PR for comments

[DES-5591](https://oktainc.atlassian.net/browse/DES-5591)

## Summary
Adds the previously deprecated `Status` `lamp` variant. This was [removed recently ](https://github.com/okta/odyssey/commit/cd68bfc7f5abc4843495419e3d94812fba969eb5)to simplify the style of `Status` but we've since found use cases for `lamp` and numerous existing uses that necessitate the style.

## Testing & Screenshots
![lamp](https://github.com/okta/odyssey/assets/147574410/a87ef288-6039-43dc-a889-942ccbd1ecb8)