### PR TITLE
[DRAFT] Add BackgroundContext for gray background component theme changes

### DIFF
--- a/packages/odyssey-react-mui/src/BackgroundContext.tsx
+++ b/packages/odyssey-react-mui/src/BackgroundContext.tsx
@@ -1,0 +1,33 @@
+/*!
+ * Copyright (c) 2023-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { createContext, useContext, ReactNode } from "react";
+
+export type BackgroundType = "white" | "gray";
+
+const BackgroundContext = createContext<BackgroundType>("white");
+
+export const useBackground = () => useContext(BackgroundContext);
+
+export const BackgroundProvider = ({
+  value,
+  children,
+}: {
+  value: BackgroundType;
+  children: ReactNode;
+}) => (
+  <BackgroundContext.Provider value={value}>
+    {children}
+  </BackgroundContext.Provider>
+);
+
+export { BackgroundContext };

--- a/packages/odyssey-react-mui/src/BackgroundContext.tsx
+++ b/packages/odyssey-react-mui/src/BackgroundContext.tsx
@@ -12,9 +12,9 @@
 
 import { createContext, useContext, ReactNode } from "react";
 
-export type BackgroundType = "white" | "gray";
+export type BackgroundType = "highContrast" | "lowContrast";
 
-const BackgroundContext = createContext<BackgroundType>("white");
+const BackgroundContext = createContext<BackgroundType>("highContrast");
 
 export const useBackground = () => useContext(BackgroundContext);
 

--- a/packages/odyssey-react-mui/src/Button.tsx
+++ b/packages/odyssey-react-mui/src/Button.tsx
@@ -25,8 +25,8 @@ import {
 } from "@mui/material";
 import { buttonClasses } from "@mui/material/Button";
 import styled from "@emotion/styled";
-import { useBackground } from "./BackgroundContext"; // Custom hook to consume the background context
-import { useButton } from "./ButtonContext"; // Custom hook to consume the button context
+import { useBackground } from "./BackgroundContext";
+import { useButton } from "./ButtonContext";
 import type { HtmlProps } from "./HtmlProps";
 import { FocusHandle } from "./inputUtils";
 import {
@@ -151,15 +151,15 @@ export type ButtonProps = {
   >;
 
 // Styled version of the Button for gray background context style overrides
-const nonForwardedProps = ["isGrayBackground", "odysseyDesignTokens"];
+const nonForwardedProps = ["isLowContrast", "odysseyDesignTokens"];
 
 const StyledButton = styled(MuiButton, {
-  shouldForwardProp: (prop) => !nonForwardedProps.includes(prop as string),
+  shouldForwardProp: (prop: string) => !nonForwardedProps.includes(prop),
 })<{
-  isGrayBackground?: boolean;
+  isLowContrast?: boolean;
   odysseyDesignTokens: DesignTokens;
-}>(({ isGrayBackground, odysseyDesignTokens }) => ({
-  ...(isGrayBackground && {
+}>(({ isLowContrast, odysseyDesignTokens }) => ({
+  ...(isLowContrast && {
     [`&.${buttonClasses.root}.${buttonClasses.disabled}.MuiButton-secondary`]: {
       backgroundColor: odysseyDesignTokens.HueNeutral200,
       color: odysseyDesignTokens.TypographyColorDisabled,
@@ -196,7 +196,8 @@ const Button = ({
   const background = useBackground();
   const odysseyDesignTokens = useOdysseyDesignTokens();
   // Determine if the button is in a gray background and is a secondary variant
-  const isGrayBackground = background === "gray" && variantProp === "secondary";
+  const isLowContrast =
+    background === "lowContrast" && variantProp === "secondary";
 
   // We're deprecating the "tertiary" variant, so map it to
   // "secondary" in lieu of making a breaking change
@@ -255,7 +256,7 @@ const Button = ({
           translate={translate}
           type={type}
           variant={variant}
-          isGrayBackground={isGrayBackground}
+          isLowContrast={isLowContrast}
           odysseyDesignTokens={odysseyDesignTokens}
         >
           {label}
@@ -273,7 +274,7 @@ const Button = ({
       href,
       id,
       isDisabled,
-      isGrayBackground,
+      isLowContrast,
       isFullWidth,
       label,
       odysseyDesignTokens,

--- a/packages/odyssey-react-mui/src/Status.tsx
+++ b/packages/odyssey-react-mui/src/Status.tsx
@@ -17,7 +17,7 @@ import styled from "@emotion/styled";
 
 import { useMuiProps } from "./MuiPropsContext";
 import type { HtmlProps } from "./HtmlProps";
-import { useBackground } from "./BackgroundContext"; // Custom hook to consume the background context
+import { useBackground } from "./BackgroundContext";
 import {
   DesignTokens,
   useOdysseyDesignTokens,
@@ -47,15 +47,15 @@ export type StatusProps = {
   variant?: (typeof statusVariantValues)[number];
 } & Pick<HtmlProps, "testId" | "translate">;
 
-const nonForwardedProps = ["isGrayBackground", "odysseyDesignTokens"];
+const nonForwardedProps = ["isLowContrast", "odysseyDesignTokens"];
 
 const StyledChip = styled(Chip, {
   shouldForwardProp: (prop) => !nonForwardedProps.includes(prop as string),
 })<{
-  isGrayBackground: boolean;
+  isLowContrast: boolean;
   odysseyDesignTokens: DesignTokens;
-}>(({ isGrayBackground, odysseyDesignTokens }) => ({
-  ...(isGrayBackground && {
+}>(({ isLowContrast, odysseyDesignTokens }) => ({
+  ...(isLowContrast && {
     [`&.${chipClasses.root}`]: {
       backgroundColor: odysseyDesignTokens.HueNeutral100,
       color: odysseyDesignTokens.TypographyColorBody,
@@ -90,7 +90,7 @@ const Status = ({
   const background = useBackground();
   const odysseyDesignTokens = useOdysseyDesignTokens();
 
-  const isGrayBackground = background === "gray";
+  const isLowContrast = background === "lowContrast";
 
   return (
     <StyledChip
@@ -100,7 +100,7 @@ const Status = ({
       label={label}
       translate={translate}
       variant={variant}
-      isGrayBackground={isGrayBackground}
+      isLowContrast={isLowContrast}
       odysseyDesignTokens={odysseyDesignTokens}
     />
   );

--- a/packages/odyssey-react-mui/src/Status.tsx
+++ b/packages/odyssey-react-mui/src/Status.tsx
@@ -57,7 +57,7 @@ const StyledChip = styled(Chip, {
 }>(({ isLowContrast, odysseyDesignTokens }) => ({
   ...(isLowContrast && {
     [`&.${chipClasses.root}`]: {
-      backgroundColor: odysseyDesignTokens.HueNeutral100,
+      backgroundColor: odysseyDesignTokens.HueNeutral200,
       color: odysseyDesignTokens.TypographyColorBody,
     },
     [`&.${chipClasses.colorError}`]: {

--- a/packages/odyssey-react-mui/src/Status.tsx
+++ b/packages/odyssey-react-mui/src/Status.tsx
@@ -12,9 +12,16 @@
 
 import { memo } from "react";
 import { Chip } from "@mui/material";
+import { chipClasses } from "@mui/material/Chip";
+import styled from "@emotion/styled";
 
 import { useMuiProps } from "./MuiPropsContext";
 import type { HtmlProps } from "./HtmlProps";
+import { useBackground } from "./BackgroundContext"; // Custom hook to consume the background context
+import {
+  DesignTokens,
+  useOdysseyDesignTokens,
+} from "./OdysseyDesignTokensContext";
 
 export const statusSeverityValues = [
   "default",
@@ -40,6 +47,38 @@ export type StatusProps = {
   variant?: (typeof statusVariantValues)[number];
 } & Pick<HtmlProps, "testId" | "translate">;
 
+const nonForwardedProps = ["isGrayBackground", "odysseyDesignTokens"];
+
+const StyledChip = styled(Chip, {
+  shouldForwardProp: (prop) => !nonForwardedProps.includes(prop as string),
+})<{
+  isGrayBackground: boolean;
+  odysseyDesignTokens: DesignTokens;
+}>(({ isGrayBackground, odysseyDesignTokens }) => ({
+  ...(isGrayBackground && {
+    [`&.${chipClasses.root}`]: {
+      backgroundColor: odysseyDesignTokens.HueNeutral100,
+      color: odysseyDesignTokens.TypographyColorBody,
+    },
+    [`&.${chipClasses.colorError}`]: {
+      backgroundColor: odysseyDesignTokens.PaletteDangerLight,
+      color: odysseyDesignTokens.PaletteDangerDark,
+    },
+    [`&.${chipClasses.colorInfo}`]: {
+      backgroundColor: odysseyDesignTokens.PalettePrimaryLight,
+      color: odysseyDesignTokens.PalettePrimaryDark,
+    },
+    [`&.${chipClasses.colorSuccess}`]: {
+      backgroundColor: odysseyDesignTokens.PaletteSuccessLight,
+      color: odysseyDesignTokens.PaletteSuccessDark,
+    },
+    [`&.${chipClasses.colorWarning}`]: {
+      backgroundColor: odysseyDesignTokens.PaletteWarningLight,
+      color: odysseyDesignTokens.PaletteWarningDark,
+    },
+  }),
+}));
+
 const Status = ({
   label,
   severity,
@@ -48,15 +87,21 @@ const Status = ({
   variant = "pill",
 }: StatusProps) => {
   const muiProps = useMuiProps();
+  const background = useBackground();
+  const odysseyDesignTokens = useOdysseyDesignTokens();
+
+  const isGrayBackground = background === "gray";
 
   return (
-    <Chip
+    <StyledChip
       {...muiProps}
       color={severity}
       data-se={testId}
       label={label}
       translate={translate}
       variant={variant}
+      isGrayBackground={isGrayBackground}
+      odysseyDesignTokens={odysseyDesignTokens}
     />
   );
 };

--- a/packages/odyssey-react-mui/src/Tag.tsx
+++ b/packages/odyssey-react-mui/src/Tag.tsx
@@ -21,6 +21,7 @@ import {
   useOdysseyDesignTokens,
 } from "./OdysseyDesignTokensContext";
 import { CloseCircleFilledIcon } from "./icons.generated";
+import { useBackground } from "./BackgroundContext";
 
 export const tagColorVariants = [
   "default",
@@ -57,58 +58,83 @@ export type TagProps = {
 const getChipColors = (
   colorVariant: TagColorVariant,
   odysseyDesignTokens: DesignTokens,
+  isGrayBackground: boolean,
 ) => {
   const colors = {
     default: {
-      background: odysseyDesignTokens.HueNeutral100,
+      background: isGrayBackground
+        ? odysseyDesignTokens.HueNeutral200
+        : odysseyDesignTokens.HueNeutral100,
       hover: odysseyDesignTokens.HueNeutral200,
       active: odysseyDesignTokens.HueNeutral300,
-      text: odysseyDesignTokens.HueNeutral700,
+      text: isGrayBackground
+        ? odysseyDesignTokens.HueNeutral700
+        : odysseyDesignTokens.HueNeutral600,
       border: odysseyDesignTokens.HueNeutral200,
       deleteIcon: odysseyDesignTokens.HueNeutral500,
       deleteIconHover: odysseyDesignTokens.HueNeutral600,
     },
     info: {
-      background: odysseyDesignTokens.HueBlue100,
+      background: isGrayBackground
+        ? odysseyDesignTokens.HueBlue200
+        : odysseyDesignTokens.HueBlue100,
       hover: odysseyDesignTokens.HueBlue200,
       active: odysseyDesignTokens.HueBlue300,
-      text: odysseyDesignTokens.HueBlue700,
+      text: isGrayBackground
+        ? odysseyDesignTokens.HueBlue700
+        : odysseyDesignTokens.HueBlue600,
       border: odysseyDesignTokens.HueBlue200,
       deleteIcon: odysseyDesignTokens.HueBlue500,
       deleteIconHover: odysseyDesignTokens.HueBlue600,
     },
     accentOne: {
-      background: odysseyDesignTokens.HueAccentOne100,
+      background: isGrayBackground
+        ? odysseyDesignTokens.HueAccentOne200
+        : odysseyDesignTokens.HueAccentOne100,
       hover: odysseyDesignTokens.HueAccentOne200,
       active: odysseyDesignTokens.HueAccentOne300,
-      text: odysseyDesignTokens.HueAccentOne700,
+      text: isGrayBackground
+        ? odysseyDesignTokens.HueAccentOne700
+        : odysseyDesignTokens.HueAccentOne600,
       border: odysseyDesignTokens.HueAccentOne200,
       deleteIcon: odysseyDesignTokens.HueAccentOne500,
       deleteIconHover: odysseyDesignTokens.HueAccentOne600,
     },
     accentTwo: {
-      background: odysseyDesignTokens.HueAccentTwo100,
+      background: isGrayBackground
+        ? odysseyDesignTokens.HueAccentTwo200
+        : odysseyDesignTokens.HueAccentTwo100,
       hover: odysseyDesignTokens.HueAccentTwo200,
       active: odysseyDesignTokens.HueAccentTwo300,
-      text: odysseyDesignTokens.HueAccentTwo700,
+      text: isGrayBackground
+        ? odysseyDesignTokens.HueAccentTwo700
+        : odysseyDesignTokens.HueAccentTwo600,
       border: odysseyDesignTokens.HueAccentTwo200,
       deleteIcon: odysseyDesignTokens.HueAccentTwo500,
       deleteIconHover: odysseyDesignTokens.HueAccentTwo600,
     },
     accentThree: {
-      background: odysseyDesignTokens.HueAccentThree100,
+      background: isGrayBackground
+        ? odysseyDesignTokens.HueAccentThree200
+        : odysseyDesignTokens.HueAccentThree100,
       hover: odysseyDesignTokens.HueAccentThree200,
       active: odysseyDesignTokens.HueAccentThree300,
-      text: odysseyDesignTokens.HueAccentThree700,
+      text: isGrayBackground
+        ? odysseyDesignTokens.HueAccentThree700
+        : odysseyDesignTokens.HueAccentThree600,
       border: odysseyDesignTokens.HueAccentThree200,
       deleteIcon: odysseyDesignTokens.HueAccentThree500,
       deleteIconHover: odysseyDesignTokens.HueAccentThree600,
     },
     accentFour: {
-      background: odysseyDesignTokens.HueAccentFour100,
+      background: isGrayBackground
+        ? odysseyDesignTokens.HueAccentFour200
+        : odysseyDesignTokens.HueAccentFour100,
       hover: odysseyDesignTokens.HueAccentFour200,
       active: odysseyDesignTokens.HueAccentFour300,
-      text: odysseyDesignTokens.HueAccentFour700,
+      text: isGrayBackground
+        ? odysseyDesignTokens.HueAccentFour700
+        : odysseyDesignTokens.HueAccentFour600,
       border: odysseyDesignTokens.HueAccentFour200,
       deleteIcon: odysseyDesignTokens.HueAccentFour500,
       deleteIconHover: odysseyDesignTokens.HueAccentFour600,
@@ -120,13 +146,20 @@ const getChipColors = (
 
 const StyledTag = styled(MuiChip, {
   shouldForwardProp: (prop) =>
-    !["colorVariant", "odysseyDesignTokens"].includes(prop as string),
+    !["colorVariant", "isGrayBackground", "odysseyDesignTokens"].includes(
+      prop as string,
+    ),
 })<{
   colorVariant: TagColorVariant;
+  isGrayBackground: boolean;
   odysseyDesignTokens: DesignTokens;
   as?: React.ElementType; // Allow the 'as' prop to be forwarded
-}>(({ colorVariant, odysseyDesignTokens }) => {
-  const colors = getChipColors(colorVariant, odysseyDesignTokens);
+}>(({ colorVariant, isGrayBackground, odysseyDesignTokens }) => {
+  const colors = getChipColors(
+    colorVariant,
+    odysseyDesignTokens,
+    isGrayBackground,
+  );
 
   return {
     backgroundColor: colors.background,
@@ -169,6 +202,8 @@ const Tag = ({
 }: TagProps) => {
   const odysseyDesignTokens = useOdysseyDesignTokens();
   const { chipElementType } = useContext(TagListContext);
+  const background = useBackground();
+  const isGrayBackground = background === "gray";
 
   const renderTag = useCallback(
     (muiProps: MuiPropsContextType) => (
@@ -180,6 +215,7 @@ const Tag = ({
         data-se={testId}
         colorVariant={colorVariant}
         odysseyDesignTokens={odysseyDesignTokens}
+        isGrayBackground={isGrayBackground}
         disabled={isDisabled}
         icon={icon}
         label={label}
@@ -200,6 +236,7 @@ const Tag = ({
       translate,
       colorVariant,
       odysseyDesignTokens,
+      isGrayBackground,
     ],
   );
 

--- a/packages/odyssey-react-mui/src/Tag.tsx
+++ b/packages/odyssey-react-mui/src/Tag.tsx
@@ -21,7 +21,7 @@ import {
   useOdysseyDesignTokens,
 } from "./OdysseyDesignTokensContext";
 import { CloseCircleFilledIcon } from "./icons.generated";
-import { useBackground } from "./BackgroundContext";
+import { useBackground } from "./BackgroundContext"; // Custom hook to consume the background context
 
 export const tagColorVariants = [
   "default",

--- a/packages/odyssey-react-mui/src/Tag.tsx
+++ b/packages/odyssey-react-mui/src/Tag.tsx
@@ -21,7 +21,7 @@ import {
   useOdysseyDesignTokens,
 } from "./OdysseyDesignTokensContext";
 import { CloseCircleFilledIcon } from "./icons.generated";
-import { useBackground } from "./BackgroundContext"; // Custom hook to consume the background context
+import { useBackground } from "./BackgroundContext";
 
 export const tagColorVariants = [
   "default",
@@ -58,16 +58,16 @@ export type TagProps = {
 const getChipColors = (
   colorVariant: TagColorVariant,
   odysseyDesignTokens: DesignTokens,
-  isGrayBackground: boolean,
+  isLowContrast: boolean,
 ) => {
   const colors = {
     default: {
-      background: isGrayBackground
+      background: isLowContrast
         ? odysseyDesignTokens.HueNeutral200
         : odysseyDesignTokens.HueNeutral100,
       hover: odysseyDesignTokens.HueNeutral200,
       active: odysseyDesignTokens.HueNeutral300,
-      text: isGrayBackground
+      text: isLowContrast
         ? odysseyDesignTokens.HueNeutral700
         : odysseyDesignTokens.HueNeutral600,
       border: odysseyDesignTokens.HueNeutral200,
@@ -75,12 +75,12 @@ const getChipColors = (
       deleteIconHover: odysseyDesignTokens.HueNeutral600,
     },
     info: {
-      background: isGrayBackground
+      background: isLowContrast
         ? odysseyDesignTokens.HueBlue200
         : odysseyDesignTokens.HueBlue100,
       hover: odysseyDesignTokens.HueBlue200,
       active: odysseyDesignTokens.HueBlue300,
-      text: isGrayBackground
+      text: isLowContrast
         ? odysseyDesignTokens.HueBlue700
         : odysseyDesignTokens.HueBlue600,
       border: odysseyDesignTokens.HueBlue200,
@@ -88,12 +88,12 @@ const getChipColors = (
       deleteIconHover: odysseyDesignTokens.HueBlue600,
     },
     accentOne: {
-      background: isGrayBackground
+      background: isLowContrast
         ? odysseyDesignTokens.HueAccentOne200
         : odysseyDesignTokens.HueAccentOne100,
       hover: odysseyDesignTokens.HueAccentOne200,
       active: odysseyDesignTokens.HueAccentOne300,
-      text: isGrayBackground
+      text: isLowContrast
         ? odysseyDesignTokens.HueAccentOne700
         : odysseyDesignTokens.HueAccentOne600,
       border: odysseyDesignTokens.HueAccentOne200,
@@ -101,12 +101,12 @@ const getChipColors = (
       deleteIconHover: odysseyDesignTokens.HueAccentOne600,
     },
     accentTwo: {
-      background: isGrayBackground
+      background: isLowContrast
         ? odysseyDesignTokens.HueAccentTwo200
         : odysseyDesignTokens.HueAccentTwo100,
       hover: odysseyDesignTokens.HueAccentTwo200,
       active: odysseyDesignTokens.HueAccentTwo300,
-      text: isGrayBackground
+      text: isLowContrast
         ? odysseyDesignTokens.HueAccentTwo700
         : odysseyDesignTokens.HueAccentTwo600,
       border: odysseyDesignTokens.HueAccentTwo200,
@@ -114,12 +114,12 @@ const getChipColors = (
       deleteIconHover: odysseyDesignTokens.HueAccentTwo600,
     },
     accentThree: {
-      background: isGrayBackground
+      background: isLowContrast
         ? odysseyDesignTokens.HueAccentThree200
         : odysseyDesignTokens.HueAccentThree100,
       hover: odysseyDesignTokens.HueAccentThree200,
       active: odysseyDesignTokens.HueAccentThree300,
-      text: isGrayBackground
+      text: isLowContrast
         ? odysseyDesignTokens.HueAccentThree700
         : odysseyDesignTokens.HueAccentThree600,
       border: odysseyDesignTokens.HueAccentThree200,
@@ -127,12 +127,12 @@ const getChipColors = (
       deleteIconHover: odysseyDesignTokens.HueAccentThree600,
     },
     accentFour: {
-      background: isGrayBackground
+      background: isLowContrast
         ? odysseyDesignTokens.HueAccentFour200
         : odysseyDesignTokens.HueAccentFour100,
       hover: odysseyDesignTokens.HueAccentFour200,
       active: odysseyDesignTokens.HueAccentFour300,
-      text: isGrayBackground
+      text: isLowContrast
         ? odysseyDesignTokens.HueAccentFour700
         : odysseyDesignTokens.HueAccentFour600,
       border: odysseyDesignTokens.HueAccentFour200,
@@ -146,19 +146,19 @@ const getChipColors = (
 
 const StyledTag = styled(MuiChip, {
   shouldForwardProp: (prop) =>
-    !["colorVariant", "isGrayBackground", "odysseyDesignTokens"].includes(
+    !["colorVariant", "isLowContrast", "odysseyDesignTokens"].includes(
       prop as string,
     ),
 })<{
   colorVariant: TagColorVariant;
-  isGrayBackground: boolean;
+  isLowContrast: boolean;
   odysseyDesignTokens: DesignTokens;
   as?: React.ElementType; // Allow the 'as' prop to be forwarded
-}>(({ colorVariant, isGrayBackground, odysseyDesignTokens }) => {
+}>(({ colorVariant, isLowContrast, odysseyDesignTokens }) => {
   const colors = getChipColors(
     colorVariant,
     odysseyDesignTokens,
-    isGrayBackground,
+    isLowContrast,
   );
 
   return {
@@ -203,7 +203,7 @@ const Tag = ({
   const odysseyDesignTokens = useOdysseyDesignTokens();
   const { chipElementType } = useContext(TagListContext);
   const background = useBackground();
-  const isGrayBackground = background === "gray";
+  const isLowContrast = background === "lowContrast";
 
   const renderTag = useCallback(
     (muiProps: MuiPropsContextType) => (
@@ -215,7 +215,7 @@ const Tag = ({
         data-se={testId}
         colorVariant={colorVariant}
         odysseyDesignTokens={odysseyDesignTokens}
-        isGrayBackground={isGrayBackground}
+        isLowContrast={isLowContrast}
         disabled={isDisabled}
         icon={icon}
         label={label}
@@ -236,7 +236,7 @@ const Tag = ({
       translate,
       colorVariant,
       odysseyDesignTokens,
-      isGrayBackground,
+      isLowContrast,
     ],
   );
 

--- a/packages/odyssey-react-mui/src/index.ts
+++ b/packages/odyssey-react-mui/src/index.ts
@@ -59,6 +59,7 @@ export { useOdysseyDesignTokens } from "./OdysseyDesignTokensContext";
 export * from "./Accordion";
 export * from "./Autocomplete";
 export { badgeContentMaxValues } from "./Badge";
+export * from "./BackgroundContext";
 export * from "./Banner";
 export * from "./Box";
 export * from "./Breadcrumbs";

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -253,6 +253,8 @@ export const components = ({
             justifyContent: "center",
             alignItems: "center",
             borderRadius: 0,
+            borderWidth: 0,
+            borderBottomWidth: "1px",
 
             ...(ownerState.onClose !== undefined && {
               paddingInline: odysseyTokens.Spacing6,

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
@@ -127,7 +127,7 @@ const storybookMeta: Meta<ButtonProps> = {
   decorators: [
     MuiThemeDecorator,
     (Story: StoryFn<ButtonProps>, context: StoryContext<ButtonProps>) => (
-      <BackgroundProvider value="white">
+      <BackgroundProvider value="highContrast">
         <Story {...context.args} />
       </BackgroundProvider>
     ),
@@ -224,7 +224,7 @@ export const ButtonSecondaryDisabledOnWhiteBackground: StoryObj<ButtonProps> = {
   name: "Secondary, Disabled on white background",
   decorators: [
     (Story: StoryFn<ButtonProps>, context: StoryContext<ButtonProps>) => (
-      <BackgroundProvider value="white">
+      <BackgroundProvider value="highContrast">
         <Story {...context.args} />
       </BackgroundProvider>
     ),
@@ -246,7 +246,7 @@ export const ButtonSecondaryDisabledOnWhiteBackground: StoryObj<ButtonProps> = {
   parameters: {
     docs: {
       source: {
-        code: `<BackgroundProvider>
+        code: `<BackgroundProvider value="highContrast">
 <Button
   isDisabled
   label="Secondary"
@@ -257,7 +257,7 @@ export const ButtonSecondaryDisabledOnWhiteBackground: StoryObj<ButtonProps> = {
       },
       description: {
         story:
-          "Demonstrates how the `Button` component behaves in a white background using `BackgroundProvider`.",
+          "Demonstrates how the `Button` component behaves in a white (`highContrast`) background using `BackgroundProvider`.",
       },
     },
   },
@@ -267,7 +267,7 @@ export const ButtonSecondaryDisabledOnGrayBackground: StoryObj<ButtonProps> = {
   name: "Secondary, Disabled on gray background",
   decorators: [
     (Story: StoryFn<ButtonProps>, context: StoryContext<ButtonProps>) => (
-      <BackgroundProvider value="gray">
+      <BackgroundProvider value="lowContrast">
         <Box sx={{ backgroundColor: "#F4F4F4", padding: "24px" }}>
           <Story {...context.args} />
         </Box>
@@ -291,7 +291,7 @@ export const ButtonSecondaryDisabledOnGrayBackground: StoryObj<ButtonProps> = {
   parameters: {
     docs: {
       source: {
-        code: `<BackgroundProvider value="gray">
+        code: `<BackgroundProvider value="lowContrast">
   <Button
     isDisabled
     label="Secondary"
@@ -302,7 +302,7 @@ export const ButtonSecondaryDisabledOnGrayBackground: StoryObj<ButtonProps> = {
       },
       description: {
         story:
-          "Demonstrates how the `Button` component behaves in a gray background using `BackgroundProvider`.",
+          "Demonstrates how the `Button` component behaves in a gray (`lowContrast`) background using `BackgroundProvider`.",
       },
     },
   },

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
@@ -11,6 +11,7 @@
  */
 
 import {
+  BackgroundProvider,
   Box,
   Button,
   buttonSizeValues,
@@ -21,7 +22,7 @@ import {
 import { AddIcon } from "@okta/odyssey-react-mui/icons";
 import { expect } from "@storybook/jest";
 import { userEvent, waitFor, within } from "@storybook/testing-library";
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj, StoryFn, StoryContext } from "@storybook/react";
 
 import { MuiThemeDecorator } from "../../../../.storybook/components";
 import icons from "../../../../.storybook/components/iconUtils";
@@ -39,121 +40,73 @@ const storybookMeta: Meta<ButtonProps> = {
   component: Button,
   argTypes: {
     endIcon: {
-      control: {
-        type: "select",
-      },
+      control: { type: "select" },
       options: Object.keys(icons),
       mapping: icons,
       description: "An optional icon to display at the end of the button",
-      table: {
-        type: {
-          summary: "<Icon />",
-        },
-      },
+      table: { type: { summary: "<Icon />" } },
     },
     href: {
       control: "text",
       description: "Optional href to render the button as a link",
-      table: {
-        type: {
-          summary: "string",
-        },
-      },
+      table: { type: { summary: "string" } },
     },
     id: {
       control: null,
       description: "An optional ID for the button",
-      table: {
-        type: {
-          summary: "string",
-        },
-      },
+      table: { type: { summary: "string" } },
     },
     isDisabled: {
       control: "boolean",
       description: "If `true`, the button is disabled",
-      table: {
-        type: {
-          summary: "boolean",
-        },
-      },
+      table: { type: { summary: "boolean" } },
     },
     isFullWidth: {
       control: "boolean",
       description:
         "If `true`, the button will take up the full width available",
-      table: {
-        type: {
-          summary: "boolean",
-        },
-      },
+      table: { type: { summary: "boolean" } },
     },
     label: {
       control: "text",
       description:
         "The button text. If blank, the button must include an icon.",
-      table: {
-        type: {
-          summary: "string",
-        },
-      },
+      table: { type: { summary: "string" } },
     },
     onClick: {
       action: true,
       description: "Callback fired when the button is clicked",
-      table: {
-        type: {
-          summary: "(() => void)",
-        },
-      },
+      table: { type: { summary: "(() => void)" } },
     },
     size: {
       options: buttonSizeValues,
       control: { type: "radio" },
       description: "The size of the button",
       table: {
-        type: {
-          summary: buttonSizeValues.join(" | "),
-        },
-        defaultValue: {
-          summary: "medium",
-        },
+        type: { summary: buttonSizeValues.join(" | ") },
+        defaultValue: { summary: "medium" },
       },
     },
     startIcon: {
-      control: {
-        type: "select",
-      },
+      control: { type: "select" },
       options: Object.keys(icons),
       mapping: icons,
       description: "An optional icon to display at the start of the button",
-      table: {
-        type: {
-          summary: "<Icon />",
-        },
-      },
+      table: { type: { summary: "<Icon />" } },
     },
     tooltipText: {
       control: "text",
       description:
         "If defined, the button will include a tooltip that contains the string.",
-      table: {
-        type: {
-          summary: "string",
-        },
-      },
+      table: { type: { summary: "string" } },
     },
     type: {
       options: buttonTypeValues,
       control: { type: "radio" },
       description: "The type of the HTML button element.",
       table: {
-        type: {
-          summary: buttonTypeValues.join(" | "),
-        },
-        defaultValue: {
-          summary: "button",
-        },
+        type: { summary: buttonTypeValues.join(" | ") },
+        defaultValue: { summary: "button" },
       },
     },
     variant: {
@@ -161,25 +114,24 @@ const storybookMeta: Meta<ButtonProps> = {
       control: { type: "radio" },
       description: "The color and style of the button",
       table: {
-        type: {
-          summary: buttonVariantValues.join(" | "),
-        },
-        defaultValue: {
-          summary: "secondary",
-        },
+        type: { summary: buttonVariantValues.join(" | ") },
+        defaultValue: { summary: "secondary" },
       },
-      type: {
-        required: true,
-        name: "other",
-        value: "radio",
-      },
+      type: { required: true, name: "other", value: "radio" },
     },
   },
   args: {
     label: "Add crew",
     variant: "primary",
   },
-  decorators: [MuiThemeDecorator],
+  decorators: [
+    MuiThemeDecorator,
+    (Story: StoryFn<ButtonProps>, context: StoryContext<ButtonProps>) => (
+      <BackgroundProvider value="white">
+        <Story {...context.args} />
+      </BackgroundProvider>
+    ),
+  ],
   tags: ["autodocs"],
 };
 
@@ -210,6 +162,19 @@ const interactWithButton =
       });
     }
   };
