### PR TITLE
feat: adds new Shadow DOM export with better naming

### DIFF
--- a/packages/odyssey-react-mui/src/OdysseyCacheProvider.tsx
+++ b/packages/odyssey-react-mui/src/OdysseyCacheProvider.tsx
@@ -26,15 +26,19 @@ export type OdysseyCacheProviderProps = {
   /**
    * Emotion caches styles into the style element.
    * When enabling this prop, Emotion caches the styles at this element, rather than in <head>.
+   * @deprecated Use `EmotionRootElement` instead. This was incorrectly configured as an `HTMLStyleElement`, but then we're rendering `<style>` inside `<style>`. We need this to be a `<div>` instead.
    */
   emotionRoot?: HTMLStyleElement;
+  /**
+   * Emotion adds `<style>` elements into this DOM node. Normally, Emotion puts these in `document.head`.
+   * This is useful if you want to render into a Shadow DOM or iframe.
+   */
+  emotionRootElement?: HTMLElement;
   hasShadowDom?: boolean;
   nonce?: string;
   /**
    * Emotion renders into this HTML element.
    * When enabling this prop, Emotion renders at the top of this component rather than the bottom like it does in the HTML `<head>`.
-   */
-  /**
    * @deprecated Will be removed in a future Odyssey version. Use `hasShadowDomElement` instead.
    */
   shadowDomElement?: HTMLDivElement | HTMLElement;
@@ -44,6 +48,7 @@ export type OdysseyCacheProviderProps = {
 const OdysseyCacheProvider = ({
   children,
   emotionRoot,
+  emotionRootElement,
   hasShadowDom: hasShadowDomProp,
   nonce,
   shadowDomElement,
@@ -55,14 +60,23 @@ const OdysseyCacheProvider = ({
 
   const emotionCache = useMemo(() => {
     return createCache({
-      ...(emotionRoot && { container: emotionRoot }),
+      ...((emotionRootElement || emotionRoot) && {
+        container: emotionRootElement || emotionRoot,
+      }),
       key: uniqueAlphabeticalId,
       nonce: nonce ?? window.cspNonce,
       prepend: true,
       speedy: hasShadowDom ? false : true, // <-- Needs to be set to false when shadow-dom is used!! https://github.com/emotion-js/emotion/issues/2053#issuecomment-713429122
       ...(stylisPlugins && { stylisPlugins }),
     });
-  }, [emotionRoot, hasShadowDom, nonce, stylisPlugins, uniqueAlphabeticalId]);
+  }, [
+    emotionRoot,
+    emotionRootElement,
+    hasShadowDom,
+    nonce,
+    stylisPlugins,
+    uniqueAlphabeticalId,
+  ]);
 
   return <CacheProvider value={emotionCache}>{children}</CacheProvider>;
 };

--- a/packages/odyssey-react-mui/src/OdysseyProvider.tsx
+++ b/packages/odyssey-react-mui/src/OdysseyProvider.tsx
@@ -39,7 +39,9 @@ const OdysseyProvider = <SupportedLanguages extends string>({
   children,
   designTokensOverride,
   emotionRoot,
+  emotionRootElement,
   shadowDomElement,
+  shadowRootElement,
   languageCode,
   nonce,
   stylisPlugins,
@@ -47,14 +49,15 @@ const OdysseyProvider = <SupportedLanguages extends string>({
   translationOverrides,
 }: OdysseyProviderProps<SupportedLanguages>) => (
   <OdysseyCacheProvider
-    nonce={nonce}
     emotionRoot={emotionRoot}
-    hasShadowDom={Boolean(shadowDomElement)}
+    emotionRootElement={emotionRootElement}
+    hasShadowDom={Boolean(shadowRootElement || shadowDomElement)}
+    nonce={nonce}
     stylisPlugins={stylisPlugins}
   >
     <OdysseyThemeProvider
       designTokensOverride={designTokensOverride}
-      shadowDomElement={shadowDomElement}
+      shadowRootElement={shadowRootElement || shadowDomElement}
       themeOverride={themeOverride}
     >
       <ScopedCssBaseline>

--- a/packages/odyssey-react-mui/src/OdysseyThemeProvider.tsx
+++ b/packages/odyssey-react-mui/src/OdysseyThemeProvider.tsx
@@ -25,7 +25,9 @@ import { OdysseyDesignTokensContext } from "./OdysseyDesignTokensContext";
 export type OdysseyThemeProviderProps = {
   children: ReactNode;
   designTokensOverride?: DesignTokensOverride;
+  /** @deprecated Use `shadowRootElement` instead. */
   shadowDomElement?: HTMLDivElement | HTMLElement | undefined;
+  shadowRootElement?: HTMLDivElement | HTMLElement;
   themeOverride?: ThemeOptions;
 };
 
@@ -38,19 +40,21 @@ const OdysseyThemeProvider = ({
   children,
   designTokensOverride,
   shadowDomElement,
+  shadowRootElement,
   themeOverride,
 }: OdysseyThemeProviderProps) => {
   const odysseyTokens = useMemo(
     () => ({ ...Tokens, ...designTokensOverride }),
     [designTokensOverride],
   );
+
   const odysseyTheme = useMemo(
     () =>
       createOdysseyMuiTheme({
         odysseyTokens,
-        shadowDomElement,
+        shadowRootElement: shadowRootElement || shadowDomElement,
       }),
-    [odysseyTokens, shadowDomElement],
+    [odysseyTokens, shadowDomElement, shadowRootElement],
   );
 
   const customOdysseyTheme = useMemo(

--- a/packages/odyssey-react-mui/src/createShadowDomElements.ts
+++ b/packages/odyssey-react-mui/src/createShadowDomElements.ts
@@ -10,22 +10,41 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+export const createShadowDomElements = (containerElement: HTMLElement) => {
+  const shadowRoot = containerElement.attachShadow({ mode: "open" });
+
+  // Container for Emotion `<style>` elements.
+  const emotionRootElement = document.createElement("div");
+  emotionRootElement.setAttribute("id", "style-root");
+  emotionRootElement.setAttribute("nonce", window.cspNonce);
+
+  // React app root component.
+  const shadowRootElement = document.createElement("div");
+  shadowRootElement.setAttribute("id", "shadow-root");
+
+  shadowRoot.appendChild(emotionRootElement);
+  shadowRoot.appendChild(shadowRootElement);
+
+  return { emotionRootElement, shadowRootElement };
+};
+
+/** @deprecated Use `createShadowDomElements` instead. */
 export const createShadowRootElement = (
   containerElement: HTMLElement,
 ): [HTMLStyleElement, HTMLDivElement] => {
   const shadowRoot = containerElement.attachShadow({ mode: "open" });
 
   // the element that styles will be cached into
-  const emotionRoot = document.createElement("style");
-  emotionRoot.setAttribute("id", "style-root");
-  emotionRoot.setAttribute("nonce", window.cspNonce);
+  const emotionRootElement = document.createElement("style");
+  emotionRootElement.setAttribute("id", "style-root");
+  emotionRootElement.setAttribute("nonce", window.cspNonce);
 
   // the element that emotion renders html into
   const shadowRootElement = document.createElement("div");
   shadowRootElement.setAttribute("id", "shadow-root");
 
-  shadowRoot.appendChild(emotionRoot);
+  shadowRoot.appendChild(emotionRootElement);
   shadowRoot.appendChild(shadowRootElement);
 
-  return [emotionRoot, shadowRootElement];
+  return [emotionRootElement, shadowRootElement];
 };

--- a/packages/odyssey-react-mui/src/index.ts
+++ b/packages/odyssey-react-mui/src/index.ts
@@ -69,7 +69,7 @@ export * from "./Checkbox";
 export * from "./CheckboxGroup";
 export * from "./CircularProgress";
 export * from "./CssBaseline";
-export * from "./createShadowRootElement";
+export * from "./createShadowDomElements";
 export * from "./createUniqueId";
 export * from "./DataTable";
 export * from "./Dialog";

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -62,9 +62,12 @@ const drawerSizes = {
 export const components = ({
   odysseyTokens,
   shadowDomElement,
+  shadowRootElement,
 }: {
   odysseyTokens: DesignTokens;
+  /** @deprecated use `shadowRootElement` */
   shadowDomElement?: HTMLElement;
+  shadowRootElement?: HTMLElement;
 }): ThemeOptions["components"] => {
   return {
     MuiAccordion: {
@@ -2222,7 +2225,7 @@ export const components = ({
     },
     MuiModal: {
       defaultProps: {
-        container: shadowDomElement,
+        container: shadowRootElement || shadowDomElement,
       },
     },
     MuiNativeSelect: {
@@ -2262,7 +2265,7 @@ export const components = ({
     },
     MuiPopover: {
       defaultProps: {
-        container: shadowDomElement,
+        container: shadowRootElement || shadowDomElement,
       },
       styleOverrides: {
         paper: {
@@ -2275,7 +2278,7 @@ export const components = ({
     },
     MuiPopper: {
       defaultProps: {
-        container: shadowDomElement,
+        container: shadowRootElement || shadowDomElement,
       },
     },
     MuiRadio: {

--- a/packages/odyssey-react-mui/src/theme/createOdysseyMuiTheme.ts
+++ b/packages/odyssey-react-mui/src/theme/createOdysseyMuiTheme.ts
@@ -30,14 +30,17 @@ export type DesignTokensOverride = Partial<typeof Tokens>;
 export const createOdysseyMuiTheme = ({
   odysseyTokens,
   shadowDomElement,
+  shadowRootElement,
 }: {
   odysseyTokens: DesignTokens;
+  /** @deprecated Use `shadowRootElement` */
   shadowDomElement?: HTMLElement;
+  shadowRootElement?: HTMLElement;
 }) =>
   createTheme({
     components: components({
       odysseyTokens,
-      shadowDomElement,
+      shadowRootElement: shadowRootElement || shadowDomElement,
     }),
     mixins: mixins({ odysseyTokens }),
     palette: palette({ odysseyTokens }),

--- a/packages/odyssey-storybook/src/installation/ShadowDom.mdx
+++ b/packages/odyssey-storybook/src/installation/ShadowDom.mdx
@@ -2,47 +2,46 @@ import { Meta } from "@storybook/blocks";
 
 <Meta title="Installation/Shadow DOM" />
 
-# Shadow DOM with Odyssey
+# Shadow DOM
+
+## Using a Shadow DOM with Odyssey
 
 Sometimes, you may need to sandbox your application's styles so Odyssey components show up correctly in other applications. This typically happens when other global styles are on the page.
 
 To sandbox your application's styles, you need to use a Shadow DOM. Odyssey natively supports the use of a Shadow DOM and even exports some helper functions.
 
-When creating the shadow root for your application, `createshadowDomElement` will return 2 elements in a tuple:
+When creating the shadow root for your application, `createShadowDomElements` will return 2 elements in an object:
 
 <dl>
   <dt>emotionRoot</dt>
-  <dd>A `style` node within the shadow root of the root node of your application. Emotion will cache styles here.</dd>
+  <dd>An element that holds Emotion's styles.</dd>
 
   <dt>shadowDomElementRoot</dt>
-  <dd>A `div` node within the shadow root of your root node of your application. React-DOM should use this to create a root to render your application to.</dd>
+  <dd>An element that is going to be the new root element React-DOM renders into.</dd>
 </dl>
 
-To create a Shadow DOM, simply use the `createshadowDomElement` function from Odyssey:
+To create a Shadow DOM, simply use the `createShadowDomElements` in your app's top-level file (typically `index.ts`):
 
 ```tsx
-import { createshadowDomElement } from "@okta/odyssey-react-mui";
+import { createShadowDomElements } from "@okta/odyssey-react-mui";
 
-const [emotionRoot, shadowDomElementRoot] = createshadowDomElement(
+const { emotionRootElement, shadowRootElement } = createShadowDomElements(
   document.querySelector("#root") as HTMLElement,
 );
-```
 
-Then render your React app into the Shadow DOM root element and pass it to Odyssey's top-level `OdysseyProvider` like so:
-
-```tsx
-ReactDOM.createRoot(shadowDomElementRoot).render(
+createRoot(shadowDomElementRoot).render(
   <OdysseyProvider
-    emotionRoot={emotionRoot}
-    shadowDomElement={shadowDomElementRoot}
+    emotionRootElement={emotionRootElement}
+    shadowRootElement={shadowRootElement}
   >
     <App />
   </OdysseyProvider>,
 );
 ```
 
-If you are using a shadow DOM and a separate Emotion Cache in your application for other CSS styles within your app, you will need to create an instance of `Emotion`
-and supply it a container reference to the created `emotionRoot` above:
+## Advanced Usage (Custom Emotion Cache)
+
+If you are using a shadow DOM and a separate Emotion Cache in your application for other CSS styles within your app, you'll need to create an instance of `Emotion` and supply it a container reference to the created `emotionRootElement` above:
 
 ```ts
 // utils.ts
@@ -52,18 +51,18 @@ and supply it a container reference to the created `emotionRoot` above:
 
 import createEmotion from "@emotion/css/create-instance";
 
-export const getCss = () => {
-  const { css } = createEmotion({
-    key: "css",
-    nonce: window.cspNonce,
-    speedy: false,
-    prepend: true,
+export const getEmotionCss = () => {
+  const { css: emotionCss } = createEmotion({
     container:
       document
         .querySelector("#root")
         ?.shadowRoot?.querySelector("#style-root") || undefined,
+    key: "css",
+    nonce: window.cspNonce,
+    prepend: true,
   });
-  return css;
+
+  return emotionCss;
 };
 ```
 
@@ -72,10 +71,10 @@ Then in your code, you can do something like:
 ```tsx
 // MyComponent.tsx
 
-import { getCss } from "./utils";
+import { getEmotionCss } from "./utils";
 
 export const MyComponent = () => {
-  const css = getCss();
+  const emotionCss = getEmotionCss();
 
   const componentStyle = css`
     backgroundcolor: white;
@@ -85,4 +84,4 @@ export const MyComponent = () => {
 };
 ```
 
-If you're using separate `OdysseyThemeProvider` and `OdysseyCacheProvider` components, both of those also take the `shadowDomElement` element.
+If you're using separate `OdysseyThemeProvider` and `OdysseyCacheProvider` components, both of those also take the `shadowRootElement` element.


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[OKTA-798986](https://oktainc.atlassian.net/browse/OKTA-798986)

## Summary

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

**Nothing is breaking.** All breaking changes were marked `@deprecated`.

Our Shadow DOM code nomenclature didn't make that much sense and wasn't consistent. Also, the return value was a tuple rather than an object with named props. I've updated it to be consistent throughout Odyssey including the documentation (which didn't match either).

We also had the issue of `<style>` tags from Emotion rendering into a global `<style>` tag. This should've been a `div` instead.

## Testing & Screenshots

- [x] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
