### PR TITLE
build: adds Git hash to Storybook package

### DIFF
--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -24,7 +24,7 @@ git checkout .
 # All packages are built by `prepack`.
 
 # update version with commit SHA to allow lerna to publish
-FILES_TO_UPDATE_VERSION="lerna.json packages/odyssey-design-tokens/package.json packages/odyssey-babel-preset/package.json packages/odyssey-babel-loader/package.json packages/odyssey-react-mui/package.json packages/browserslist-config-odyssey/package.json"
+FILES_TO_UPDATE_VERSION="lerna.json packages/odyssey-design-tokens/package.json packages/odyssey-babel-preset/package.json packages/odyssey-babel-loader/package.json packages/odyssey-react-mui/package.json packages/browserslist-config-odyssey/package.json packages/odyssey-storybook/package.json"
 for PATH_AND_FILE in $FILES_TO_UPDATE_VERSION; do
   FULL_PATH="$OKTA_HOME/$REPO/$PATH_AND_FILE"
   json_contents="$(jq '.version = "'$TAGGED_VERSION'"' $FULL_PATH)" && \


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[OKTA-737450](https://oktainc.atlassian.net/browse/OKTA-737450)

## Summary

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->
Our Storybook topic deploy is missing the hash other packages have. This PR adds it as another hashed package.

## Testing & Screenshots

<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
Passing Bacon CI is the test as this is a Bacon task. I verified by looking at Artifactory for the package.