+
+const checkButtonStyles = async (
+  canvas: ReturnType<typeof within>,
+  buttonLabel: string,
+  expectedBackgroundColor: string,
+  expectedColor: string,
+) => {
+  const button = canvas.getByText(buttonLabel);
+  await expect(button).toHaveStyle(
+    `background-color: ${expectedBackgroundColor}`,
+  );
+  await expect(button).toHaveStyle(`color: ${expectedColor}`);
+};
 
 export const ButtonPrimary: StoryObj<ButtonProps> = {
   name: "Primary",
@@ -252,6 +217,94 @@ export const ButtonSecondaryDisabled: StoryObj<ButtonProps> = {
     isDisabled: true,
     label: "Add crew",
     variant: "secondary",
+  },
+};
+
+export const ButtonSecondaryDisabledOnWhiteBackground: StoryObj<ButtonProps> = {
+  name: "Secondary, Disabled on white background",
+  decorators: [
+    (Story: StoryFn<ButtonProps>, context: StoryContext<ButtonProps>) => (
+      <BackgroundProvider value="white">
+        <Story {...context.args} />
+      </BackgroundProvider>
+    ),
+  ],
+  args: {
+    variant: "secondary",
+    isDisabled: true,
+    label: "Secondary",
+  },
+  play: async ({ canvasElement }: playType) => {
+    const canvas = within(canvasElement);
+    await checkButtonStyles(
+      canvas,
+      "Secondary",
+      "rgb(243, 244, 246)",
+      "rgb(143, 149, 158)",
+    );
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<BackgroundProvider>
+<Button
+  isDisabled
+  label="Secondary"
+  onClick={() => {}}
+  variant="secondary"
+/>
+</BackgroundProvider>`,
+      },
+      description: {
+        story:
+          "Demonstrates how the `Button` component behaves in a white background using `BackgroundProvider`.",
+      },
+    },
+  },
+};
+
+export const ButtonSecondaryDisabledOnGrayBackground: StoryObj<ButtonProps> = {
+  name: "Secondary, Disabled on gray background",
+  decorators: [
+    (Story: StoryFn<ButtonProps>, context: StoryContext<ButtonProps>) => (
+      <BackgroundProvider value="gray">
+        <Box sx={{ backgroundColor: "#F4F4F4", padding: "24px" }}>
+          <Story {...context.args} />
+        </Box>
+      </BackgroundProvider>
+    ),
+  ],
+  args: {
+    variant: "secondary",
+    isDisabled: true,
+    label: "Secondary",
+  },
+  play: async ({ canvasElement }: playType) => {
+    const canvas = within(canvasElement);
+    await checkButtonStyles(
+      canvas,
+      "Secondary",
+      "rgb(229, 231, 235)",
+      "rgb(143, 149, 158)",
+    );
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<BackgroundProvider value="gray">
+  <Button
+    isDisabled
+    label="Secondary"
+    onClick={() => {}}
+    variant="secondary"
+  />
+</BackgroundProvider>`,
+      },
+      description: {
+        story:
+          "Demonstrates how the `Button` component behaves in a gray background using `BackgroundProvider`.",
+      },
+    },
   },
 };
 

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
@@ -20,6 +20,8 @@ import {
   type ButtonProps,
 } from "@okta/odyssey-react-mui";
 import { AddIcon } from "@okta/odyssey-react-mui/icons";
