### PR TITLE
Fix DataTable scroll hook

### DIFF
--- a/packages/odyssey-react-mui/src/DataTable/useScrollIndication.tsx
+++ b/packages/odyssey-react-mui/src/DataTable/useScrollIndication.tsx
@@ -79,8 +79,8 @@ export const useScrollIndication = ({
       }, 100); // debounce delay
     });
 
-    if (tableOuterContainer) {
-      resizeObserverRef.current.observe(tableOuterContainer);
+    if (tableOuterContainer && tableOuterContainer.parentElement) {
+      resizeObserverRef.current.observe(tableOuterContainer.parentElement);
     }
 
     return () => {


### PR DESCRIPTION
https://github.com/user-attachments/assets/2cf1a4b6-4cbf-4419-b60d-c8fef2bda4cb

The problem: Due to how the scroll overflow works, we use JS to detect the size of the table's wrapper div and then pass that size to the table itself. This works fine most of the time, but when its container doesn't have a set width, it can get into a weird state where it keeps modifying its width slightly, which triggers the resize observer, which modifies its width slightly, which triggers the resize observer... over and over again.

The solution: Have it observe the table wrapper's parent, instead of the table wrapper itself.