### PR TITLE
Fix virtual autocomplete height

### DIFF
--- a/packages/odyssey-react-mui/package.json
+++ b/packages/odyssey-react-mui/package.json
@@ -85,7 +85,6 @@
     "luxon": "^3.4.4",
     "material-react-table": "^2.11.3",
     "react-i18next": "^14.0.5",
-    "react-virtualized-auto-sizer": "^1.0.22",
     "react-window": "^1.8.10",
     "word-wrap": "^1.2.5"
   },

--- a/packages/odyssey-react-mui/src/Autocomplete.tsx
+++ b/packages/odyssey-react-mui/src/Autocomplete.tsx
@@ -375,16 +375,17 @@ const Autocomplete = <
      * we need to add it to each list item that is being rendered in the viewable list window.
      * @see here if you need to know more: https://github.com/bvaughn/react-window?tab=readme-ov-file#why-is-my-list-blank-when-i-scroll
      */
+    const styles = useMemo(
+      () => ({
+        ...style,
+        height: "auto",
+      }),
+      [style],
+    );
+
     return (
       <div ref={rowRef}>
-        <li
-          style={{
-            ...style,
-            height: "auto",
-          }}
-          key={key}
-          {...props}
-        />
+        <li {...props} key={key} style={styles} />
       </div>
     );
   };
@@ -397,13 +398,13 @@ const Autocomplete = <
   });
 
   const useResetCache = (length: number) => {
-    const ref = useRef<VariableSizeList>(null);
+    const resetCacheRef = useRef<VariableSizeList>(null);
     useEffect(() => {
-      if (ref.current) {
-        ref.current.resetAfterIndex(0, true);
+      if (resetCacheRef.current) {
+        resetCacheRef.current.resetAfterIndex(0, true);
       }
     }, [length]);
-    return ref;
+    return resetCacheRef;
   };
 
   const ListboxComponent = forwardRef<
@@ -426,7 +427,7 @@ const Autocomplete = <
 
       if (itemData.length > OVERSCAN_ROW_COUNT) {
         // has a max-height of 40vh set in CSS. This is only set because height needs to be a number
-        return 1000;
+        return 99999;
       } else {
         const itemsHeightCalculated = itemData
           .map((_, index) => sizeMap.current[index] || 0)

--- a/packages/odyssey-react-mui/src/Autocomplete.tsx
+++ b/packages/odyssey-react-mui/src/Autocomplete.tsx
@@ -422,7 +422,7 @@ const Autocomplete = <
 
     const getListBoxHeight = useCallback(() => {
       // 8px of padding top/bottom applied by MUI
-      const LISTBOX_PADDING = 8;
+      const COMBINED_LISTBOX_PADDING = 16;
 
       if (itemData.length > OVERSCAN_ROW_COUNT) {
         // has a max-height of 40vh set in CSS. This is only set because height needs to be a number
@@ -430,8 +430,11 @@ const Autocomplete = <
       } else {
         const itemsHeightCalculated = itemData
           .map((_, index) => sizeMap.current[index] || 0)
-          .reduce((a, b) => a + b, 0);
-        return LISTBOX_PADDING * 2 + itemsHeightCalculated;
+          .reduce(
+            (prevItemHeight, nextItemHeight) => prevItemHeight + nextItemHeight,
+            0,
+          );
+        return COMBINED_LISTBOX_PADDING + itemsHeightCalculated;
       }
     }, [itemData, sizeMap]);
 

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -486,7 +486,6 @@ export const components = ({
           background: "transparent",
           paddingBlockStart: odysseyTokens.Spacing1,
           ...(ownerState.ListboxComponent !== undefined && {
-            height: "100%",
             maxHeight: "40vh",
           }),
         }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -5293,7 +5293,6 @@ __metadata:
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     react-i18next: "npm:^14.0.5"
-    react-virtualized-auto-sizer: "npm:^1.0.22"
     react-window: "npm:^1.8.10"
     regenerator-runtime: "npm:^0.14.1"
     rimraf: "npm:^5.0.1"
@@ -22359,16 +22358,6 @@ __metadata:
     react: ">=16.6.0"
     react-dom: ">=16.6.0"
   checksum: 10/ca32d3fd2168c976c5d90a317f25d5f5cd723608b415fb3b9006f9d793c8965c619562d0884503a3e44e4b06efbca4fdd1520f30e58ca3e00a0890e637d55419
-  languageName: node
-  linkType: hard
-
-"react-virtualized-auto-sizer@npm:^1.0.22":
-  version: 1.0.24
-  resolution: "react-virtualized-auto-sizer@npm:1.0.24"
-  peerDependencies:
-    react: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0
-    react-dom: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0
-  checksum: 10/02101a340bdbe3e40c49dbc52e524eb7ca18832690e91f045a25675600d7adc0a63e800a4ace6a014132adcdcce0e12a8137971de408427a5a3112d7c87c9f3e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[OKTA-793324](https://oktainc.atlassian.net/browse/OKTA-793324)

## Summary
- Fix bug where listbox was too long in some cases
- Allow dynamic height autocomplete items
<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
