### PR TITLE
fix: Applitools isn't consistently running VRTs

### DIFF
--- a/.bacon.yml
+++ b/.bacon.yml
@@ -1,6 +1,5 @@
 test_suites:
   - name: "Build"
-    abort_commit_on_failure: true
     criteria: MERGE
     queue_name: ci-queue-productionJenga-AL2023
     script_path: /root/okta/odyssey/scripts
@@ -15,7 +14,6 @@ test_suites:
     timeout: "20"
 
   - name: "Code Coverage"
-    abort_commit_on_failure: true
     criteria: OPTIONAL
     queue_name: ci-queue-prodJenga-Ubuntu20 # Playwright only works with certain distros of Linux
     script_name: code-coverage
@@ -24,7 +22,6 @@ test_suites:
     timeout: "20"
 
   - name: "Interaction Test"
-    abort_commit_on_failure: true
     criteria: MERGE
     queue_name: ci-queue-prodJenga-Ubuntu20 # Playwright only works with certain distros of Linux
     script_path: /root/okta/odyssey/scripts
@@ -33,7 +30,6 @@ test_suites:
     timeout: "20"
 
   - name: "Lint"
-    abort_commit_on_failure: true
     criteria: MERGE
     queue_name: ci-queue-productionJenga-AL2023
     script_path: /root/okta/odyssey/scripts
@@ -48,7 +44,6 @@ test_suites:
     timeout: "20"
 
   - name: "Publish Package"
-    abort_commit_on_failure: true
     criteria: MERGE
     queue_name: ci-queue-productionJenga-AL2023
     script_name: publish-packages
@@ -57,7 +52,6 @@ test_suites:
     timeout: "15"
 
   - name: "Publish Storybook"
-    abort_commit_on_failure: true
     criteria: MERGE
     queue_name: ci-queue-productionJenga-AL2023
     script_name: publish-storybook
@@ -70,11 +64,10 @@ test_suites:
     queue_name: ci-queue-productionJenga-AL2023
     script_name: semgrep
     script_path: /root/okta/odyssey/scripts
-    sort_order: "7"
+    sort_order: "10"
     timeout: "10"
 
   - name: "Test"
-    abort_commit_on_failure: true
     criteria: MERGE
     queue_name: ci-queue-productionJenga-AL2023
     script_name: unit-test
@@ -83,7 +76,6 @@ test_suites:
     timeout: "20"
 
   - name: "Typecheck"
-    abort_commit_on_failure: true
     criteria: MERGE
     queue_name: ci-queue-productionJenga-AL2023
     script_path: /root/okta/odyssey/scripts
@@ -98,7 +90,6 @@ test_suites:
     timeout: "20"
 
   - name: "Visual Regression Test"
-    abort_commit_on_failure: true
     criteria: MERGE
     queue_name: ci-queue-productionJenga-AL2023
     script_name: visual-regression-test

--- a/packages/odyssey-storybook/.storybook/main.ts
+++ b/packages/odyssey-storybook/.storybook/main.ts
@@ -22,7 +22,6 @@ const getAbsolutePath = (value: string): any => {
 };
 
 const config: StorybookConfig = {
-  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
   addons: [
     {
       name: "@storybook/addon-docs",
@@ -37,10 +36,17 @@ const config: StorybookConfig = {
     getAbsolutePath("@storybook/addon-mdx-gfm"),
     getAbsolutePath("storybook-addon-rtl-direction"),
   ],
+  core: {
+    disableTelemetry: true,
+  },
+  docs: {
+    autodocs: true,
+  },
   framework: {
     name: getAbsolutePath("@storybook/react-vite"),
     options: {},
   },
+  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
   typescript: {
     check: false,
     reactDocgen: "react-docgen-typescript",
@@ -54,9 +60,6 @@ const config: StorybookConfig = {
         );
       },
     },
-  },
-  docs: {
-    autodocs: true,
   },
 };
 

--- a/packages/odyssey-storybook/applitools.config.js
+++ b/packages/odyssey-storybook/applitools.config.js
@@ -41,7 +41,7 @@ const applitoolsConfig = {
   saveNewTests: true,
   serverUrl: "https://oktaeyes.applitools.com",
   testConcurrency: 20,
-  waitBeforeCapture: 1000,
+  waitBeforeCapture: 2000,
 };
 
 module.exports = applitoolsConfig;

--- a/packages/odyssey-storybook/applitools.config.js
+++ b/packages/odyssey-storybook/applitools.config.js
@@ -11,7 +11,10 @@
  */
 
 const branchName = process.env.CURRENT_BRANCH_NAME;
-const parentBranchName = process.env.BASE_BRANCH_NAME ?? "main";
+const parentBranchName =
+  process.env.BASE_BRANCH_NAME === "null" || !process.env.BASE_BRANCH_NAME
+    ? "main"
+    : process.env.BASE_BRANCH_NAME;
 const commitHash = process.env.SHA;
 
 const applitoolsConfig = {

--- a/packages/odyssey-storybook/applitools.config.js
+++ b/packages/odyssey-storybook/applitools.config.js
@@ -10,11 +10,9 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-const branchName =
-  process.env.GITHUB_HEAD_REF ?? process.env.CURRENT_BRANCH_NAME;
-const parentBranchName =
-  process.env.GITHUB_BASE_REF ?? process.env.BASE_BRANCH_NAME ?? "main";
-const commitHash = process.env.GITHUB_SHA ?? process.env.SHA;
+const branchName = process.env.CURRENT_BRANCH_NAME;
+const parentBranchName = process.env.BASE_BRANCH_NAME ?? "main";
+const commitHash = process.env.SHA;
 
 const applitoolsConfig = {
   accessibilityValidation: {
@@ -37,8 +35,10 @@ const applitoolsConfig = {
     headless: true,
   },
   runInDocker: true,
+  saveNewTests: true,
   serverUrl: "https://oktaeyes.applitools.com",
   testConcurrency: 20,
+  waitBeforeCapture: 1000,
 };
 
 module.exports = applitoolsConfig;


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[OKTA-756835](https://oktainc.atlassian.net/browse/OKTA-756835)

## Summary

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->
Applitools is having inconsistent runs since moving to Bacon. This PR adds a 2 second delay which should fix our consistently issues.

I removed any hint of GITHUB env vars and even fixed a bug where `main` wasn't used for the branch name if no PR existed when running Bacon.

Lastly, stopped one failed test from aborting others in Bacon.

## Testing & Screenshots

<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->

This worked in my testing on Bacon both locally and on this branch. Without making new branches, it's hard to test, but others have reported it fixing these issues for them as well.
