### PR TITLE
fix: select multioption not rendering text when you use an options object

### DIFF
--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -283,27 +283,31 @@ const Select = <
 
   // Normalize the options array to accommodate the various
   // data types that might be passed
-  const normalizedOptions = useMemo(
-    () =>
-      options.map((option) => {
-        if (typeof option === "object") {
-          /**
-           * If the value of `option?.value is an empty string, we need to make sure that we
-           * set an empty string to `value` in the normalized option so that the select component
-           * can potentially set it as the selected one in the text input
-           */
-          const value =
-            option?.value === "" ? option.value : option.value || option.text;
-          return {
-            text: option.text,
-            value,
-            type: option.type === "heading" ? "heading" : "option",
-          };
-        }
-        return { text: option, value: option, type: "option" };
-      }),
-    [options],
-  );
+  const [normalizedOptions, normalizedOptionsMap] = useMemo(() => {
+    const normalizedOptions = options.map((option) => {
+      if (typeof option === "object") {
+        /**
+         * If the value of `option?.value is an empty string, we need to make sure that we
+         * set an empty string to `value` in the normalized option so that the select component
+         * can potentially set it as the selected one in the text input
+         */
+        const value =
+          option?.value === "" ? option.value : option.value || option.text;
+        return {
+          text: option.text,
+          value,
+          type: option.type === "heading" ? "heading" : "option",
+        };
+      }
+
+      return { text: option, value: option, type: "option" };
+    });
+
+    const normalizedOptionsMap = new Map(
+      normalizedOptions.map((option) => [option.value, option]),
+    );
+    return [normalizedOptions, normalizedOptionsMap];
+  }, [options]);
 
   const removeSelectedValue = useCallback(
     (selectedValue: string) => {
@@ -331,7 +335,6 @@ const Select = <
         !isInteractive &&
         controlledStateRef.current === CONTROLLED &&
         hasMultipleChoices;
-
       return (
         Array.isArray(internalSelectedValues) && (
           <ChipsInnerContainer
@@ -345,7 +348,7 @@ const Select = <
                     key={item}
                     label={
                       <>
-                        {item}
+                        {normalizedOptionsMap.get(item)?.text}
                         {hasNonInteractiveIcon && (
                           <NonInteractiveIcon
                             odysseyDesignTokens={odysseyDesignTokens}
@@ -381,6 +384,7 @@ const Select = <
       internalSelectedValues,
       odysseyDesignTokens,
       removeSelectedValue,
+      normalizedOptionsMap,
     ],
   );
 

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Select/Select.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Select/Select.stories.tsx
@@ -313,6 +313,23 @@ export const OptionsObject: StoryObj<typeof Select> = {
   },
 };
 
+export const OptionsObjectAndMultiSelect: StoryObj<typeof Select> = {
+  args: {
+    options: optionsObject,
+    value: [],
+    hasMultipleChoices: true,
+  },
+  render: function C(props) {
+    const [localValue, setLocalValue] = useState<string[]>([]);
+    const onChange = useCallback(
+      (event: SelectChangeEvent<string | string[]>) =>
+        setLocalValue(event.target.value as string[]),
+      [],
+    );
+    return <Select {...props} value={localValue} onChange={onChange} />;
+  },
+};
+
 export const OptionsGrouped: StoryObj<typeof Select> = {
   args: {
     options: optionsGrouped,
@@ -442,32 +459,6 @@ export const ControlledEmptyValue: StoryObj<typeof Select> = {
     const onChange = useCallback(
       (event: SelectChangeEvent<string | string[]>) =>
         setLocalValue(event.target.value as string),
-      [],
-    );
-    return <Select {...props} value={localValue} onChange={onChange} />;
-  },
-};
-
-export const ControlledPreselectedMultipleSelectOptionsObject: StoryObj<
-  typeof Select
-> = {
-  parameters: {
-    docs: {
-      description: {
-        story: "Select with multiselect & options is bugged",
-      },
-    },
-  },
-  args: {
-    options: optionsObject,
-    value: [],
-    hasMultipleChoices: true,
-  },
-  render: function C(props) {
-    const [localValue, setLocalValue] = useState<string[]>([]);
-    const onChange = useCallback(
-      (event: SelectChangeEvent<string | string[]>) =>
-        setLocalValue(event.target.value as string[]),
       [],
     );
     return <Select {...props} value={localValue} onChange={onChange} />;

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Select/Select.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Select/Select.stories.tsx
@@ -447,3 +447,29 @@ export const ControlledEmptyValue: StoryObj<typeof Select> = {
     return <Select {...props} value={localValue} onChange={onChange} />;
   },
 };
+
+export const ControlledPreselectedMultipleSelectOptionsObject: StoryObj<
+  typeof Select
+> = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Select with multiselect & options is bugged",
+      },
+    },
+  },
+  args: {
+    options: optionsObject,
+    value: [],
+    hasMultipleChoices: true,
+  },
+  render: function C(props) {
+    const [localValue, setLocalValue] = useState<string[]>([]);
+    const onChange = useCallback(
+      (event: SelectChangeEvent<string | string[]>) =>
+        setLocalValue(event.target.value as string[]),
+      [],
+    );
+    return <Select {...props} value={localValue} onChange={onChange} />;
+  },
+};


### PR DESCRIPTION


[OKTA-795183](https://oktainc.atlassian.net/browse/OKTA-795183)

Previously: 
![image](https://github.com/user-attachments/assets/2ad05cbb-7e32-4042-8ceb-6d95194c4c1f)


Now:
![image](https://github.com/user-attachments/assets/cca342cd-734d-403e-a492-3ad987321bb5)
