### PR TITLE
feat: add additional buttons and action menu items to tables

### DIFF
--- a/packages/odyssey-react-mui/src/DataTable/DataTable.tsx
+++ b/packages/odyssey-react-mui/src/DataTable/DataTable.tsx
@@ -103,6 +103,14 @@ export type DataTableRenderDetailPanelType = {
 
 export type DataTableProps = {
   /**
+   * An optional action button above the table.
+   */
+  additionalActionButton?: ReactNode;
+  /**
+   * MenuItems that go in an optional action menu above the table.
+   */
+  additionalActionMenuItems?: ReactNode;
+  /**
    * Menu items to include in the bulk actions menu, which appears above the table if a row or rows are selected
    */
   bulkActionMenuItems?: (
@@ -314,6 +322,8 @@ const ScrollableTableContainer = styled("div", {
 );
 
 const DataTable = ({
+  additionalActionButton,
+  additionalActionMenuItems,
   bulkActionMenuItems,
   columns,
   currentPage = 1,
@@ -876,7 +886,9 @@ const DataTable = ({
         hasFilters ||
         hasChangeableDensity ||
         hasColumnVisibility ||
-        bulkActionMenuItems) && (
+        bulkActionMenuItems ||
+        additionalActionButton ||
+        additionalActionMenuItems) && (
         <Box sx={{ marginBottom: 5 }}>
           <DataFilters
             onChangeSearch={hasSearch ? setSearch : undefined}
@@ -898,6 +910,17 @@ const DataTable = ({
                   setColumnVisibility={setColumnVisibility}
                 />
                 {bulkActionMenuItems && bulkActionMenuButton}
+                {additionalActionMenuItems && (
+                  <MenuButton
+                    endIcon={<MoreIcon />}
+                    ariaLabel={t("table.moreactions.arialabel")}
+                    buttonVariant="secondary"
+                    menuAlignment="right"
+                  >
+                    {additionalActionMenuItems}
+                  </MenuButton>
+                )}
+                {additionalActionButton}
               </>
             }
           />

--- a/packages/odyssey-react-mui/src/labs/DataComponents/DataTable.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataComponents/DataTable.tsx
@@ -18,6 +18,8 @@ import { TableProps, UniversalProps } from "./componentTypes";
 export type DataTableProps = UniversalProps & TableProps;
 
 const DataTable = ({
+  additionalActionButton,
+  additionalActionMenuItems,
   bulkActionMenuItems,
   columns,
   currentPage,
@@ -80,6 +82,8 @@ const DataTable = ({
 
   return (
     <DataView
+      additionalActionButton={additionalActionButton}
+      additionalActionMenuItems={additionalActionMenuItems}
       availableLayouts={["table"]}
       bulkActionMenuItems={bulkActionMenuItems}
       currentPage={currentPage}

--- a/packages/odyssey-react-mui/src/labs/DataComponents/DataView.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataComponents/DataView.tsx
@@ -46,6 +46,8 @@ import {
   useOdysseyDesignTokens,
 } from "../../OdysseyDesignTokensContext";
 import styled from "@emotion/styled";
+import { MenuButton } from "../..";
+import { MoreIcon } from "../../icons.generated";
 
 export type DataViewProps = UniversalProps & ViewProps<DataLayout>;
 
@@ -68,6 +70,8 @@ const AdditionalActionsContainer = styled("div")(() => ({
 }));
 
 const DataView = ({
+  additionalActionButton,
+  additionalActionMenuItems,
   availableLayouts = allAvailableLayouts,
   bulkActionMenuItems,
   currentPage = 1,
@@ -142,7 +146,11 @@ const DataView = ({
     rowDensity: tableOptions?.initialDensity ?? densityValues[0],
   });
 
-  const shouldShowFilters = hasSearch || hasFilters;
+  const shouldShowFilters =
+    hasSearch ||
+    hasFilters ||
+    additionalActionButton ||
+    additionalActionMenuItems;
 
   const availableFilters = useFilterConversion({
     filters: filters,
@@ -272,9 +280,30 @@ const DataView = ({
             setCurrentLayout={setCurrentLayout}
           />
         )}
+
+        {additionalActionButton}
+
+        {additionalActionMenuItems && (
+          <MenuButton
+            endIcon={<MoreIcon />}
+            ariaLabel={t("table.moreactions.arialabel")}
+            buttonVariant="secondary"
+            menuAlignment="right"
+          >
+            {additionalActionMenuItems}
+          </MenuButton>
+        )}
       </>
     ),
-    [currentLayout, tableOptions, tableState, availableLayouts],
+    [
+      currentLayout,
+      tableOptions,
+      tableState,
+      availableLayouts,
+      additionalActionButton,
+      additionalActionMenuItems,
+      t,
+    ],
   );
 
   const { lastRow: lastRowOnPage } = usePagination({

--- a/packages/odyssey-react-mui/src/labs/DataComponents/componentTypes.ts
+++ b/packages/odyssey-react-mui/src/labs/DataComponents/componentTypes.ts
@@ -40,6 +40,8 @@ export type AvailableLayouts = DataLayout[];
 export type AvailableStackLayouts = StackLayout[];
 
 export type UniversalProps = {
+  additionalActionButton?: ReactNode;
+  additionalActionMenuItems?: ReactNode;
   bulkActionMenuItems?: (
     selectedRows: MRT_RowSelectionState,
   ) => MenuButtonProps["children"];

--- a/packages/odyssey-storybook/src/components/odyssey-labs/DataComponents/DataComponents.mdx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/DataComponents/DataComponents.mdx
@@ -416,6 +416,11 @@ const onReorderRows = useCallback(
 
 ## Additional Features
 
+### Additional action buttons and menu items
+
+Using `additionalActionButton` and `additionalActionMenuItems`, you can provide additional actions that sit at the top of the `DataView`. This is
+perfect for things like an "Add row" button or a menu of actions that affect the entire table or list.
+
 ### Bulk Actions Menu
 
 When row selection is enabled, you can provide bulk actions that apply to all selected rows:

--- a/packages/odyssey-storybook/src/components/odyssey-labs/DataComponents/DataComponents.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/DataComponents/DataComponents.stories.tsx
@@ -62,6 +62,8 @@ type DataViewMetaProps = DataViewProps &
     hasCustomNoResultsPlaceholder: boolean;
     hasActionMenuItems: boolean;
     hasActionButtons: boolean;
+    hasAdditionalActionButton: boolean;
+    hasAdditionalActionMenuItems: boolean;
   };
 
 const storybookMeta: Meta<DataViewMetaProps> = {
@@ -244,6 +246,14 @@ const storybookMeta: Meta<DataViewMetaProps> = {
       control: "boolean",
       name: "[STORY ONLY] Has action buttons in table view?",
     },
+    hasAdditionalActionButton: {
+      control: "boolean",
+      name: "[STORY ONLY] Has additional action button?",
+    },
+    hasAdditionalActionMenuItems: {
+      control: "boolean",
+      name: "[STORY ONLY] Has additional action menu items?",
+    },
   },
   args: {
     currentPage: 1,
@@ -297,6 +307,15 @@ const actionMenuItems = (selectedRows: DataRowSelectionState) => (
   <>
     <MenuItem onClick={() => console.log(selectedRows)}>Action 1</MenuItem>
     <MenuItem onClick={() => console.log(selectedRows)}>Action 2</MenuItem>
+  </>
+);
+
+const additionalActionButton = <Button variant="primary" label="Add widget" />;
+
+const additionalActionMenuItems = (
+  <>
+    <MenuItem onClick={() => console.log("Action 1")}>Action 1</MenuItem>
+    <MenuItem onClick={() => console.log("Action 2")}>Action 2</MenuItem>
   </>
 );
 
@@ -384,6 +403,14 @@ const BaseStory: StoryObj<DataViewMetaProps> = {
         paginationType={args.paginationType}
         resultsPerPage={args.resultsPerPage}
         totalRows={args.totalRows}
+        additionalActionButton={
+          args.hasAdditionalActionButton ? additionalActionButton : undefined
+        }
+        additionalActionMenuItems={
+          args.hasAdditionalActionMenuItems
+            ? additionalActionMenuItems
+            : undefined
+        }
         hasFilters={args.hasFilters}
         hasSearch={args.hasSearch}
         hasSearchSubmitButton={args.hasSearchSubmitButton}
@@ -475,6 +502,8 @@ export const Everything: StoryObj<DataViewMetaProps> = {
     hasActionButtons: true,
     hasActionMenuItems: true,
     hasRowSelection: true,
+    hasAdditionalActionButton: true,
+    hasAdditionalActionMenuItems: true,
   },
 };
 
@@ -491,6 +520,14 @@ export const DataTableComponent: StoryObj<DataViewMetaProps> = {
         getData={getData}
         onReorderRows={onReorderRows}
         onChangeRowSelection={onChangeRowSelection}
+        additionalActionButton={
+          args.hasAdditionalActionButton ? additionalActionButton : undefined
+        }
+        additionalActionMenuItems={
+          args.hasAdditionalActionMenuItems
+            ? additionalActionMenuItems
+            : undefined
+        }
         bulkActionMenuItems={
           args.hasActionMenuItems ? actionMenuItems : undefined
         }

--- a/packages/odyssey-storybook/src/components/odyssey-mui/DataTable/DataTable.mdx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/DataTable/DataTable.mdx
@@ -422,6 +422,11 @@ Action buttons and menu items can be added to each row. If rows are selectable, 
 which will be applied to all selected rows. (For example, the bulk actions menu starts out disabled, but if the user selects 3 rows,
 the actions menu will be enabled and any actions performed would be applied to all 3 selected rows.)
 
+### Additional action buttons and menu items
+
+Using `additionalActionButton` and `additionalActionMenuItems`, you can provide additional actions that sit at the top of the `DataView`. This is
+perfect for things like an "Add row" button or a menu of actions that affect the entire table or list.
+
 ## Row details
 
 Rows can optionally expand down to reveal additional content, defined via the `renderDetailPanel` prop, which expects a function with two

--- a/packages/odyssey-storybook/src/components/odyssey-mui/DataTable/DataTable.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/DataTable/DataTable.stories.tsx
@@ -47,6 +47,25 @@ const storybookMeta: Meta<DataTableProps> = {
   title: "MUI Components/DataTable",
   component: DataTable,
   argTypes: {
+    additionalActionButton: {
+      control: null,
+      description: "An optional action button above the table.",
+      table: {
+        type: {
+          summary: "ReactNode",
+        },
+      },
+    },
+    additionalActionMenuItems: {
+      control: null,
+      description:
+        "MenuItems that go in an optional action menu above the table.",
+      table: {
+        type: {
+          summary: "ReactNode",
+        },
+      },
+    },
     columns: {
       control: null,
       description: "The columns that make up the table.",
@@ -451,6 +470,15 @@ const reorderData = <T extends { id: string | number }>({
 
   return updatedData;
 };
+
+const additionalActionButton = <Button variant="primary" label="Add widget" />;
+
+const additionalActionMenuItems = (
+  <>
+    <MenuItem onClick={() => console.log("Action 1")}>Action 1</MenuItem>
+    <MenuItem onClick={() => console.log("Action 2")}>Action 2</MenuItem>
+  </>
+);
 
 export const Default: StoryObj<DataTableProps> = {
   args: {
@@ -1070,6 +1098,59 @@ export const ColumnGrowDemo: StoryObj<DataTableProps> = {
         columns={columns}
         getData={getData}
         rowActionMenuItems={actionMenuItems}
+      />
+    );
+  },
+};
+
+export const AdditionalActions: StoryObj<DataTableProps> = {
+  args: {
+    hasChangeableDensity: true,
+    hasColumnResizing: true,
+    hasColumnVisibility: false,
+    hasFilters: true,
+    hasPagination: false,
+    hasRowSelection: true,
+    hasSearch: true,
+    hasSorting: true,
+    hasRowReordering: false,
+  },
+  render: function C(props) {
+    const [data, setData] = useState<Planet[]>(planetData);
+
+    const getData = useCallback(
+      ({ ...props }: DataTableGetDataType) => {
+        return filterData({ data, ...props });
+      },
+      [data],
+    );
+
+    const onReorderRows = useCallback(
+      ({ ...props }: DataTableOnReorderRowsType) => {
+        const reorderedData = reorderData({ data, ...props });
+        setData(reorderedData);
+      },
+      [data],
+    );
+
+    const onChangeRowSelection = useCallback(
+      (rowSelection: DataTableRowSelectionState) => {
+        if (Object.keys(rowSelection).length > 0) {
+          console.log(`${Object.keys(rowSelection).length} selected`);
+        }
+      },
+      [],
+    );
+
+    return (
+      <DataTable
+        {...props}
+        additionalActionButton={additionalActionButton}
+        additionalActionMenuItems={additionalActionMenuItems}
+        columns={planetColumns}
+        getData={getData}
+        onReorderRows={onReorderRows}
+        onChangeRowSelection={onChangeRowSelection}
       />
     );
   },


### PR DESCRIPTION
By popular request (and to achieve parity with that first version of `DataTable`), this resurrects a feature that was lost as a regression.

Both `DataView` and `DataTable` now offer props for `additionalActionButton` and `additionalActionMenuItems`, which render arbitrary action button or menu items into the top of the component. This is intended for functionality like an "Add row" action or similar that should live on the table itself, not at the page-level.

<img width="401" alt="Screenshot 2024-08-15 at 12 31 52 PM" src="https://github.com/user-attachments/assets/ff7d9204-8eb5-4c75-8a53-f912061d5180">
