### PR TITLE
fix: remove invalid pseudo element from theme overrides

### DIFF
--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -1933,11 +1933,6 @@ export const components = ({
             WebkitAppearance: "none",
           } satisfies CSSProperties,
 
-          [`&::-moz-search-cancel-button`]: {
-            display: "none",
-            MozAppearance: "none",
-          } satisfies CSSProperties,
-
           [`&::-ms-clear`]: {
             display: "none",
           },


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[OKTA-755668](https://oktainc.atlassian.net/browse/OKTA-755668)

## Summary
`-moz-search-cancel-button` is not a valid pseudo-element, unlike [-webkit-search-cancel-button](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-search-cancel-button), but they are both treated equal in the [Odyssey theme overrides](https://github.com/okta/odyssey/blob/main/packages/odyssey-react-mui/src/theme/components.tsx#L1936-L1939), which should be removed.
<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
Error example:
<img width="1549" alt="image" src="https://github.com/user-attachments/assets/1ccdac5a-5e99-44ab-8751-d34f790a717c">
