### PR TITLE
Data Table legacy improvements

### DIFF
--- a/packages/odyssey-react-mui/src/DataTable/DataTable.tsx
+++ b/packages/odyssey-react-mui/src/DataTable/DataTable.tsx
@@ -837,6 +837,7 @@ const DataTable = ({
   }, [rowSelection, onChangeRowSelection]);
 
   const { lastRow } = usePagination({
+    currentRowsCount: data.length,
     pageIndex: pagination.pageIndex,
     pageSize: pagination.pageSize,
     totalRows,
@@ -901,6 +902,7 @@ const DataTable = ({
           onPaginationChange={setPagination}
           lastRow={lastRow}
           totalRows={totalRows}
+          currentRowsCount={data.length}
           isDisabled={isEmpty}
           isMoreDisabled={isPaginationMoreDisabled}
           variant={paginationType}

--- a/packages/odyssey-react-mui/src/DataTable/DataTable.tsx
+++ b/packages/odyssey-react-mui/src/DataTable/DataTable.tsx
@@ -196,6 +196,10 @@ export type DataTableProps = {
    */
   initialSearchValue?: string;
   /**
+   * Is the next or show-more button disabled
+   */
+  isPaginationMoreDisabled?: boolean;
+  /**
    * The component to display when the query returns no results
    */
   noResultsPlaceholder?: ReactNode;
@@ -385,6 +389,7 @@ const DataTable = ({
   hasSorting,
   initialDensity = densityValues[0],
   initialSearchValue = "",
+  isPaginationMoreDisabled,
   noResultsPlaceholder,
   onChangeRowSelection,
   onReorderRows,
@@ -897,6 +902,7 @@ const DataTable = ({
           lastRow={lastRow}
           totalRows={totalRows}
           isDisabled={isEmpty}
+          isMoreDisabled={isPaginationMoreDisabled}
           variant={paginationType}
           rowsPerPageLabel={t("pagination.rowsperpage")}
           currentPageLabel={t("pagination.page")}

--- a/packages/odyssey-react-mui/src/DataTable/DataTable.tsx
+++ b/packages/odyssey-react-mui/src/DataTable/DataTable.tsx
@@ -240,6 +240,15 @@ export type DataTableProps = {
    * to calculate. Used in table pagination to know when to disable the "next"/"more" button.
    */
   totalRows?: number;
+  /**
+   * The largest number of rows allowed to be shown per page. This only affects the row input
+   * in pagination.
+   */
+  maxResultsPerPage?: number;
+  /**
+   * The highest page number allowed to be manually input in pagination
+   */
+  maxPages?: number;
 };
 
 const displayColumnDefOptions = {
@@ -382,6 +391,8 @@ const DataTable = ({
   paginationType = "paged",
   renderDetailPanel,
   resultsPerPage = 20,
+  maxResultsPerPage,
+  maxPages,
   rowActionButtons,
   rowActionMenuItems,
   searchDelayTime,
@@ -810,6 +821,13 @@ const DataTable = ({
   ]);
 
   useEffect(() => {
+    setPagination((prev) => ({
+      pageIndex: 1,
+      pageSize: prev.pageSize,
+    }));
+  }, [filters, search]);
+
+  useEffect(() => {
     onChangeRowSelection?.(rowSelection);
   }, [rowSelection, onChangeRowSelection]);
 
@@ -873,6 +891,8 @@ const DataTable = ({
         <Pagination
           pageIndex={pagination.pageIndex}
           pageSize={pagination.pageSize}
+          maxPageIndex={maxPages}
+          maxPageSize={maxResultsPerPage}
           onPaginationChange={setPagination}
           lastRow={lastRow}
           totalRows={totalRows}

--- a/packages/odyssey-react-mui/src/Pagination/Pagination.tsx
+++ b/packages/odyssey-react-mui/src/Pagination/Pagination.tsx
@@ -104,6 +104,10 @@ export type PaginationProps = {
    */
   isDisabled?: boolean;
   /**
+   * If true, the next or Show More button will be disabled
+   */
+  isMoreDisabled?: boolean;
+  /**
    * The type of pagination controls shown. Defaults to next/prev buttons, but can be
    * set to a simple "Load more" button by setting to "loadMore".
    */
@@ -139,6 +143,7 @@ const Pagination = ({
   lastRow,
   totalRows,
   isDisabled,
+  isMoreDisabled,
   variant,
   rowsPerPageLabel,
   currentPageLabel,
@@ -236,12 +241,15 @@ const Pagination = ({
   }, [onPaginationChange, page, rowsPerPage]);
 
   const loadMoreIsDisabled = useMemo(() => {
-    return totalRows ? rowsPerPage >= totalRows : false;
-  }, [rowsPerPage, totalRows]);
+    return isMoreDisabled || (totalRows ? rowsPerPage >= totalRows : false);
+  }, [isMoreDisabled, rowsPerPage, totalRows]);
 
   const nextButtonDisabled = useMemo(
-    () => (totalRows ? lastRow >= totalRows : false) || isDisabled,
-    [totalRows, lastRow, isDisabled],
+    () =>
+      isMoreDisabled ||
+      (totalRows ? lastRow >= totalRows : false) ||
+      isDisabled,
+    [isMoreDisabled, totalRows, lastRow, isDisabled],
   );
 
   const previousButtonDisabled = useMemo(

--- a/packages/odyssey-react-mui/src/Pagination/Pagination.tsx
+++ b/packages/odyssey-react-mui/src/Pagination/Pagination.tsx
@@ -66,21 +66,37 @@ const PaginationButtonContainer = styled("div")({
 
 export type PaginationProps = {
   /**
-   * The current page index
+   * The labeled rendered for the current page index
    */
-  pageIndex: number;
+  currentPageLabel: string;
   /**
-   * The current page size
+   * If true, the pagination controls will be disabled
    */
-  pageSize: number;
+  isDisabled?: boolean;
+  /**
+   * If true, the next or Show More button will be disabled
+   */
+  isMoreDisabled?: boolean;
+  /**
+   * The current page last row index
+   */
+  lastRow: number;
+  /**
+   * If the pagination is of "loadMore" variant, then this is the the load more label
+   */
+  loadMoreLabel: string;
+  /**
+   * The max page
+   */
+  maxPageIndex?: number;
   /**
    * The max rows per page
    */
   maxPageSize?: number;
   /**
-   * The max page
+   * The label for the next control
    */
-  maxPageIndex?: number;
+  nextLabel: string;
   /**
    * Page index and page size setter
    */
@@ -92,64 +108,48 @@ export type PaginationProps = {
     pageSize: number;
   }) => void;
   /**
-   * The current page last row index
+   * The current page index
    */
-  lastRow: number;
+  pageIndex: number;
   /**
-   * Total rows count
+   * The current page size
    */
-  totalRows?: number;
-  /**
-   * If true, the pagination controls will be disabled
-   */
-  isDisabled?: boolean;
-  /**
-   * If true, the next or Show More button will be disabled
-   */
-  isMoreDisabled?: boolean;
-  /**
-   * The type of pagination controls shown. Defaults to next/prev buttons, but can be
-   * set to a simple "Load more" button by setting to "loadMore".
-   */
-  variant?: (typeof paginationTypeValues)[number];
-  /**
-   * The label that shows how many results are rendered per page
-   */
-  rowsPerPageLabel: string;
-  /**
-   * The labeled rendered for the current page index
-   */
-  currentPageLabel: string;
+  pageSize: number;
   /**
    * The label for the previous control
    */
   previousLabel: string;
   /**
-   * The label for the next control
+   * The label that shows how many results are rendered per page
    */
-  nextLabel: string;
+  rowsPerPageLabel: string;
   /**
-   * If the pagination is of "loadMore" variant, then this is the the load more label
+   * Total rows count
    */
-  loadMoreLabel: string;
+  totalRows?: number;
+  /**
+   * The type of pagination controls shown. Defaults to next/prev buttons, but can be
+   * set to a simple "Load more" button by setting to "loadMore".
+   */
+  variant?: (typeof paginationTypeValues)[number];
 };
 
 const Pagination = ({
-  pageIndex,
-  pageSize,
-  maxPageSize,
-  maxPageIndex,
-  onPaginationChange,
-  lastRow,
-  totalRows,
+  currentPageLabel,
   isDisabled,
   isMoreDisabled,
-  variant,
-  rowsPerPageLabel,
-  currentPageLabel,
-  previousLabel,
-  nextLabel,
+  lastRow,
   loadMoreLabel,
+  maxPageIndex,
+  maxPageSize,
+  nextLabel,
+  onPaginationChange,
+  pageIndex,
+  pageSize,
+  previousLabel,
+  rowsPerPageLabel,
+  totalRows,
+  variant,
 }: PaginationProps) => {
   const odysseyDesignTokens = useOdysseyDesignTokens();
 

--- a/packages/odyssey-react-mui/src/Pagination/Pagination.tsx
+++ b/packages/odyssey-react-mui/src/Pagination/Pagination.tsx
@@ -74,6 +74,14 @@ export type PaginationProps = {
    */
   pageSize: number;
   /**
+   * The max rows per page
+   */
+  maxPageSize?: number;
+  /**
+   * The max page
+   */
+  maxPageIndex?: number;
+  /**
    * Page index and page size setter
    */
   onPaginationChange: ({
@@ -125,6 +133,8 @@ export type PaginationProps = {
 const Pagination = ({
   pageIndex,
   pageSize,
+  maxPageSize,
+  maxPageIndex,
   onPaginationChange,
   lastRow,
   totalRows,
@@ -192,16 +202,22 @@ const Pagination = ({
 
   const setPageFromEvent = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      setPage(parseInt(event.target.value));
+      const value = maxPageIndex
+        ? Math.min(parseInt(event.target.value), maxPageIndex)
+        : parseInt(event.target.value);
+      setPage(value);
     },
-    [setPage],
+    [setPage, maxPageIndex],
   );
 
   const setRowsPerPageFromEvent = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      setRowsPerPage(parseInt(event.target.value));
+      const value = maxPageSize
+        ? Math.min(parseInt(event.target.value), maxPageSize)
+        : parseInt(event.target.value);
+      setRowsPerPage(value);
     },
-    [setRowsPerPage],
+    [setRowsPerPage, maxPageSize],
   );
 
   const handleLoadMore = useCallback(() => {
@@ -236,15 +252,17 @@ const Pagination = ({
   const rowsPerPageInputProps = useMemo(
     () => ({
       "aria-label": rowsPerPageLabel,
+      max: maxPageSize || totalRows,
     }),
-    [rowsPerPageLabel],
+    [maxPageSize, rowsPerPageLabel, totalRows],
   );
 
   const currentPageInputProps = useMemo(
     () => ({
       "aria-label": currentPageLabel,
+      max: maxPageIndex,
     }),
-    [currentPageLabel],
+    [currentPageLabel, maxPageIndex],
   );
 
   return variant === "paged" ? (

--- a/packages/odyssey-react-mui/src/Pagination/Pagination.tsx
+++ b/packages/odyssey-react-mui/src/Pagination/Pagination.tsx
@@ -70,6 +70,10 @@ export type PaginationProps = {
    */
   currentPageLabel: string;
   /**
+   * The number of items currently visible on the page
+   */
+  currentRowsCount: number;
+  /**
    * If true, the pagination controls will be disabled
    */
   isDisabled?: boolean;
@@ -149,6 +153,7 @@ const Pagination = ({
   previousLabel,
   rowsPerPageLabel,
   totalRows,
+  currentRowsCount,
   variant,
 }: PaginationProps) => {
   const odysseyDesignTokens = useOdysseyDesignTokens();
@@ -162,7 +167,12 @@ const Pagination = ({
     setRowsPerPage(pageSize);
   }, [pageIndex, pageSize]);
 
-  const { totalRowsLabel } = usePagination({ pageIndex, pageSize, totalRows });
+  const { totalRowsLabel } = usePagination({
+    pageIndex,
+    pageSize,
+    currentRowsCount,
+    totalRows,
+  });
 
   const handlePaginationChange = useCallback(() => {
     const updatedPage =

--- a/packages/odyssey-react-mui/src/Pagination/Pagination.tsx
+++ b/packages/odyssey-react-mui/src/Pagination/Pagination.tsx
@@ -72,7 +72,7 @@ export type PaginationProps = {
   /**
    * The number of items currently visible on the page
    */
-  currentRowsCount: number;
+  currentRowsCount?: number;
   /**
    * If true, the pagination controls will be disabled
    */
@@ -170,7 +170,7 @@ const Pagination = ({
   const { totalRowsLabel } = usePagination({
     pageIndex,
     pageSize,
-    currentRowsCount,
+    currentRowsCount: currentRowsCount || pageSize,
     totalRows,
   });
 

--- a/packages/odyssey-react-mui/src/Pagination/usePagination.ts
+++ b/packages/odyssey-react-mui/src/Pagination/usePagination.ts
@@ -11,6 +11,7 @@
  */
 
 import { useTranslation } from "react-i18next";
+import { useMemo } from "react";
 
 type UsePaginationType = {
   pageIndex: number;
@@ -25,25 +26,22 @@ export const usePagination = ({
 }: UsePaginationType) => {
   const { t } = useTranslation();
 
-  const firstRow = pageSize * (pageIndex - 1) + 1;
-  const lastRow = firstRow + (pageSize - 1);
-  if (totalRows && lastRow > totalRows) {
-    // If the last eligible row is greater than the number of total rows,
-    // show the number of total rows instead (ie, if we're showing rows
-    // 180-200 but there are only 190 rows, show 180-190 instead)
+  return useMemo(() => {
+    const firstRow = pageSize * (pageIndex - 1) + 1;
+    let lastRow = firstRow + (pageSize - 1);
+
+    if (totalRows && lastRow > totalRows) {
+      lastRow = totalRows;
+    }
+
+    const totalRowsLabel = totalRows
+      ? t("pagination.rowswithtotal", { firstRow, lastRow, totalRows })
+      : t("pagination.rowswithouttotal", { firstRow, lastRow });
+
     return {
       firstRow,
-      lastRow: totalRows,
-      totalRowsLabel: totalRows
-        ? t("pagination.rowswithtotal", { firstRow, lastRow, totalRows })
-        : t("pagination.rowswithouttotal", { firstRow, lastRow }),
+      lastRow,
+      totalRowsLabel,
     };
-  }
-  return {
-    firstRow,
-    lastRow,
-    totalRowsLabel: totalRows
-      ? t("pagination.rowswithtotal", { firstRow, lastRow, totalRows })
-      : t("pagination.rowswithouttotal", { firstRow, lastRow }),
-  };
+  }, [pageIndex, pageSize, totalRows, t]);
 };

--- a/packages/odyssey-react-mui/src/Pagination/usePagination.ts
+++ b/packages/odyssey-react-mui/src/Pagination/usePagination.ts
@@ -14,12 +14,14 @@ import { useTranslation } from "react-i18next";
 import { useMemo } from "react";
 
 type UsePaginationType = {
+  currentRowsCount: number;
   pageIndex: number;
   pageSize: number;
   totalRows?: number;
 };
 
 export const usePagination = ({
+  currentRowsCount,
   pageIndex,
   pageSize,
   totalRows,
@@ -28,11 +30,7 @@ export const usePagination = ({
 
   return useMemo(() => {
     const firstRow = pageSize * (pageIndex - 1) + 1;
-    let lastRow = firstRow + (pageSize - 1);
-
-    if (totalRows && lastRow > totalRows) {
-      lastRow = totalRows;
-    }
+    const lastRow = firstRow + (currentRowsCount - 1);
 
     const totalRowsLabel = totalRows
       ? t("pagination.rowswithtotal", { firstRow, lastRow, totalRows })
@@ -43,5 +41,5 @@ export const usePagination = ({
       lastRow,
       totalRowsLabel,
     };
-  }, [pageIndex, pageSize, totalRows, t]);
+  }, [currentRowsCount, pageIndex, pageSize, totalRows, t]);
 };

--- a/packages/odyssey-react-mui/src/labs/DataComponents/DataStack.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataComponents/DataStack.tsx
@@ -44,6 +44,7 @@ const DataStack = ({
   isEmpty,
   isLoading,
   isNoResults,
+  isPaginationMoreDisabled,
   isRowReorderingDisabled,
   maxGridColumns,
   noResultsPlaceholder,
@@ -83,6 +84,7 @@ const DataStack = ({
       isEmpty={isEmpty}
       isLoading={isLoading}
       isNoResults={isNoResults}
+      isPaginationMoreDisabled={isPaginationMoreDisabled}
       isRowReorderingDisabled={isRowReorderingDisabled}
       maxPages={maxPages}
       maxResultsPerPage={maxResultsPerPage}

--- a/packages/odyssey-react-mui/src/labs/DataComponents/DataStack.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataComponents/DataStack.tsx
@@ -53,6 +53,8 @@ const DataStack = ({
   rowActionMenuItems,
   searchDelayTime,
   totalRows,
+  maxPages,
+  maxResultsPerPage,
 }: DataStackProps) => {
   const stackOptions = useMemo(
     () => ({
@@ -82,6 +84,8 @@ const DataStack = ({
       isLoading={isLoading}
       isNoResults={isNoResults}
       isRowReorderingDisabled={isRowReorderingDisabled}
+      maxPages={maxPages}
+      maxResultsPerPage={maxResultsPerPage}
       noResultsPlaceholder={noResultsPlaceholder}
       onChangeRowSelection={onChangeRowSelection}
       paginationType={paginationType}

--- a/packages/odyssey-react-mui/src/labs/DataComponents/DataStack.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataComponents/DataStack.tsx
@@ -47,6 +47,8 @@ const DataStack = ({
   isPaginationMoreDisabled,
   isRowReorderingDisabled,
   maxGridColumns,
+  maxPages,
+  maxResultsPerPage,
   noResultsPlaceholder,
   onChangeRowSelection,
   paginationType,
@@ -54,8 +56,6 @@ const DataStack = ({
   rowActionMenuItems,
   searchDelayTime,
   totalRows,
-  maxPages,
-  maxResultsPerPage,
 }: DataStackProps) => {
   const stackOptions = useMemo(
     () => ({

--- a/packages/odyssey-react-mui/src/labs/DataComponents/DataTable.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataComponents/DataTable.tsx
@@ -41,6 +41,8 @@ const DataTable = ({
   isNoResults,
   isPaginationMoreDisabled,
   isRowReorderingDisabled,
+  maxResultsPerPage,
+  maxPages,
   noResultsPlaceholder,
   onChangeRowSelection,
   paginationType,
@@ -50,8 +52,6 @@ const DataTable = ({
   rowActionMenuItems,
   searchDelayTime,
   totalRows,
-  maxResultsPerPage,
-  maxPages,
 }: DataTableProps) => {
   const tableOptions = useMemo(
     () => ({

--- a/packages/odyssey-react-mui/src/labs/DataComponents/DataTable.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataComponents/DataTable.tsx
@@ -39,6 +39,7 @@ const DataTable = ({
   isLoading,
   isEmpty,
   isNoResults,
+  isPaginationMoreDisabled,
   isRowReorderingDisabled,
   noResultsPlaceholder,
   onChangeRowSelection,
@@ -95,6 +96,7 @@ const DataTable = ({
       isEmpty={isEmpty}
       isLoading={isLoading}
       isNoResults={isNoResults}
+      isPaginationMoreDisabled={isPaginationMoreDisabled}
       isRowReorderingDisabled={isRowReorderingDisabled}
       maxPages={maxPages}
       maxResultsPerPage={maxResultsPerPage}

--- a/packages/odyssey-react-mui/src/labs/DataComponents/DataTable.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataComponents/DataTable.tsx
@@ -49,6 +49,8 @@ const DataTable = ({
   rowActionMenuItems,
   searchDelayTime,
   totalRows,
+  maxResultsPerPage,
+  maxPages,
 }: DataTableProps) => {
   const tableOptions = useMemo(
     () => ({
@@ -94,6 +96,8 @@ const DataTable = ({
       isLoading={isLoading}
       isNoResults={isNoResults}
       isRowReorderingDisabled={isRowReorderingDisabled}
+      maxPages={maxPages}
+      maxResultsPerPage={maxResultsPerPage}
       noResultsPlaceholder={noResultsPlaceholder}
       onChangeRowSelection={onChangeRowSelection}
       paginationType={paginationType}

--- a/packages/odyssey-react-mui/src/labs/DataComponents/DataView.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataComponents/DataView.tsx
@@ -96,6 +96,8 @@ const DataView = ({
   stackOptions,
   tableOptions,
   totalRows,
+  maxPages,
+  maxResultsPerPage,
 }: DataViewProps) => {
   const odysseyDesignTokens = useOdysseyDesignTokens();
   const { t } = useTranslation();
@@ -382,6 +384,8 @@ const DataView = ({
           rowsPerPageLabel={t("pagination.rowsperpage")}
           totalRows={totalRows}
           variant={paginationType}
+          maxPageIndex={maxPages}
+          maxPageSize={maxResultsPerPage}
         />
       )}
     </DataViewContainer>

--- a/packages/odyssey-react-mui/src/labs/DataComponents/DataView.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataComponents/DataView.tsx
@@ -86,6 +86,7 @@ const DataView = ({
   isEmpty: isEmptyProp,
   isLoading: isLoadingProp,
   isNoResults: isNoResultsProp,
+  isPaginationMoreDisabled,
   isRowReorderingDisabled,
   noResultsPlaceholder,
   onChangeRowSelection,
@@ -374,6 +375,7 @@ const DataView = ({
         <Pagination
           currentPageLabel={t("pagination.page")}
           isDisabled={isEmpty}
+          isMoreDisabled={isPaginationMoreDisabled}
           lastRow={lastRowOnPage}
           loadMoreLabel={t("pagination.loadmore")}
           nextLabel={t("pagination.next")}

--- a/packages/odyssey-react-mui/src/labs/DataComponents/DataView.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataComponents/DataView.tsx
@@ -182,6 +182,14 @@ const DataView = ({
     });
   }, [currentPage, resultsPerPage]);
 
+  // Reset pagination if search or filters change
+  useEffect(() => {
+    setPagination((prev) => ({
+      pageIndex: 1,
+      pageSize: prev.pageSize,
+    }));
+  }, [filters, search]);
+
   // Retrieve the data
   useEffect(() => {
     fetchData({

--- a/packages/odyssey-react-mui/src/labs/DataComponents/DataView.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataComponents/DataView.tsx
@@ -253,6 +253,11 @@ const DataView = ({
     return;
   }, [noResultsPlaceholder, t, isEmpty, isNoResults, emptyPlaceholder]);
 
+  const paginationTotalRows = useMemo(
+    () => (data.length < resultsPerPage ? data.length : totalRows),
+    [data, resultsPerPage, totalRows],
+  );
+
   const additionalActions = useMemo(
     () => (
       <>
@@ -394,7 +399,7 @@ const DataView = ({
           pageSize={pagination.pageSize}
           previousLabel={t("pagination.previous")}
           rowsPerPageLabel={t("pagination.rowsperpage")}
-          totalRows={totalRows}
+          totalRows={paginationTotalRows}
           variant={paginationType}
         />
       )}

--- a/packages/odyssey-react-mui/src/labs/DataComponents/DataView.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataComponents/DataView.tsx
@@ -253,11 +253,6 @@ const DataView = ({
     return;
   }, [noResultsPlaceholder, t, isEmpty, isNoResults, emptyPlaceholder]);
 
-  const paginationTotalRows = useMemo(
-    () => (data.length < resultsPerPage ? data.length : totalRows),
-    [data, resultsPerPage, totalRows],
-  );
-
   const additionalActions = useMemo(
     () => (
       <>
@@ -282,6 +277,7 @@ const DataView = ({
   );
 
   const { lastRow: lastRowOnPage } = usePagination({
+    currentRowsCount: data.length,
     pageIndex: pagination.pageIndex,
     pageSize: pagination.pageSize,
     totalRows,
@@ -399,7 +395,8 @@ const DataView = ({
           pageSize={pagination.pageSize}
           previousLabel={t("pagination.previous")}
           rowsPerPageLabel={t("pagination.rowsperpage")}
-          totalRows={paginationTotalRows}
+          totalRows={totalRows}
+          currentRowsCount={data.length}
           variant={paginationType}
         />
       )}

--- a/packages/odyssey-react-mui/src/labs/DataComponents/DataView.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataComponents/DataView.tsx
@@ -386,6 +386,8 @@ const DataView = ({
           isMoreDisabled={isPaginationMoreDisabled}
           lastRow={lastRowOnPage}
           loadMoreLabel={t("pagination.loadmore")}
+          maxPageIndex={maxPages}
+          maxPageSize={maxResultsPerPage}
           nextLabel={t("pagination.next")}
           onPaginationChange={setPagination}
           pageIndex={pagination.pageIndex}
@@ -394,8 +396,6 @@ const DataView = ({
           rowsPerPageLabel={t("pagination.rowsperpage")}
           totalRows={totalRows}
           variant={paginationType}
-          maxPageIndex={maxPages}
-          maxPageSize={maxResultsPerPage}
         />
       )}
     </DataViewContainer>

--- a/packages/odyssey-react-mui/src/labs/DataComponents/componentTypes.ts
+++ b/packages/odyssey-react-mui/src/labs/DataComponents/componentTypes.ts
@@ -69,6 +69,8 @@ export type UniversalProps = {
   isLoading?: boolean;
   isNoResults?: boolean;
   isRowReorderingDisabled?: boolean;
+  maxPages?: number;
+  maxResultsPerPage?: number;
   noResultsPlaceholder?: ReactNode;
   onChangeRowSelection?: (rowSelection: DataRowSelectionState) => void;
   onReorderRows?: ({ rowId, newRowIndex }: DataOnReorderRowsType) => void;

--- a/packages/odyssey-react-mui/src/labs/DataComponents/componentTypes.ts
+++ b/packages/odyssey-react-mui/src/labs/DataComponents/componentTypes.ts
@@ -68,6 +68,7 @@ export type UniversalProps = {
   isEmpty?: boolean;
   isLoading?: boolean;
   isNoResults?: boolean;
+  isPaginationMoreDisabled?: boolean;
   isRowReorderingDisabled?: boolean;
   maxPages?: number;
   maxResultsPerPage?: number;

--- a/packages/odyssey-storybook/src/components/odyssey-labs/DataComponents/DataComponents.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/DataComponents/DataComponents.stories.tsx
@@ -216,6 +216,16 @@ const storybookMeta: Meta<DataViewMetaProps> = {
     isNoResults: {
       control: "boolean",
     },
+    isPaginationMoreDisabled: {
+      control: "boolean",
+      description:
+        "If true, the pagination next or show more button will be disabled.",
+      table: {
+        type: {
+          summary: "boolean",
+        },
+      },
+    },
     hasCustomEmptyPlaceholder: {
       control: "boolean",
       name: "[STORY ONLY] Has custom empty placeholder?",
@@ -375,6 +385,7 @@ const BaseStory: StoryObj<DataViewMetaProps> = {
         hasFilters={args.hasFilters}
         hasSearch={args.hasSearch}
         hasSearchSubmitButton={args.hasSearchSubmitButton}
+        isPaginationMoreDisabled={args.isPaginationMoreDisabled}
         searchDelayTime={args.searchDelayTime}
         errorMessage={args.errorMessage}
         initialLayout={args.initialLayout}

--- a/packages/odyssey-storybook/src/components/odyssey-mui/DataTable/DataTable.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/DataTable/DataTable.stories.tsx
@@ -18,7 +18,7 @@ import {
 import {
   Box,
   Button,
-  // DataTable,
+  DataTable,
   EmptyState,
   DataTableGetDataType,
   DataTableOnReorderRowsType,
@@ -26,9 +26,8 @@ import {
   DataTableRenderDetailPanelType,
   DataTableRowSelectionState,
   MenuItem,
-  // densityValues,
+  densityValues,
 } from "@okta/odyssey-react-mui";
-import { DataTable, densityValues } from "@okta/odyssey-react-mui/labs";
 import { MuiThemeDecorator } from "../../../../.storybook/components";
 import {
   Planet,
@@ -244,6 +243,16 @@ const storybookMeta: Meta<DataTableProps> = {
       table: {
         type: {
           summary: "number",
+        },
+      },
+    },
+    isPaginationMoreDisabled: {
+      control: "boolean",
+      description:
+        "If true, the pagination next or show more button will be disabled.",
+      table: {
+        type: {
+          summary: "boolean",
         },
       },
     },

--- a/packages/odyssey-storybook/src/components/odyssey-mui/DataTable/DataTable.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/DataTable/DataTable.stories.tsx
@@ -247,6 +247,26 @@ const storybookMeta: Meta<DataTableProps> = {
         },
       },
     },
+    maxPages: {
+      control: "number",
+      description:
+        "The highest page number allowed to be manually input in pagination.",
+      table: {
+        type: {
+          summary: "number",
+        },
+      },
+    },
+    maxResultsPerPage: {
+      control: "number",
+      description:
+        "The largest number of rows allowed to be shown per page. This only affects the row input in pagination.",
+      table: {
+        type: {
+          summary: "number",
+        },
+      },
+    },
     paginationType: {
       options: paginationTypeValues,
       control: { type: "radio" },

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Pagination/Pagination.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Pagination/Pagination.stories.tsx
@@ -87,6 +87,16 @@ const storyBookMeta: Meta<PaginationProps> = {
       },
     },
 
+    isMoreDisabled: {
+      control: "boolean",
+      description:
+        "If true, the pagination next/show more button will be disabled",
+      type: {
+        required: true,
+        name: "boolean",
+      },
+    },
+
     variant: {
       control: { type: "radio" },
       options: paginationTypeValues,

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Pagination/Pagination.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Pagination/Pagination.stories.tsx
@@ -178,6 +178,15 @@ const storyBookMeta: Meta<PaginationProps> = {
         },
       },
     },
+    currentRowsCount: {
+      control: "number",
+      description: "The number of items currently visible on the page",
+      table: {
+        type: {
+          summary: "number",
+        },
+      },
+    },
   },
 
   decorators: [MuiThemeDecorator],
@@ -191,6 +200,7 @@ export const Default: StoryObj<PaginationProps> = {
     pageIndex: 1,
     pageSize: 20,
     lastRow: 20,
+    currentRowsCount: 20,
     isDisabled: false,
     variant: "paged",
     rowsPerPageLabel: "Rows per page",

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Pagination/Pagination.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Pagination/Pagination.stories.tsx
@@ -147,6 +147,27 @@ const storyBookMeta: Meta<PaginationProps> = {
         name: "string",
       },
     },
+
+    maxPageIndex: {
+      control: "number",
+      description:
+        "The highest page number allowed to be manually input in pagination.",
+      table: {
+        type: {
+          summary: "number",
+        },
+      },
+    },
+    maxPageSize: {
+      control: "number",
+      description:
+        "The largest number of rows allowed to be shown per page. This only affects the row input in pagination.",
+      table: {
+        type: {
+          summary: "number",
+        },
+      },
+    },
   },
 
   decorators: [MuiThemeDecorator],


### PR DESCRIPTION
In response to some feedback from @alexma-okta, this PR fixes three bits of missing functionality or unanticipated behavior:

## Pagination now includes max row and page counts.

Previously, it was possible for a user to specify nonsensical or invalid pagination values, like trying to show 9999 rows per page on a dataset that only includes 100 rows, or navigating to page 100000 when there are only 20 pages.

Now, you can manually set maximum allowed values for row count and page.

## Pagination resets when searching or filtering

Previously, if you were on page 20 (for example) and you started searching for something in a table, the pagination would continue to show that you were on page 20 even as the data changed.

Now, the pagination resets to the proper values when searching or filtering.

## Manual disabling for "Show more" pagination button

There are cases in which we don't know the total row count due to API limitations. Now, a consumer can manually set the pagination's **Next** or **Load more results** buttons to disabled, providing a better UX for users when they reach the end of the results.