+import * as Tokens from "@okta/odyssey-design-tokens";
+
 import { expect } from "@storybook/jest";
 import { userEvent, waitFor, within } from "@storybook/testing-library";
 import type { Meta, StoryObj, StoryFn, StoryContext } from "@storybook/react";
@@ -186,13 +188,13 @@ export const ButtonPrimary: StoryObj<ButtonProps> = {
     });
   },
 };
-
 export const ButtonPrimaryDisabled: StoryObj<ButtonProps> = {
   name: "Primary, Disabled",
   args: {
     isDisabled: true,
     label: "Add crew",
     variant: "primary",
+    testId: "button-primary-disabled",
   },
 };
 
@@ -201,6 +203,7 @@ export const ButtonSecondary: StoryObj<ButtonProps> = {
   args: {
     label: "Add crew",
     variant: "secondary",
+    testId: "button-secondary",
   },
   play: async ({ args, canvasElement, step }: playType) => {
     await interactWithButton({ canvasElement, step })({
@@ -217,6 +220,7 @@ export const ButtonSecondaryDisabled: StoryObj<ButtonProps> = {
     isDisabled: true,
     label: "Add crew",
     variant: "secondary",
+    testId: "button-secondary-disabled",
   },
 };
 
@@ -233,33 +237,16 @@ export const ButtonSecondaryDisabledOnWhiteBackground: StoryObj<ButtonProps> = {
     variant: "secondary",
     isDisabled: true,
     label: "Secondary",
+    testId: "button-secondary-disabled-white",
   },
   play: async ({ canvasElement }: playType) => {
     const canvas = within(canvasElement);
     await checkButtonStyles(
       canvas,
-      "Secondary",
-      "rgb(243, 244, 246)",
-      "rgb(143, 149, 158)",
+      "button-secondary-disabled-white",
+      Tokens.HueNeutral100,
+      Tokens.TypographyColorDisabled,
     );
-  },
-  parameters: {
-    docs: {
-      source: {
-        code: `<BackgroundProvider value="highContrast">
-<Button
-  isDisabled
-  label="Secondary"
-  onClick={() => {}}
-  variant="secondary"
-/>
-</BackgroundProvider>`,
-      },
-      description: {
-        story:
-          "Demonstrates how the `Button` component behaves in a white (`highContrast`) background using `BackgroundProvider`.",
-      },
-    },
   },
 };
 
@@ -268,7 +255,7 @@ export const ButtonSecondaryDisabledOnGrayBackground: StoryObj<ButtonProps> = {
   decorators: [
     (Story: StoryFn<ButtonProps>, context: StoryContext<ButtonProps>) => (
       <BackgroundProvider value="lowContrast">
-        <Box sx={{ backgroundColor: "#F4F4F4", padding: "24px" }}>
+        <Box sx={{ backgroundColor: Tokens.HueNeutral50, padding: "24px" }}>
           <Story {...context.args} />
         </Box>
       </BackgroundProvider>
@@ -278,33 +265,16 @@ export const ButtonSecondaryDisabledOnGrayBackground: StoryObj<ButtonProps> = {
     variant: "secondary",
     isDisabled: true,
     label: "Secondary",
+    testId: "button-secondary-disabled-gray",
   },
   play: async ({ canvasElement }: playType) => {
     const canvas = within(canvasElement);
     await checkButtonStyles(
       canvas,
-      "Secondary",
-      "rgb(229, 231, 235)",
-      "rgb(143, 149, 158)",
+      "button-secondary-disabled-gray",
+      Tokens.HueNeutral200,
+      Tokens.TypographyColorDisabled,
     );
-  },
-  parameters: {
-    docs: {
-      source: {
-        code: `<BackgroundProvider value="lowContrast">
-  <Button
-    isDisabled
-    label="Secondary"
-    onClick={() => {}}
-    variant="secondary"
-  />
-</BackgroundProvider>`,
-      },
-      description: {
-        story:
-          "Demonstrates how the `Button` component behaves in a gray (`lowContrast`) background using `BackgroundProvider`.",
-      },
-    },
   },
 };
 
@@ -313,6 +283,7 @@ export const ButtonDanger: StoryObj<ButtonProps> = {
   args: {
     label: "Add crew",
     variant: "danger",
+    testId: "button-danger",
   },
   play: async ({ args, canvasElement, step }: playType) => {
     await interactWithButton({ canvasElement, step })({
@@ -328,6 +299,7 @@ export const ButtonDangerSecondary: StoryObj<ButtonProps> = {
   args: {
     label: "Add crew",
     variant: "dangerSecondary",
+    testId: "button-danger-secondary",
   },
 };
 
@@ -337,6 +309,7 @@ export const ButtonDangerDisabled: StoryObj<ButtonProps> = {
     label: "Add crew",
     isDisabled: true,
     variant: "danger",
+    testId: "button-danger-disabled",
   },
 };
 
@@ -345,6 +318,7 @@ export const ButtonFloating: StoryObj<ButtonProps> = {
   args: {
     label: "Add crew",
     variant: "floating",
+    testId: "button-floating",
   },
   play: async ({ args, canvasElement, step }: playType) => {
     await interactWithButton({ canvasElement, step })({
@@ -354,11 +328,13 @@ export const ButtonFloating: StoryObj<ButtonProps> = {
     });
   },
 };
+
 export const ButtonFloatingAction: StoryObj<ButtonProps> = {
   name: "Floating Action",
   args: {
     label: "Add crew",
     variant: "floatingAction",
+    testId: "button-floating-action",
   },
   play: async ({ args, canvasElement, step }: playType) => {
     await interactWithButton({ canvasElement, step })({
@@ -368,14 +344,17 @@ export const ButtonFloatingAction: StoryObj<ButtonProps> = {
     });
   },
 };
+
 export const ButtonFloatingDisabled: StoryObj<ButtonProps> = {
   name: "Floating, Disabled",
   args: {
     label: "Add crew",
     isDisabled: true,
     variant: "floating",
+    testId: "button-floating-disabled",
   },
 };
+
 export const ButtonSecondaryAsLink: StoryObj<ButtonProps> = {
   name: "Button as a link",
   args: {
@@ -383,13 +362,16 @@ export const ButtonSecondaryAsLink: StoryObj<ButtonProps> = {
     variant: "floatingAction",
     href: "https://okta.com",
     onClick: undefined,
+    testId: "button-link",
   },
 };
+
 export const ButtonSmall: StoryObj<ButtonProps> = {
   name: "Small",
   args: {
     label: "Add crew",
     size: "small",
+    testId: "button-small",
   },
   play: async ({ args, canvasElement, step }: playType) => {
     await interactWithButton({ canvasElement, step })({
@@ -406,6 +388,7 @@ export const ButtonMedium: StoryObj<ButtonProps> = {
     label: "Add crew",
     size: "medium",
     variant: "secondary",
+    testId: "button-medium",
   },
   play: async ({ args, canvasElement, step }: playType) => {
     await interactWithButton({ canvasElement, step })({
@@ -422,6 +405,7 @@ export const ButtonLarge: StoryObj<ButtonProps> = {
     label: "Add crew",
     size: "large",
     variant: "danger",
+    testId: "button-large",
   },
   play: async ({ args, canvasElement, step }: playType) => {
     await interactWithButton({ canvasElement, step })({
@@ -437,6 +421,7 @@ export const ButtonFullWidth: StoryObj<ButtonProps> = {
   args: {
     label: "Add crew",
     isFullWidth: true,
+    testId: "button-fullwidth",
   },
   play: async ({ args, canvasElement, step }: playType) => {
     await interactWithButton({ canvasElement, step })({
@@ -452,6 +437,7 @@ export const ButtonWithIcon: StoryObj<ButtonProps> = {
   args: {
     label: "Add crew",
     startIcon: <AddIcon />,
+    testId: "button-icon",
   },
   play: async ({ args, canvasElement, step }: playType) => {
     await interactWithButton({ canvasElement, step })({
@@ -477,6 +463,7 @@ export const IconOnly: StoryObj<ButtonProps> = {
     ariaLabel: "Add crew",
     label: undefined,
     tooltipText: "Add crew",
+    testId: "button-icon-only",
   },
 };
 
@@ -484,13 +471,30 @@ export const KitchenSink: StoryObj<ButtonProps> = {
   name: "Kitchen sink",
   render: ({}) => (
     <Box sx={{ display: "flex", flexWrap: "wrap", rowGap: 2 }}>
-      <Button label="Primary" variant="primary" />
-      <Button label="Secondary" variant="secondary" />
-      <Button label="Danger Secondary" variant="dangerSecondary" />
-      <Button label="Danger" variant="danger" />
-      <Button label="Floating" variant="floating" />
-      <Button label="Floating Action" variant="floatingAction" />
-      <Button ariaLabel="Add" startIcon={<AddIcon />} variant="primary" />
+      <Button label="Primary" variant="primary" data-se="button-primary" />
+      <Button
+        label="Secondary"
+        variant="secondary"
+        data-se="button-secondary"
+      />
+      <Button
+        label="Danger Secondary"
+        variant="dangerSecondary"
+        data-se="button-danger-secondary"
+      />
+      <Button label="Danger" variant="danger" data-se="button-danger" />
+      <Button label="Floating" variant="floating" data-se="button-floating" />
+      <Button
+        label="Floating Action"
+        variant="floatingAction"
+        data-se="button-floating-action"
+      />
+      <Button
+        ariaLabel="Add"
+        startIcon={<AddIcon />}
+        variant="primary"
+        data-se="button-icon-primary"
+      />
     </Box>
   ),
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Button/Button.stories.tsx
@@ -153,7 +153,7 @@ const interactWithButton =
     if (args.label) {
       await step("hover and click", async () => {
         const canvas = within(canvasElement);
-        const button = canvas.getByText(args.label ?? "");
+        const button = canvas.getByRole("button", { name: args.label });
         userEvent.tab();
         await userEvent.click(button);
         expect(args.onClick).toHaveBeenCalledTimes(1);
@@ -171,7 +171,7 @@ const checkButtonStyles = async (
   expectedBackgroundColor: string,
   expectedColor: string,
 ) => {
-  const button = canvas.getByText(buttonLabel);
+  const button = canvas.getByRole("button", { name: buttonLabel });
   await expect(button).toHaveStyle(
     `background-color: ${expectedBackgroundColor}`,
   );
@@ -188,13 +188,13 @@ export const ButtonPrimary: StoryObj<ButtonProps> = {
     });
   },
 };
+
 export const ButtonPrimaryDisabled: StoryObj<ButtonProps> = {
   name: "Primary, Disabled",
   args: {
     isDisabled: true,
     label: "Add crew",
     variant: "primary",
-    testId: "button-primary-disabled",
   },
 };
 
@@ -203,7 +203,6 @@ export const ButtonSecondary: StoryObj<ButtonProps> = {
   args: {
     label: "Add crew",
     variant: "secondary",
-    testId: "button-secondary",
   },
   play: async ({ args, canvasElement, step }: playType) => {
     await interactWithButton({ canvasElement, step })({
@@ -220,7 +219,6 @@ export const ButtonSecondaryDisabled: StoryObj<ButtonProps> = {
     isDisabled: true,
     label: "Add crew",
     variant: "secondary",
-    testId: "button-secondary-disabled",
   },
 };
 
@@ -237,13 +235,12 @@ export const ButtonSecondaryDisabledOnWhiteBackground: StoryObj<ButtonProps> = {
     variant: "secondary",
     isDisabled: true,
     label: "Secondary",
-    testId: "button-secondary-disabled-white",
   },
   play: async ({ canvasElement }: playType) => {
     const canvas = within(canvasElement);
     await checkButtonStyles(
       canvas,
-      "button-secondary-disabled-white",
+      "Secondary",
       Tokens.HueNeutral100,
       Tokens.TypographyColorDisabled,
     );
@@ -265,13 +262,12 @@ export const ButtonSecondaryDisabledOnGrayBackground: StoryObj<ButtonProps> = {
     variant: "secondary",
     isDisabled: true,
     label: "Secondary",
-    testId: "button-secondary-disabled-gray",
   },
   play: async ({ canvasElement }: playType) => {
     const canvas = within(canvasElement);
     await checkButtonStyles(
       canvas,
-      "button-secondary-disabled-gray",
+      "Secondary",
       Tokens.HueNeutral200,
       Tokens.TypographyColorDisabled,
     );
@@ -283,7 +279,6 @@ export const ButtonDanger: StoryObj<ButtonProps> = {
   args: {
     label: "Add crew",
     variant: "danger",
-    testId: "button-danger",
   },
   play: async ({ args, canvasElement, step }: playType) => {
     await interactWithButton({ canvasElement, step })({
@@ -299,7 +294,6 @@ export const ButtonDangerSecondary: StoryObj<ButtonProps> = {
   args: {
     label: "Add crew",
     variant: "dangerSecondary",
-    testId: "button-danger-secondary",
   },
 };
 
@@ -309,7 +303,6 @@ export const ButtonDangerDisabled: StoryObj<ButtonProps> = {
     label: "Add crew",
     isDisabled: true,
     variant: "danger",
-    testId: "button-danger-disabled",
   },
 };
 
@@ -318,7 +311,6 @@ export const ButtonFloating: StoryObj<ButtonProps> = {
   args: {
     label: "Add crew",
     variant: "floating",
-    testId: "button-floating",
   },
   play: async ({ args, canvasElement, step }: playType) => {
     await interactWithButton({ canvasElement, step })({
@@ -334,7 +326,6 @@ export const ButtonFloatingAction: StoryObj<ButtonProps> = {
   args: {
     label: "Add crew",
     variant: "floatingAction",
-    testId: "button-floating-action",
   },
   play: async ({ args, canvasElement, step }: playType) => {
     await interactWithButton({ canvasElement, step })({
@@ -351,7 +342,6 @@ export const ButtonFloatingDisabled: StoryObj<ButtonProps> = {
     label: "Add crew",
     isDisabled: true,
     variant: "floating",
-    testId: "button-floating-disabled",
   },
 };
 
@@ -362,7 +352,6 @@ export const ButtonSecondaryAsLink: StoryObj<ButtonProps> = {
     variant: "floatingAction",
     href: "https://okta.com",
     onClick: undefined,
-    testId: "button-link",
   },
 };
 
@@ -371,7 +360,6 @@ export const ButtonSmall: StoryObj<ButtonProps> = {
   args: {
     label: "Add crew",
     size: "small",
-    testId: "button-small",
   },
   play: async ({ args, canvasElement, step }: playType) => {
     await interactWithButton({ canvasElement, step })({
@@ -388,7 +376,6 @@ export const ButtonMedium: StoryObj<ButtonProps> = {
     label: "Add crew",
     size: "medium",
     variant: "secondary",
-    testId: "button-medium",
   },
   play: async ({ args, canvasElement, step }: playType) => {
     await interactWithButton({ canvasElement, step })({
@@ -405,7 +392,6 @@ export const ButtonLarge: StoryObj<ButtonProps> = {
     label: "Add crew",
     size: "large",
     variant: "danger",
-    testId: "button-large",
   },
   play: async ({ args, canvasElement, step }: playType) => {
     await interactWithButton({ canvasElement, step })({
@@ -421,7 +407,6 @@ export const ButtonFullWidth: StoryObj<ButtonProps> = {
   args: {
     label: "Add crew",
     isFullWidth: true,
-    testId: "button-fullwidth",
   },
   play: async ({ args, canvasElement, step }: playType) => {
     await interactWithButton({ canvasElement, step })({
@@ -437,7 +422,6 @@ export const ButtonWithIcon: StoryObj<ButtonProps> = {
   args: {
     label: "Add crew",
     startIcon: <AddIcon />,
-    testId: "button-icon",
   },
   play: async ({ args, canvasElement, step }: playType) => {
     await interactWithButton({ canvasElement, step })({
@@ -463,7 +447,6 @@ export const IconOnly: StoryObj<ButtonProps> = {
     ariaLabel: "Add crew",
     label: undefined,
     tooltipText: "Add crew",
-    testId: "button-icon-only",
   },
 };
 
@@ -471,30 +454,13 @@ export const KitchenSink: StoryObj<ButtonProps> = {
   name: "Kitchen sink",
   render: ({}) => (
     <Box sx={{ display: "flex", flexWrap: "wrap", rowGap: 2 }}>
-      <Button label="Primary" variant="primary" data-se="button-primary" />
-      <Button
-        label="Secondary"
-        variant="secondary"
-        data-se="button-secondary"
-      />
-      <Button
-        label="Danger Secondary"
-        variant="dangerSecondary"
-        data-se="button-danger-secondary"
-      />
-      <Button label="Danger" variant="danger" data-se="button-danger" />
-      <Button label="Floating" variant="floating" data-se="button-floating" />
-      <Button
-        label="Floating Action"
-        variant="floatingAction"
-        data-se="button-floating-action"
-      />
-      <Button
-        ariaLabel="Add"
-        startIcon={<AddIcon />}
-        variant="primary"
-        data-se="button-icon-primary"
-      />
+      <Button label="Primary" variant="primary" />
+      <Button label="Secondary" variant="secondary" />
+      <Button label="Danger Secondary" variant="dangerSecondary" />
+      <Button label="Danger" variant="danger" />
+      <Button label="Floating" variant="floating" />
+      <Button label="Floating Action" variant="floatingAction" />
+      <Button ariaLabel="Add" startIcon={<AddIcon />} variant="primary" />
     </Box>
   ),
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Status/Status.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Status/Status.stories.tsx
@@ -19,6 +19,7 @@ import {
   BackgroundProvider,
   Box,
 } from "@okta/odyssey-react-mui";
+import * as Tokens from "@okta/odyssey-design-tokens";
 import { MuiThemeDecorator } from "../../../../.storybook/components";
 import { within } from "@storybook/testing-library";
 import { expect } from "@storybook/jest";
@@ -81,17 +82,16 @@ export default storybookMeta;
 
 const checkStatusStyles = async (
   canvas: ReturnType<typeof within>,
-  statusLabel: string,
+  testId: string,
   expectedBackgroundColor: string,
   expectedColor: string,
 ) => {
-  const status = canvas.getByText(statusLabel);
+  const status = canvas.getByTestId(testId);
   await expect(status).toHaveStyle(
     `background-color: ${expectedBackgroundColor}`,
   );
   await expect(status).toHaveStyle(`color: ${expectedColor}`);
 };
-
 export const DefaultPill: StoryObj<StatusProps> = {
   args: {
     label: "Warp drive in standby",
@@ -125,36 +125,53 @@ export const WarningPill: StoryObj<StatusProps> = {
     severity: "warning",
   },
 };
-
 export const StatusesOnWhiteBackground: StoryObj<StatusProps> = {
   name: "Statuses on White Background",
   render: () => (
     <BackgroundProvider value="highContrast">
       <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
-        <Status label="Default" severity="default" />
-        <Status label="Error" severity="error" />
-        <Status label="Info" severity="info" />
-        <Status label="Success" severity="success" />
-        <Status label="Warning" severity="warning" />
+        <Status label="Default" severity="default" data-se="status-default" />
+        <Status label="Error" severity="error" data-se="status-error" />
+        <Status label="Info" severity="info" data-se="status-info" />
+        <Status label="Success" severity="success" data-se="status-success" />
+        <Status label="Warning" severity="warning" data-se="status-warning" />
       </Box>
     </BackgroundProvider>
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+
     await checkStatusStyles(
       canvas,
-      "Default",
-      "rgb(243, 244, 246)",
-      "rgb(23, 27, 37)",
+      "status-default",
+      Tokens.HueNeutral50,
+      Tokens.TypographyColorSubordinate,
     );
     await checkStatusStyles(
       canvas,
-      "Error",
-      "rgb(254, 242, 242)",
-      "rgb(153, 27, 27)",
+      "status-error",
+      Tokens.PaletteDangerLighter,
+      Tokens.TypographyColorDanger,
     );
-    // Add checks for other severities
-    await axeRun("Statuses on White Background");
+    await checkStatusStyles(
+      canvas,
+      "status-info",
+      Tokens.PalettePrimaryLighter,
+      Tokens.PalettePrimaryText,
+    );
+    await checkStatusStyles(
+      canvas,
+      "status-success",
+      Tokens.PaletteSuccessLighter,
+      Tokens.TypographyColorSuccess,
+    );
+    await checkStatusStyles(
+      canvas,
+      "status-warning",
+      Tokens.PaletteWarningLighter,
+      Tokens.TypographyColorWarning,
+    );
+    await axeRun("Statuses on white (`highContrast`) background");
   },
   parameters: {
     docs: {
@@ -181,37 +198,55 @@ export const StatusesOnGrayBackground: StoryObj<StatusProps> = {
     <BackgroundProvider value="lowContrast">
       <Box
         sx={{
-          backgroundColor: "#F4F4F4",
+          backgroundColor: Tokens.HueNeutral50,
           padding: "24px",
           display: "flex",
           flexWrap: "wrap",
           gap: 2,
         }}
       >
-        <Status label="Default" severity="default" />
-        <Status label="Error" severity="error" />
-        <Status label="Info" severity="info" />
-        <Status label="Success" severity="success" />
-        <Status label="Warning" severity="warning" />
+        <Status label="Default" severity="default" data-se="status-default" />
+        <Status label="Error" severity="error" data-se="status-error" />
+        <Status label="Info" severity="info" data-se="status-info" />
+        <Status label="Success" severity="success" data-se="status-success" />
+        <Status label="Warning" severity="warning" data-se="status-warning" />
       </Box>
     </BackgroundProvider>
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+
     await checkStatusStyles(
       canvas,
-      "Default",
-      "rgb(229, 231, 235)",
-      "rgb(23, 27, 37)",
+      "status-default",
+      Tokens.HueNeutral100,
+      Tokens.TypographyColorBody,
     );
     await checkStatusStyles(
       canvas,
-      "Error",
-      "rgb(254, 226, 226)",
-      "rgb(120, 21, 21)",
+      "status-error",
+      Tokens.PaletteDangerLight,
+      Tokens.PaletteDangerDark,
     );
-    // Add checks for other severities
-    await axeRun("Statuses on Gray Background");
+    await checkStatusStyles(
+      canvas,
+      "status-info",
+      Tokens.PalettePrimaryLight,
+      Tokens.PalettePrimaryDark,
+    );
+    await checkStatusStyles(
+      canvas,
+      "status-success",
+      Tokens.PaletteSuccessLight,
+      Tokens.PaletteSuccessDark,
+    );
+    await checkStatusStyles(
+      canvas,
+      "status-warning",
+      Tokens.PaletteWarningLight,
+      Tokens.PaletteWarningDark,
+    );
+    await axeRun("Statuses on gray (`lowContrast`) background");
   },
   parameters: {
     docs: {
@@ -231,7 +266,6 @@ export const StatusesOnGrayBackground: StoryObj<StatusProps> = {
     },
   },
 };
-
 export const DefaultLamp: StoryObj<StatusProps> = {
   args: {
     label: "Warp drive in standby",

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Status/Status.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Status/Status.stories.tsx
@@ -129,7 +129,7 @@ export const WarningPill: StoryObj<StatusProps> = {
 export const StatusesOnWhiteBackground: StoryObj<StatusProps> = {
   name: "Statuses on White Background",
   render: () => (
-    <BackgroundProvider value="white">
+    <BackgroundProvider value="highContrast">
       <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
         <Status label="Default" severity="default" />
         <Status label="Error" severity="error" />
@@ -159,7 +159,7 @@ export const StatusesOnWhiteBackground: StoryObj<StatusProps> = {
   parameters: {
     docs: {
       source: {
-        code: `<BackgroundProvider>
+        code: `<BackgroundProvider value="highContrast">
   <Status label="Default" severity="default" />
   <Status label="Error" severity="error" />
   <Status label="Info" severity="info" />
@@ -169,7 +169,7 @@ export const StatusesOnWhiteBackground: StoryObj<StatusProps> = {
       },
       description: {
         story:
-          "Demonstrates how the `Status` component behaves on a white background using `BackgroundProvider`.",
+          "Demonstrates how the `Status` component behaves on a white (`highContrast`) background using `BackgroundProvider`.",
       },
     },
   },
@@ -178,7 +178,7 @@ export const StatusesOnWhiteBackground: StoryObj<StatusProps> = {
 export const StatusesOnGrayBackground: StoryObj<StatusProps> = {
   name: "Statuses on Gray Background",
   render: () => (
-    <BackgroundProvider value="gray">
+    <BackgroundProvider value="lowContrast">
       <Box
         sx={{
           backgroundColor: "#F4F4F4",
@@ -216,7 +216,7 @@ export const StatusesOnGrayBackground: StoryObj<StatusProps> = {
   parameters: {
     docs: {
       source: {
-        code: `<BackgroundProvider value="gray">
+        code: `<BackgroundProvider value="lowContrast">
   <Status label="Default" severity="default" />
   <Status label="Error" severity="error" />
   <Status label="Info" severity="info" />
@@ -226,7 +226,7 @@ export const StatusesOnGrayBackground: StoryObj<StatusProps> = {
       },
       description: {
         story:
-          "Demonstrates how the `Status` component behaves on a gray background using `BackgroundProvider`.",
+          "Demonstrates how the `Status` component behaves on a gray (`lowContrast`) background using `BackgroundProvider`.",
       },
     },
   },

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Status/Status.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Status/Status.stories.tsx
@@ -82,16 +82,17 @@ export default storybookMeta;
 
 const checkStatusStyles = async (
   canvas: ReturnType<typeof within>,
-  testId: string,
+  label: string,
   expectedBackgroundColor: string,
   expectedColor: string,
 ) => {
-  const status = canvas.getByTestId(testId);
+  const status = canvas.getByRole("status", { name: label });
   await expect(status).toHaveStyle(
     `background-color: ${expectedBackgroundColor}`,
   );
   await expect(status).toHaveStyle(`color: ${expectedColor}`);
 };
+
 export const DefaultPill: StoryObj<StatusProps> = {
   args: {
     label: "Warp drive in standby",
@@ -125,16 +126,17 @@ export const WarningPill: StoryObj<StatusProps> = {
     severity: "warning",
   },
 };
+
 export const StatusesOnWhiteBackground: StoryObj<StatusProps> = {
   name: "Statuses on White Background",
   render: () => (
     <BackgroundProvider value="highContrast">
       <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
-        <Status label="Default" severity="default" data-se="status-default" />
-        <Status label="Error" severity="error" data-se="status-error" />
-        <Status label="Info" severity="info" data-se="status-info" />
-        <Status label="Success" severity="success" data-se="status-success" />
-        <Status label="Warning" severity="warning" data-se="status-warning" />
+        <Status label="Default" severity="default" />
+        <Status label="Error" severity="error" />
+        <Status label="Info" severity="info" />
+        <Status label="Success" severity="success" />
+        <Status label="Warning" severity="warning" />
       </Box>
     </BackgroundProvider>
   ),
@@ -143,31 +145,31 @@ export const StatusesOnWhiteBackground: StoryObj<StatusProps> = {
 
     await checkStatusStyles(
       canvas,
-      "status-default",
+      "Default",
       Tokens.HueNeutral50,
       Tokens.TypographyColorSubordinate,
     );
     await checkStatusStyles(
       canvas,
-      "status-error",
+      "Error",
       Tokens.PaletteDangerLighter,
       Tokens.TypographyColorDanger,
     );
     await checkStatusStyles(
       canvas,
-      "status-info",
+      "Info",
       Tokens.PalettePrimaryLighter,
       Tokens.PalettePrimaryText,
     );
     await checkStatusStyles(
       canvas,
-      "status-success",
+      "Success",
       Tokens.PaletteSuccessLighter,
       Tokens.TypographyColorSuccess,
     );
     await checkStatusStyles(
       canvas,
-      "status-warning",
+      "Warning",
       Tokens.PaletteWarningLighter,
       Tokens.TypographyColorWarning,
     );
@@ -186,7 +188,7 @@ export const StatusesOnWhiteBackground: StoryObj<StatusProps> = {
       },
       description: {
         story:
-          "Demonstrates how the `Status` component behaves on a white (`highContrast`) background using `BackgroundProvider`.",
+          "`Status` component on a white (`highContrast`) background using `BackgroundProvider`.",
       },
     },
   },
@@ -205,11 +207,11 @@ export const StatusesOnGrayBackground: StoryObj<StatusProps> = {
           gap: 2,
         }}
       >
-        <Status label="Default" severity="default" data-se="status-default" />
-        <Status label="Error" severity="error" data-se="status-error" />
-        <Status label="Info" severity="info" data-se="status-info" />
-        <Status label="Success" severity="success" data-se="status-success" />
-        <Status label="Warning" severity="warning" data-se="status-warning" />
+        <Status label="Default" severity="default" />
+        <Status label="Error" severity="error" />
+        <Status label="Info" severity="info" />
+        <Status label="Success" severity="success" />
+        <Status label="Warning" severity="warning" />
       </Box>
     </BackgroundProvider>
   ),
@@ -218,31 +220,31 @@ export const StatusesOnGrayBackground: StoryObj<StatusProps> = {
 
     await checkStatusStyles(
       canvas,
-      "status-default",
+      "Default",
       Tokens.HueNeutral100,
       Tokens.TypographyColorBody,
     );
     await checkStatusStyles(
       canvas,
-      "status-error",
+      "Error",
       Tokens.PaletteDangerLight,
       Tokens.PaletteDangerDark,
     );
     await checkStatusStyles(
       canvas,
-      "status-info",
+      "Info",
       Tokens.PalettePrimaryLight,
       Tokens.PalettePrimaryDark,
     );
     await checkStatusStyles(
       canvas,
-      "status-success",
+      "Success",
       Tokens.PaletteSuccessLight,
       Tokens.PaletteSuccessDark,
     );
     await checkStatusStyles(
       canvas,
-      "status-warning",
+      "Warning",
       Tokens.PaletteWarningLight,
       Tokens.PaletteWarningDark,
     );
@@ -261,11 +263,12 @@ export const StatusesOnGrayBackground: StoryObj<StatusProps> = {
       },
       description: {
         story:
-          "Demonstrates how the `Status` component behaves on a gray (`lowContrast`) background using `BackgroundProvider`.",
+          "`Status` component on a gray (`lowContrast`) background using `BackgroundProvider`.",
       },
     },
   },
 };
+
 export const DefaultLamp: StoryObj<StatusProps> = {
   args: {
     label: "Warp drive in standby",

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Status/Status.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Status/Status.stories.tsx
@@ -16,8 +16,13 @@ import {
   StatusProps,
   statusSeverityValues,
   statusVariantValues,
+  BackgroundProvider,
+  Box,
 } from "@okta/odyssey-react-mui";
 import { MuiThemeDecorator } from "../../../../.storybook/components";
+import { within } from "@storybook/testing-library";
+import { expect } from "@storybook/jest";
+import { axeRun } from "../../../axe-util";
 
 const storybookMeta: Meta<StatusProps> = {
   title: "MUI Components/Status",
@@ -74,6 +79,19 @@ const storybookMeta: Meta<StatusProps> = {
 
 export default storybookMeta;
 
+const checkStatusStyles = async (
+  canvas: ReturnType<typeof within>,
+  statusLabel: string,
+  expectedBackgroundColor: string,
+  expectedColor: string,
+) => {
+  const status = canvas.getByText(statusLabel);
+  await expect(status).toHaveStyle(
+    `background-color: ${expectedBackgroundColor}`,
+  );
+  await expect(status).toHaveStyle(`color: ${expectedColor}`);
+};
+
 export const DefaultPill: StoryObj<StatusProps> = {
   args: {
     label: "Warp drive in standby",
@@ -105,6 +123,112 @@ export const WarningPill: StoryObj<StatusProps> = {
   args: {
     label: "Warp fuel low",
     severity: "warning",
+  },
+};
+
+export const StatusesOnWhiteBackground: StoryObj<StatusProps> = {
+  name: "Statuses on White Background",
+  render: () => (
+    <BackgroundProvider value="white">
+      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+        <Status label="Default" severity="default" />
+        <Status label="Error" severity="error" />
+        <Status label="Info" severity="info" />
+        <Status label="Success" severity="success" />
+        <Status label="Warning" severity="warning" />
+      </Box>
+    </BackgroundProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await checkStatusStyles(
+      canvas,
+      "Default",
+      "rgb(243, 244, 246)",
+      "rgb(23, 27, 37)",
+    );
+    await checkStatusStyles(
+      canvas,
+      "Error",
+      "rgb(254, 242, 242)",
+      "rgb(153, 27, 27)",
+    );
+    // Add checks for other severities
+    await axeRun("Statuses on White Background");
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<BackgroundProvider>
+  <Status label="Default" severity="default" />
+  <Status label="Error" severity="error" />
+  <Status label="Info" severity="info" />
+  <Status label="Success" severity="success" />
+  <Status label="Warning" severity="warning" />
+</BackgroundProvider>`,
+      },
+      description: {
+        story:
+          "Demonstrates how the `Status` component behaves on a white background using `BackgroundProvider`.",
+      },
+    },
+  },
+};
+
+export const StatusesOnGrayBackground: StoryObj<StatusProps> = {
+  name: "Statuses on Gray Background",
+  render: () => (
+    <BackgroundProvider value="gray">
+      <Box
+        sx={{
+          backgroundColor: "#F4F4F4",
+          padding: "24px",
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 2,
+        }}
+      >
+        <Status label="Default" severity="default" />
+        <Status label="Error" severity="error" />
+        <Status label="Info" severity="info" />
+        <Status label="Success" severity="success" />
+        <Status label="Warning" severity="warning" />
+      </Box>
+    </BackgroundProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await checkStatusStyles(
+      canvas,
+      "Default",
+      "rgb(229, 231, 235)",
+      "rgb(23, 27, 37)",
+    );
+    await checkStatusStyles(
+      canvas,
+      "Error",
+      "rgb(254, 226, 226)",
+      "rgb(120, 21, 21)",
+    );
+    // Add checks for other severities
+    await axeRun("Statuses on Gray Background");
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<BackgroundProvider value="gray">
+  <Status label="Default" severity="default" />
+  <Status label="Error" severity="error" />
+  <Status label="Info" severity="info" />
+  <Status label="Success" severity="success" />
+  <Status label="Warning" severity="warning" />
+</BackgroundProvider>`,
+      },
+      description: {
+        story:
+          "Demonstrates how the `Status` component behaves on a gray background using `BackgroundProvider`.",
+      },
+    },
   },
 };
 

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
@@ -128,11 +128,11 @@ export default storybookMeta;
 
 const checkTagStyles = async (
   canvas: ReturnType<typeof within>,
-  testId: string,
+  label: string,
   expectedBackgroundColor: string,
   expectedColor: string,
 ) => {
-  const tag = canvas.getByTestId(testId);
+  const tag = canvas.getByText(label);
   await expect(tag).toHaveStyle(`background-color: ${expectedBackgroundColor}`);
   await expect(tag).toHaveStyle(`color: ${expectedColor}`);
 };
@@ -140,7 +140,6 @@ const checkTagStyles = async (
 export const Default: StoryObj<TagProps> = {
   args: {
     label: "Starship",
-    testId: "tag-default",
   },
 };
 
@@ -148,7 +147,6 @@ export const Info: StoryObj<TagProps> = {
   args: {
     label: "Starship",
     colorVariant: "info",
-    testId: "tag-info",
   },
 };
 
@@ -156,7 +154,6 @@ export const AccentOne: StoryObj<TagProps> = {
   args: {
     label: "Starship",
     colorVariant: "accentOne",
-    testId: "tag-accent-one",
   },
 };
 
@@ -164,7 +161,6 @@ export const AccentTwo: StoryObj<TagProps> = {
   args: {
     label: "Starship",
     colorVariant: "accentTwo",
-    testId: "tag-accent-two",
   },
 };
 
@@ -172,7 +168,6 @@ export const AccentThree: StoryObj<TagProps> = {
   args: {
     label: "Starship",
     colorVariant: "accentThree",
-    testId: "tag-accent-three",
   },
 };
 
@@ -180,7 +175,6 @@ export const AccentFour: StoryObj<TagProps> = {
   args: {
     label: "Starship",
     colorVariant: "accentFour",
-    testId: "tag-accent-four",
   },
 };
 
@@ -188,28 +182,12 @@ export const List: StoryObj<TagProps> = {
   render: function C(args) {
     return (
       <TagList>
-        <Tag label={args.label} data-se="tag-default" />
-        <Tag label="Info tag" colorVariant="info" data-se="tag-info" />
-        <Tag
-          label="AccentOne tag"
-          colorVariant="accentOne"
-          data-se="tag-accent-one"
-        />
-        <Tag
-          label="AccentTwo tag"
-          colorVariant="accentTwo"
-          data-se="tag-accent-two"
-        />
-        <Tag
-          label="AccentThree tag"
-          colorVariant="accentThree"
-          data-se="tag-accent-three"
-        />
-        <Tag
-          label="AccentFour tag"
-          colorVariant="accentFour"
-          data-se="tag-accent-four"
-        />
+        <Tag label={args.label} />
+        <Tag label="Info tag" colorVariant="info" />
+        <Tag label="AccentOne tag" colorVariant="accentOne" />
+        <Tag label="AccentTwo tag" colorVariant="accentTwo" />
+        <Tag label="AccentThree tag" colorVariant="accentThree" />
+        <Tag label="AccentFour tag" colorVariant="accentFour" />
       </TagList>
     );
   },
@@ -222,25 +200,21 @@ export const Icon: StoryObj<TagProps> = {
   args: {
     label: "Crew",
     icon: <GroupIcon />,
-    testId: "tag-icon",
   },
 };
 
 export const Clickable: StoryObj<TagProps> = {
   args: {
     label: "Starship",
-    testId: "tag-clickable",
+    onClick: () => {},
   },
   play: async ({ args, canvasElement, step }) => {
-    await step("remove the tag on click", async () => {
-      const tag = canvasElement.querySelector(`[data-se="${args.testId}"]`);
-      if (tag) {
-        await userEvent.click(tag);
-        expect(args.onClick).toHaveBeenCalledTimes(1);
-        await axeRun("Clickable Tag");
-      } else {
-        throw new Error(`Element with data-se="${args.testId}" not found`);
-      }
+    await step("click the tag", async () => {
+      const canvas = within(canvasElement);
+      const tag = canvas.getByText(args.label);
+      await userEvent.click(tag);
+      expect(args.onClick).toHaveBeenCalledTimes(1);
+      await axeRun("Clickable Tag");
     });
   },
 };
@@ -248,17 +222,15 @@ export const Clickable: StoryObj<TagProps> = {
 export const Removable: StoryObj<TagProps> = {
   args: {
     label: "Starship",
-    testId: "tag-removable",
+    onRemove: () => {},
   },
   play: async ({ args, canvasElement, step }) => {
-    await step("remove the tag on click", async () => {
-      const tagElement = canvasElement.querySelector('[role="button"]');
-      const removeIcon = tagElement?.querySelector("svg");
-      if (removeIcon) {
-        await userEvent.click(removeIcon);
-        await userEvent.tab();
-        await expect(args.onRemove).toHaveBeenCalled();
-      }
+    await step("remove the tag", async () => {
+      const canvas = within(canvasElement);
+      const removeButton = canvas.getByLabelText(`Remove ${args.label}`);
+      await userEvent.click(removeButton);
+      await userEvent.tab();
+      expect(args.onRemove).toHaveBeenCalled();
       await axeRun("Removable Tag");
     });
   },
@@ -268,7 +240,6 @@ export const Disabled: StoryObj<TagProps> = {
   args: {
     label: "Starship",
     isDisabled: true,
-    testId: "tag-disabled",
   },
 };
 
@@ -277,28 +248,12 @@ export const TagsOnWhiteBackground: StoryObj<TagProps> = {
   render: () => (
     <BackgroundProvider value="highContrast">
       <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
-        <Tag label="Default" data-se="tag-default" />
-        <Tag label="Info" colorVariant="info" data-se="tag-info" />
-        <Tag
-          label="AccentOne"
-          colorVariant="accentOne"
-          data-se="tag-accent-one"
-        />
-        <Tag
-          label="AccentTwo"
-          colorVariant="accentTwo"
-          data-se="tag-accent-two"
-        />
-        <Tag
-          label="AccentThree"
-          colorVariant="accentThree"
-          data-se="tag-accent-three"
-        />
-        <Tag
-          label="AccentFour"
-          colorVariant="accentFour"
-          data-se="tag-accent-four"
-        />
+        <Tag label="Default" />
+        <Tag label="Info" colorVariant="info" />
+        <Tag label="AccentOne" colorVariant="accentOne" />
+        <Tag label="AccentTwo" colorVariant="accentTwo" />
+        <Tag label="AccentThree" colorVariant="accentThree" />
+        <Tag label="AccentFour" colorVariant="accentFour" />
       </Box>
     </BackgroundProvider>
   ),
@@ -306,37 +261,32 @@ export const TagsOnWhiteBackground: StoryObj<TagProps> = {
     const canvas = within(canvasElement);
     await checkTagStyles(
       canvas,
-      "tag-default",
+      "Default",
       Tokens.HueNeutral100,
       Tokens.TypographyColorBody,
     );
+    await checkTagStyles(canvas, "Info", Tokens.HueBlue100, Tokens.HueBlue700);
     await checkTagStyles(
       canvas,
-      "tag-info",
-      Tokens.HueBlue100,
-      Tokens.HueBlue700,
-    );
-    await checkTagStyles(
-      canvas,
-      "tag-accent-one",
+      "AccentOne",
       Tokens.HueAccentOne100,
       Tokens.HueAccentOne700,
     );
     await checkTagStyles(
       canvas,
-      "tag-accent-two",
+      "AccentTwo",
       Tokens.HueAccentTwo100,
       Tokens.HueAccentTwo700,
     );
     await checkTagStyles(
       canvas,
-      "tag-accent-three",
+      "AccentThree",
       Tokens.HueAccentThree100,
       Tokens.HueAccentThree700,
     );
     await checkTagStyles(
       canvas,
-      "tag-accent-four",
+      "AccentFour",
       Tokens.HueAccentFour100,
       Tokens.HueAccentFour700,
     );
@@ -376,28 +326,12 @@ export const TagsOnGrayBackground: StoryObj<TagProps> = {
           gap: 2,
         }}
       >
-        <Tag label="Default" data-se="tag-default" />
-        <Tag label="Info" colorVariant="info" data-se="tag-info" />
-        <Tag
-          label="AccentOne"
-          colorVariant="accentOne"
-          data-se="tag-accent-one"
-        />
-        <Tag
-          label="AccentTwo"
-          colorVariant="accentTwo"
-          data-se="tag-accent-two"
-        />
-        <Tag
-          label="AccentThree"
-          colorVariant="accentThree"
-          data-se="tag-accent-three"
-        />
-        <Tag
-          label="AccentFour"
-          colorVariant="accentFour"
-          data-se="tag-accent-four"
-        />
+        <Tag label="Default" />
+        <Tag label="Info" colorVariant="info" />
+        <Tag label="AccentOne" colorVariant="accentOne" />
+        <Tag label="AccentTwo" colorVariant="accentTwo" />
+        <Tag label="AccentThree" colorVariant="accentThree" />
+        <Tag label="AccentFour" colorVariant="accentFour" />
       </Box>
     </BackgroundProvider>
   ),
@@ -405,38 +339,32 @@ export const TagsOnGrayBackground: StoryObj<TagProps> = {
     const canvas = within(canvasElement);
     await checkTagStyles(
       canvas,
-      "tag-default",
+      "Default",
       Tokens.HueNeutral200,
       Tokens.TypographyColorBody,
     );
+    await checkTagStyles(canvas, "Info", Tokens.HueBlue200, Tokens.HueBlue700);
     await checkTagStyles(
       canvas,
-      "tag-info",
-      Tokens.HueBlue200,
-      Tokens.HueBlue700,
-    );
-
-    await checkTagStyles(
-      canvas,
-      "tag-accent-one",
+      "AccentOne",
       Tokens.HueAccentOne200,
       Tokens.HueAccentOne700,
     );
     await checkTagStyles(
       canvas,
-      "tag-accent-two",
+      "AccentTwo",
       Tokens.HueAccentTwo200,
       Tokens.HueAccentTwo700,
     );
     await checkTagStyles(
       canvas,
-      "tag-accent-three",
+      "AccentThree",
       Tokens.HueAccentThree200,
       Tokens.HueAccentThree700,
     );
     await checkTagStyles(
       canvas,
-      "tag-accent-four",
+      "AccentFour",
       Tokens.HueAccentFour200,
       Tokens.HueAccentFour700,
     );

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
@@ -244,7 +244,7 @@ export const Disabled: StoryObj<TagProps> = {
 export const TagsOnWhiteBackground: StoryObj<TagProps> = {
   name: "Tags on White Background",
   render: () => (
-    <BackgroundProvider value="white">
+    <BackgroundProvider value="highContrast">
       <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
         <Tag label="Default" />
         <Tag label="Info" colorVariant="info" />
@@ -286,7 +286,7 @@ export const TagsOnWhiteBackground: StoryObj<TagProps> = {
       },
       description: {
         story:
-          "Demonstrates how the `Tag` component behaves on a white background using `BackgroundProvider`.",
+          "Demonstrates how the `Tag` component behaves on a white (`highContrast`) background using `BackgroundProvider`.",
       },
     },
   },
@@ -295,7 +295,7 @@ export const TagsOnWhiteBackground: StoryObj<TagProps> = {
 export const TagsOnGrayBackground: StoryObj<TagProps> = {
   name: "Tags on Gray Background",
   render: () => (
-    <BackgroundProvider value="gray">
+    <BackgroundProvider value="lowContrast">
       <Box
         sx={{
           backgroundColor: "#F4F4F4",
@@ -334,7 +334,7 @@ export const TagsOnGrayBackground: StoryObj<TagProps> = {
   parameters: {
     docs: {
       source: {
-        code: `<BackgroundProvider value="gray">
+        code: `<BackgroundProvider value="lowContrast">
   <Tag label="Default" />
   <Tag label="Info" colorVariant="info" />
   <Tag label="AccentOne" colorVariant="accentOne" />
@@ -345,7 +345,7 @@ export const TagsOnGrayBackground: StoryObj<TagProps> = {
       },
       description: {
         story:
-          "Demonstrates how the `Tag` component behaves on a gray background using `BackgroundProvider`.",
+          "Demonstrates how the `Tag` component behaves on a gray (`lowContrast`) background using `BackgroundProvider`.",
       },
     },
   },

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
@@ -18,6 +18,7 @@ import {
   TagList,
   TagProps,
 } from "@okta/odyssey-react-mui";
+import * as Tokens from "@okta/odyssey-design-tokens";
 import { MuiThemeDecorator } from "../../../../.storybook/components";
 import { GroupIcon } from "@okta/odyssey-react-mui/icons";
 import icons from "../../../../.storybook/components/iconUtils";
@@ -117,6 +118,7 @@ const storybookMeta: Meta<TagProps> = {
   args: {
     label: "Starship",
     colorVariant: "default",
+    testId: "tag-default",
   },
   decorators: [MuiThemeDecorator],
   tags: ["autodocs"],
@@ -126,11 +128,11 @@ export default storybookMeta;
 
 const checkTagStyles = async (
   canvas: ReturnType<typeof within>,
-  tagLabel: string,
+  testId: string,
   expectedBackgroundColor: string,
   expectedColor: string,
 ) => {
-  const tag = canvas.getByText(tagLabel);
+  const tag = canvas.getByTestId(testId);
   await expect(tag).toHaveStyle(`background-color: ${expectedBackgroundColor}`);
   await expect(tag).toHaveStyle(`color: ${expectedColor}`);
 };
@@ -138,6 +140,7 @@ const checkTagStyles = async (
 export const Default: StoryObj<TagProps> = {
   args: {
     label: "Starship",
+    testId: "tag-default",
   },
 };
 
@@ -145,6 +148,7 @@ export const Info: StoryObj<TagProps> = {
   args: {
     label: "Starship",
     colorVariant: "info",
+    testId: "tag-info",
   },
 };
 
@@ -152,6 +156,7 @@ export const AccentOne: StoryObj<TagProps> = {
   args: {
     label: "Starship",
     colorVariant: "accentOne",
+    testId: "tag-accent-one",
   },
 };
 
@@ -159,6 +164,7 @@ export const AccentTwo: StoryObj<TagProps> = {
   args: {
     label: "Starship",
     colorVariant: "accentTwo",
+    testId: "tag-accent-two",
   },
 };
 
@@ -166,6 +172,7 @@ export const AccentThree: StoryObj<TagProps> = {
   args: {
     label: "Starship",
     colorVariant: "accentThree",
+    testId: "tag-accent-three",
   },
 };
 
@@ -173,6 +180,7 @@ export const AccentFour: StoryObj<TagProps> = {
   args: {
     label: "Starship",
     colorVariant: "accentFour",
+    testId: "tag-accent-four",
   },
 };
 
@@ -180,12 +188,28 @@ export const List: StoryObj<TagProps> = {
   render: function C(args) {
     return (
       <TagList>
-        <Tag label={args.label} />
-        <Tag label="Info tag" colorVariant="info" />
-        <Tag label="AccentOne tag" colorVariant="accentOne" />
-        <Tag label="AccentTwo tag" colorVariant="accentTwo" />
-        <Tag label="AccentThree tag" colorVariant="accentThree" />
-        <Tag label="AccentFour tag" colorVariant="accentFour" />
+        <Tag label={args.label} data-se="tag-default" />
+        <Tag label="Info tag" colorVariant="info" data-se="tag-info" />
+        <Tag
+          label="AccentOne tag"
+          colorVariant="accentOne"
+          data-se="tag-accent-one"
+        />
+        <Tag
+          label="AccentTwo tag"
+          colorVariant="accentTwo"
+          data-se="tag-accent-two"
+        />
+        <Tag
+          label="AccentThree tag"
+          colorVariant="accentThree"
+          data-se="tag-accent-three"
+        />
+        <Tag
+          label="AccentFour tag"
+          colorVariant="accentFour"
+          data-se="tag-accent-four"
+        />
       </TagList>
     );
   },
@@ -198,20 +222,25 @@ export const Icon: StoryObj<TagProps> = {
   args: {
     label: "Crew",
     icon: <GroupIcon />,
+    testId: "tag-icon",
   },
 };
 
 export const Clickable: StoryObj<TagProps> = {
   args: {
     label: "Starship",
+    testId: "tag-clickable",
   },
   play: async ({ args, canvasElement, step }) => {
     await step("remove the tag on click", async () => {
-      const canvas = within(canvasElement);
-      const tag = canvas.getByText(args.label);
-      await userEvent.click(tag);
-      expect(args.onClick).toHaveBeenCalledTimes(1);
-      await axeRun("Clickable Tag");
+      const tag = canvasElement.querySelector(`[data-se="${args.testId}"]`);
+      if (tag) {
+        await userEvent.click(tag);
+        expect(args.onClick).toHaveBeenCalledTimes(1);
+        await axeRun("Clickable Tag");
+      } else {
+        throw new Error(`Element with data-se="${args.testId}" not found`);
+      }
     });
   },
 };
@@ -219,6 +248,7 @@ export const Clickable: StoryObj<TagProps> = {
 export const Removable: StoryObj<TagProps> = {
   args: {
     label: "Starship",
+    testId: "tag-removable",
   },
   play: async ({ args, canvasElement, step }) => {
     await step("remove the tag on click", async () => {
@@ -238,6 +268,7 @@ export const Disabled: StoryObj<TagProps> = {
   args: {
     label: "Starship",
     isDisabled: true,
+    testId: "tag-disabled",
   },
 };
 
@@ -246,12 +277,28 @@ export const TagsOnWhiteBackground: StoryObj<TagProps> = {
   render: () => (
     <BackgroundProvider value="highContrast">
       <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
-        <Tag label="Default" />
-        <Tag label="Info" colorVariant="info" />
-        <Tag label="AccentOne" colorVariant="accentOne" />
-        <Tag label="AccentTwo" colorVariant="accentTwo" />
-        <Tag label="AccentThree" colorVariant="accentThree" />
-        <Tag label="AccentFour" colorVariant="accentFour" />
+        <Tag label="Default" data-se="tag-default" />
+        <Tag label="Info" colorVariant="info" data-se="tag-info" />
+        <Tag
+          label="AccentOne"
+          colorVariant="accentOne"
+          data-se="tag-accent-one"
+        />
+        <Tag
+          label="AccentTwo"
+          colorVariant="accentTwo"
+          data-se="tag-accent-two"
+        />
+        <Tag
+          label="AccentThree"
+          colorVariant="accentThree"
+          data-se="tag-accent-three"
+        />
+        <Tag
+          label="AccentFour"
+          colorVariant="accentFour"
+          data-se="tag-accent-four"
+        />
       </Box>
     </BackgroundProvider>
   ),
@@ -259,23 +306,47 @@ export const TagsOnWhiteBackground: StoryObj<TagProps> = {
     const canvas = within(canvasElement);
     await checkTagStyles(
       canvas,
-      "Default",
-      "rgb(243, 244, 246)",
-      "rgb(23, 27, 37)",
+      "tag-default",
+      Tokens.HueNeutral100,
+      Tokens.TypographyColorBody,
     );
     await checkTagStyles(
       canvas,
-      "Info",
-      "rgb(236, 242, 255)",
-      "rgb(2, 48, 135)",
+      "tag-info",
+      Tokens.HueBlue100,
+      Tokens.HueBlue700,
     );
-    // Add checks for other color variants
-    await axeRun("Tags on White Background");
+    await checkTagStyles(
+      canvas,
+      "tag-accent-one",
+      Tokens.HueAccentOne100,
+      Tokens.HueAccentOne700,
+    );
+    await checkTagStyles(
+      canvas,
+      "tag-accent-two",
+      Tokens.HueAccentTwo100,
+      Tokens.HueAccentTwo700,
+    );
+    await checkTagStyles(
+      canvas,
+      "tag-accent-three",
+      Tokens.HueAccentThree100,
+      Tokens.HueAccentThree700,
+    );
+    await checkTagStyles(
+      canvas,
+      "tag-accent-four",
+      Tokens.HueAccentFour100,
+      Tokens.HueAccentFour700,
+    );
+
+    await axeRun("Tags on white (`highContrast`) background");
   },
   parameters: {
     docs: {
       source: {
-        code: `<BackgroundProvider>
+        code: `<BackgroundProvider value="highContrast">
   <Tag label="Default" />
   <Tag label="Info" colorVariant="info" />
   <Tag label="AccentOne" colorVariant="accentOne" />
@@ -298,19 +369,35 @@ export const TagsOnGrayBackground: StoryObj<TagProps> = {
     <BackgroundProvider value="lowContrast">
       <Box
         sx={{
-          backgroundColor: "#F4F4F4",
+          backgroundColor: Tokens.HueNeutral50,
           padding: "24px",
           display: "flex",
           flexWrap: "wrap",
           gap: 2,
         }}
       >
-        <Tag label="Default" />
-        <Tag label="Info" colorVariant="info" />
-        <Tag label="AccentOne" colorVariant="accentOne" />
-        <Tag label="AccentTwo" colorVariant="accentTwo" />
-        <Tag label="AccentThree" colorVariant="accentThree" />
-        <Tag label="AccentFour" colorVariant="accentFour" />
+        <Tag label="Default" data-se="tag-default" />
+        <Tag label="Info" colorVariant="info" data-se="tag-info" />
+        <Tag
+          label="AccentOne"
+          colorVariant="accentOne"
+          data-se="tag-accent-one"
+        />
+        <Tag
+          label="AccentTwo"
+          colorVariant="accentTwo"
+          data-se="tag-accent-two"
+        />
+        <Tag
+          label="AccentThree"
+          colorVariant="accentThree"
+          data-se="tag-accent-three"
+        />
+        <Tag
+          label="AccentFour"
+          colorVariant="accentFour"
+          data-se="tag-accent-four"
+        />
       </Box>
     </BackgroundProvider>
   ),
@@ -318,18 +405,43 @@ export const TagsOnGrayBackground: StoryObj<TagProps> = {
     const canvas = within(canvasElement);
     await checkTagStyles(
       canvas,
-      "Default",
-      "rgb(229, 231, 235)",
-      "rgb(23, 27, 37)",
+      "tag-default",
+      Tokens.HueNeutral200,
+      Tokens.TypographyColorBody,
     );
     await checkTagStyles(
       canvas,
-      "Info",
-      "rgb(225, 235, 255)",
-      "rgb(2, 48, 135)",
+      "tag-info",
+      Tokens.HueBlue200,
+      Tokens.HueBlue700,
     );
-    // Add checks for other color variants
-    await axeRun("Tags on Gray Background");
+
+    await checkTagStyles(
+      canvas,
+      "tag-accent-one",
+      Tokens.HueAccentOne200,
+      Tokens.HueAccentOne700,
+    );
+    await checkTagStyles(
+      canvas,
+      "tag-accent-two",
+      Tokens.HueAccentTwo200,
+      Tokens.HueAccentTwo700,
+    );
+    await checkTagStyles(
+      canvas,
+      "tag-accent-three",
+      Tokens.HueAccentThree200,
+      Tokens.HueAccentThree700,
+    );
+    await checkTagStyles(
+      canvas,
+      "tag-accent-four",
+      Tokens.HueAccentFour200,
+      Tokens.HueAccentFour700,
+    );
+
+    await axeRun("Tags on gray (`lowContrast`) background");
   },
   parameters: {
     docs: {

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
@@ -211,7 +211,7 @@ export const Clickable: StoryObj<TagProps> = {
   play: async ({ args, canvasElement, step }) => {
     await step("click the tag", async () => {
       const canvas = within(canvasElement);
-      const tag = canvas.getByText(args.label);
+      const tag = canvas.getByRole("button", { name: args.label });
       await userEvent.click(tag);
       expect(args.onClick).toHaveBeenCalledTimes(1);
       await axeRun("Clickable Tag");

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
@@ -11,7 +11,13 @@
  */
 
 import { Meta, StoryObj } from "@storybook/react";
-import { Tag, TagList, TagProps } from "@okta/odyssey-react-mui";
+import {
+  BackgroundProvider,
+  Box,
+  Tag,
+  TagList,
+  TagProps,
+} from "@okta/odyssey-react-mui";
 import { MuiThemeDecorator } from "../../../../.storybook/components";
 import { GroupIcon } from "@okta/odyssey-react-mui/icons";
 import icons from "../../../../.storybook/components/iconUtils";
@@ -118,6 +124,17 @@ const storybookMeta: Meta<TagProps> = {
 
 export default storybookMeta;
 
+const checkTagStyles = async (
+  canvas: ReturnType<typeof within>,
+  tagLabel: string,
+  expectedBackgroundColor: string,
+  expectedColor: string,
+) => {
+  const tag = canvas.getByText(tagLabel);
+  await expect(tag).toHaveStyle(`background-color: ${expectedBackgroundColor}`);
+  await expect(tag).toHaveStyle(`color: ${expectedColor}`);
+};
+
 export const Default: StoryObj<TagProps> = {
   args: {
     label: "Starship",
@@ -221,5 +238,115 @@ export const Disabled: StoryObj<TagProps> = {
   args: {
     label: "Starship",
     isDisabled: true,
+  },
+};
+
+export const TagsOnWhiteBackground: StoryObj<TagProps> = {
+  name: "Tags on White Background",
+  render: () => (
+    <BackgroundProvider value="white">
+      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+        <Tag label="Default" />
+        <Tag label="Info" colorVariant="info" />
+        <Tag label="AccentOne" colorVariant="accentOne" />
+        <Tag label="AccentTwo" colorVariant="accentTwo" />
+        <Tag label="AccentThree" colorVariant="accentThree" />
+        <Tag label="AccentFour" colorVariant="accentFour" />
+      </Box>
+    </BackgroundProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await checkTagStyles(
+      canvas,
+      "Default",
+      "rgb(243, 244, 246)",
+      "rgb(23, 27, 37)",
+    );
+    await checkTagStyles(
+      canvas,
+      "Info",
+      "rgb(236, 242, 255)",
+      "rgb(2, 48, 135)",
+    );
+    // Add checks for other color variants
+    await axeRun("Tags on White Background");
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<BackgroundProvider>
+  <Tag label="Default" />
+  <Tag label="Info" colorVariant="info" />
+  <Tag label="AccentOne" colorVariant="accentOne" />
+  <Tag label="AccentTwo" colorVariant="accentTwo" />
+  <Tag label="AccentThree" colorVariant="accentThree" />
+  <Tag label="AccentFour" colorVariant="accentFour" />
+</BackgroundProvider>`,
+      },
+      description: {
+        story:
+          "Demonstrates how the `Tag` component behaves on a white background using `BackgroundProvider`.",
+      },
+    },
+  },
+};
+
+export const TagsOnGrayBackground: StoryObj<TagProps> = {
+  name: "Tags on Gray Background",
+  render: () => (
+    <BackgroundProvider value="gray">
+      <Box
+        sx={{
+          backgroundColor: "#F4F4F4",
+          padding: "24px",
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 2,
+        }}
+      >
+        <Tag label="Default" />
+        <Tag label="Info" colorVariant="info" />
+        <Tag label="AccentOne" colorVariant="accentOne" />
+        <Tag label="AccentTwo" colorVariant="accentTwo" />
+        <Tag label="AccentThree" colorVariant="accentThree" />
+        <Tag label="AccentFour" colorVariant="accentFour" />
+      </Box>
+    </BackgroundProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await checkTagStyles(
+      canvas,
+      "Default",
+      "rgb(229, 231, 235)",
+      "rgb(23, 27, 37)",
+    );
+    await checkTagStyles(
+      canvas,
+      "Info",
+      "rgb(225, 235, 255)",
+      "rgb(2, 48, 135)",
+    );
+    // Add checks for other color variants
+    await axeRun("Tags on Gray Background");
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<BackgroundProvider value="gray">
+  <Tag label="Default" />
+  <Tag label="Info" colorVariant="info" />
+  <Tag label="AccentOne" colorVariant="accentOne" />
+  <Tag label="AccentTwo" colorVariant="accentTwo" />
+  <Tag label="AccentThree" colorVariant="accentThree" />
+  <Tag label="AccentFour" colorVariant="accentFour" />
+</BackgroundProvider>`,
+      },
+      description: {
+        story:
+          "Demonstrates how the `Tag` component behaves on a gray background using `BackgroundProvider`.",
+      },
+    },
   },
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tooltip/Tooltip.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tooltip/Tooltip.stories.tsx
@@ -175,18 +175,6 @@ export const StatusWrapper: StoryObj<TooltipProps> = {
   },
 };
 
-export const Disabled: StoryObj<TooltipProps> = {
-  ...Template,
-  args: {
-    children: (
-      <Button variant="secondary" isDisabled startIcon={<DownloadIcon />} />
-    ),
-    ariaType: "description",
-    placement: "top",
-    text: "You don't have access to these logs",
-  },
-};
-
 export const Placement: StoryObj<TooltipProps> = {
   render: function C({}) {
     return (


### PR DESCRIPTION
[DES-6423](https://oktainc.atlassian.net/browse/DES-6423)

## Summary

**This is a variation of [my other PR that leverages OdysseyProvider and leverages the theme to add the BackgroundProvider logic globally](https://github.com/okta/odyssey/pull/2364)**

* Adds BackgroundContext react context which can be used to display optimized contrast versions of certain components/component states
* Currently configured for `isDisabled` secondary `Button`, `Status`, and `Tag`
* Uses styled-components for the lowContrast/highContrast style differneces.

**Example usage:**

`<BackgroundProvider value="lowContrast">
  <Button
    isDisabled
    label="Secondary"
    onClick={() => {}}
    variant="secondary"
  />
</BackgroundProvider>`



## Testing & Screenshots

- [x] I have confirmed this change with my designer and the Odyssey Design Team.
![CleanShot 2024-09-18 at 10 05 46@2x](https://github.com/user-attachments/assets/7d75544a-4471-4d4c-bf86-09f72d167b92)
