### PR TITLE
feat: add Card variant

### DIFF
--- a/packages/odyssey-react-mui/src/Card.tsx
+++ b/packages/odyssey-react-mui/src/Card.tsx
@@ -47,11 +47,19 @@ export type CardProps = {
       onClick: MouseEventHandler;
       button?: never;
       menuButtonChildren?: never;
+      onClickMenuButton?: never;
     }
   | {
       onClick?: never;
       button?: ReactElement<typeof Button>;
       menuButtonChildren?: MenuButtonProps["children"];
+      onClickMenuButton?: never;
+    }
+  | {
+      onClick?: MouseEventHandler;
+      button?: never;
+      menuButtonChildren?: never;
+      onClickMenuButton: MouseEventHandler;
     }
 );
 
@@ -89,6 +97,7 @@ const Card = ({
   image,
   menuButtonChildren,
   onClick,
+  onClickMenuButton,
   overline,
   title,
 }: CardProps) => {
@@ -142,7 +151,7 @@ const Card = ({
         cardContent
       )}
 
-      {menuButtonChildren && (
+      {(menuButtonChildren || onClickMenuButton) && (
         <MenuButtonContainer odysseyDesignTokens={odysseyDesignTokens}>
           <MenuButton
             endIcon={<MoreIcon />}
@@ -151,6 +160,7 @@ const Card = ({
             menuAlignment="right"
             size="small"
             tooltipText="Actions"
+            onClickMenuButton={onClickMenuButton}
           >
             {menuButtonChildren}
           </MenuButton>

--- a/packages/odyssey-react-mui/src/MenuButton.tsx
+++ b/packages/odyssey-react-mui/src/MenuButton.tsx
@@ -71,6 +71,10 @@ export type MenuButtonProps = {
    * The tooltip text for the Button if it's icon-only
    */
   tooltipText?: string;
+  /**
+   * The event handler if the menu button is clickable.
+   */
+  onClickMenuButton?: React.MouseEventHandler<HTMLButtonElement>;
 } & Pick<
   HtmlProps,
   "ariaDescribedBy" | "ariaLabel" | "ariaLabelledBy" | "testId" | "translate"
@@ -105,6 +109,7 @@ const MenuButton = ({
   testId,
   tooltipText,
   translate,
+  onClickMenuButton,
 }: MenuButtonProps) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
@@ -115,6 +120,10 @@ const MenuButton = ({
   }, []);
 
   const openMenu = useCallback<MenuContextType["openMenu"]>((event) => {
+    if (onClickMenuButton) {
+      onClickMenuButton(event as React.MouseEvent<HTMLButtonElement>);
+      return;
+    }
     setAnchorEl(event.currentTarget);
   }, []);
 

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Card/Card.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Card/Card.stories.tsx
@@ -199,3 +199,18 @@ export const ButtonWithoutImage: StoryObj<typeof Card> = {
     </Box>
   ),
 };
+
+export const ClickableMenu: StoryObj<CardProps> = {
+  render: ({ ...props }) => (
+    <Box sx={{ maxWidth: 262 }}>
+      <Card
+        {...props}
+        overline={props.overline}
+        title={props.title}
+        description={props.description}
+        onClickMenuButton={() => alert("Clicked on menu")}
+        onClick={() => alert("Clicked on Card")}
+      />
+    </Box>
+  ),
+};


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[OKTA-794818](https://oktainc.atlassian.net/browse/OKTA-794818)

## Summary
- Add a new variant of the Card component
- This new Card variant is to match the behaviours of the existing card/tile on enduser dashboard page
- Existing behaviours on enduser dashboard:
  - click on the card to open the application or "Sign In To App" dialog if password is required
  - click on the menu button (`...` at the top right corner) to open the side drawer
<img width="1468" alt="Screenshot 2024-08-27 at 11 41 51 AM" src="https://github.com/user-attachments/assets/14fe5d84-0e2e-4d44-bf71-9e528e3d287a">


<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
