### PR TITLE
Fix useScrollIndication expansion issue

### DIFF
--- a/packages/odyssey-react-mui/src/DataTable/useScrollIndication.tsx
+++ b/packages/odyssey-react-mui/src/DataTable/useScrollIndication.tsx
@@ -17,6 +17,7 @@ import {
   useEffect,
   useRef,
 } from "react";
+import { useOdysseyDesignTokens } from "../OdysseyDesignTokensContext";
 
 type UseScrollIndicationProps = {
   tableOuterContainer: HTMLDivElement | null;
@@ -35,6 +36,8 @@ export const useScrollIndication = ({
   const animationFrameIdRef = useRef<number | null>(null);
 
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
+
+  const odysseyDesignTokens = useOdysseyDesignTokens();
 
   const checkScrollIndicators = useCallback(() => {
     if (!tableOuterContainer || !tableInnerContainer) return;
@@ -73,7 +76,7 @@ export const useScrollIndication = ({
 
         setTableInnerContainerWidth(
           tableInnerContainer?.clientWidth
-            ? `${tableInnerContainer.clientWidth}px`
+            ? `${tableInnerContainer.clientWidth - parseInt(odysseyDesignTokens.BorderWidthMain) * 2}px` // Account for the border on the outer container
             : "100%",
         );
       }, 100); // debounce delay
@@ -101,6 +104,7 @@ export const useScrollIndication = ({
     tableInnerContainer,
     setIsTableContainerScrolledToStart,
     setIsTableContainerScrolledToEnd,
+    odysseyDesignTokens.BorderWidthMain,
   ]);
 
   useEffect(() => {

--- a/packages/odyssey-react-mui/src/DataTable/useScrollIndication.tsx
+++ b/packages/odyssey-react-mui/src/DataTable/useScrollIndication.tsx
@@ -76,7 +76,7 @@ export const useScrollIndication = ({
 
         setTableInnerContainerWidth(
           tableInnerContainer?.clientWidth
-            ? `${tableInnerContainer.clientWidth - parseInt(odysseyDesignTokens.BorderWidthMain) * 2}px` // Account for the border on the outer container
+            ? `${tableInnerContainer.clientWidth - Number(odysseyDesignTokens.BorderWidthMain) * 2}px` // Account for the border on the outer container
             : "100%",
         );
       }, 100); // debounce delay


### PR DESCRIPTION
The fix in #2331 missed one crucial thing — we need to account for the table containers 2px of transparent borders. This PR addresses that, ensuring that if we make the inner width match the outer width, we don't accidentally push the outer width wider and wider until it expands beyond the bounds of the known universe.

From #2331:

https://github.com/user-attachments/assets/2cf1a4b6-4cbf-4419-b60d-c8fef2bda4cb

> The problem: Due to how the scroll overflow works, we use JS to detect the size of the table's wrapper div and then pass that size to the table itself. This works fine most of the time, but when its container doesn't have a set width, it can get into a weird state where it keeps modifying its width slightly, which triggers the resize observer, which modifies its width slightly, which triggers the resize observer... over and over again.

> The solution: Have it observe the table wrapper's parent, instead of the table wrapper itself.

