### PR TITLE
Add onPaginationChange hook to DataView

### DIFF
--- a/packages/odyssey-react-mui/src/labs/DataView/DataView.test.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataView/DataView.test.tsx
@@ -76,10 +76,12 @@ describe("DataView", () => {
     });
     expect(rowElements.length).toBe(21);
 
-    fireEvent.click(screen.getByText("Show more"));
+    fireEvent.click(await screen.findByText("Show more"));
 
     waitFor(() => {
-      const loadedRows = within(tableElement).getAllByRole("row");
+      const loadedRows = within(tableElement).getAllByRole("row", {
+        hidden: false,
+      });
       expect(loadedRows.length).toBe(41);
     });
   });

--- a/packages/odyssey-react-mui/src/labs/DataView/DataView.test.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataView/DataView.test.tsx
@@ -76,9 +76,9 @@ describe("DataView", () => {
     });
     expect(rowElements.length).toBe(21);
 
-    fireEvent.click(await screen.findByText("Show more"));
-
     waitFor(() => {
+      fireEvent.click(screen.getByText("Show more"));
+
       const loadedRows = within(tableElement).getAllByRole("row", {
         hidden: false,
       });

--- a/packages/odyssey-react-mui/src/labs/DataView/DataView.test.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataView/DataView.test.tsx
@@ -79,9 +79,7 @@ describe("DataView", () => {
     fireEvent.click(screen.getByText("Show more"));
 
     waitFor(() => {
-      const loadedRows = within(tableElement).getAllByRole("row", {
-        hidden: false,
-      });
+      const loadedRows = within(tableElement).getAllByRole("row");
       expect(loadedRows.length).toBe(41);
     });
   });

--- a/packages/odyssey-react-mui/src/labs/DataView/DataView.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataView/DataView.tsx
@@ -123,6 +123,7 @@ const DataView = ({
   totalRows,
   maxPages,
   maxResultsPerPage,
+  onPaginationChange,
 }: DataViewProps) => {
   const odysseyDesignTokens = useOdysseyDesignTokens();
   const { t } = useTranslation();
@@ -217,6 +218,11 @@ const DataView = ({
       pageSize: paginationType == "loadMore" ? resultsPerPage : prev.pageSize,
     }));
   }, [filters, paginationType, resultsPerPage, search]);
+
+  // Fire onPaginationChange if pagination changes
+  useEffect(() => {
+    onPaginationChange?.(pagination);
+  }, [onPaginationChange, pagination]);
 
   // Retrieve the data
   useEffect(() => {

--- a/packages/odyssey-react-mui/src/labs/DataView/DataView.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataView/DataView.tsx
@@ -35,7 +35,7 @@ import { DataFilters } from "../DataFilters";
 import { EmptyState } from "../../EmptyState";
 import { fetchData } from "./fetchData";
 import { LayoutSwitcher } from "./LayoutSwitcher";
-import { MenuButton } from "../..";
+import { MenuButton } from "../../MenuButton";
 import { MoreIcon } from "../../icons.generated";
 import { TableSettings } from "./TableSettings";
 import { Pagination, usePagination } from "../../Pagination";
@@ -43,6 +43,7 @@ import { TableLayoutContent } from "./TableLayoutContent";
 import { CardLayoutContent } from "./CardLayoutContent";
 import { useFilterConversion } from "./useFilterConversion";
 import { useRowReordering } from "../../DataTable/useRowReordering";
+import { Typography } from "../../Typography";
 import {
   DesignTokens,
   useOdysseyDesignTokens,
@@ -72,6 +73,20 @@ const AdditionalActionsContainer = styled("div", {
   gap: odysseyDesignTokens.Spacing2,
 }));
 
+const AdditionalActionsInner = styled("div", {
+  shouldForwardProp: (prop) => prop !== "odysseyDesignTokens",
+})<{ odysseyDesignTokens: DesignTokens }>(({ odysseyDesignTokens }) => ({
+  display: "flex",
+  alignItems: "center",
+  gap: odysseyDesignTokens.Spacing2,
+}));
+
+const MetaTextContainer = styled("div", {
+  shouldForwardProp: (prop) => prop !== "odysseyDesignTokens",
+})<{ odysseyDesignTokens: DesignTokens }>(({ odysseyDesignTokens }) => ({
+  marginInlineEnd: odysseyDesignTokens.Spacing2,
+}));
+
 const DataView = ({
   additionalActionButton,
   additionalActionMenuItems,
@@ -96,6 +111,7 @@ const DataView = ({
   isNoResults: isNoResultsProp,
   isPaginationMoreDisabled,
   isRowReorderingDisabled,
+  metaText,
   noResultsPlaceholder,
   onChangeRowSelection,
   onReorderRows,
@@ -266,49 +282,62 @@ const DataView = ({
     return;
   }, [noResultsPlaceholder, t, isEmpty, isNoResults, emptyPlaceholder]);
 
-  const additionalActions = useMemo(
-    () => (
-      <>
-        {currentLayout === "table" && tableLayoutOptions && (
-          <TableSettings
-            setTableState={setTableState}
-            tableLayoutOptions={tableLayoutOptions}
-            tableState={tableState}
-          />
-        )}
+  const additionalActions = useMemo(() => {
+    return (
+      (metaText ||
+        (currentLayout === "table" && tableLayoutOptions) ||
+        availableLayouts.length > 1 ||
+        additionalActionButton ||
+        additionalActionMenuItems) && (
+        <AdditionalActionsInner odysseyDesignTokens={odysseyDesignTokens}>
+          {metaText && (
+            <MetaTextContainer odysseyDesignTokens={odysseyDesignTokens}>
+              <Typography color="textSecondary">{metaText}</Typography>
+            </MetaTextContainer>
+          )}
 
-        {availableLayouts.length > 1 && (
-          <LayoutSwitcher
-            availableLayouts={availableLayouts}
-            currentLayout={currentLayout}
-            setCurrentLayout={setCurrentLayout}
-          />
-        )}
+          {currentLayout === "table" && tableLayoutOptions && (
+            <TableSettings
+              setTableState={setTableState}
+              tableLayoutOptions={tableLayoutOptions}
+              tableState={tableState}
+            />
+          )}
 
-        {additionalActionButton}
+          {availableLayouts.length > 1 && (
+            <LayoutSwitcher
+              availableLayouts={availableLayouts}
+              currentLayout={currentLayout}
+              setCurrentLayout={setCurrentLayout}
+            />
+          )}
 
-        {additionalActionMenuItems && (
-          <MenuButton
-            endIcon={<MoreIcon />}
-            ariaLabel={t("table.moreactions.arialabel")}
-            buttonVariant="secondary"
-            menuAlignment="right"
-          >
-            {additionalActionMenuItems}
-          </MenuButton>
-        )}
-      </>
-    ),
-    [
-      currentLayout,
-      tableLayoutOptions,
-      tableState,
-      availableLayouts,
-      additionalActionButton,
-      additionalActionMenuItems,
-      t,
-    ],
-  );
+          {additionalActionButton}
+
+          {additionalActionMenuItems && (
+            <MenuButton
+              endIcon={<MoreIcon />}
+              ariaLabel={t("table.moreactions.arialabel")}
+              buttonVariant="secondary"
+              menuAlignment="right"
+            >
+              {additionalActionMenuItems}
+            </MenuButton>
+          )}
+        </AdditionalActionsInner>
+      )
+    );
+  }, [
+    additionalActionButton,
+    additionalActionMenuItems,
+    availableLayouts,
+    currentLayout,
+    metaText,
+    odysseyDesignTokens,
+    tableLayoutOptions,
+    tableState,
+    t,
+  ]);
 
   const enableVirtualization = useMemo(
     () => enableVirtualizationProp ?? paginationType === "loadMore",
@@ -365,11 +394,14 @@ const DataView = ({
         </BulkActionsContainer>
       )}
 
-      {!shouldShowFilters && !bulkActionMenuItems && !hasRowSelection && (
-        <AdditionalActionsContainer odysseyDesignTokens={odysseyDesignTokens}>
-          {additionalActions}
-        </AdditionalActionsContainer>
-      )}
+      {!shouldShowFilters &&
+        !bulkActionMenuItems &&
+        !hasRowSelection &&
+        additionalActions && (
+          <AdditionalActionsContainer odysseyDesignTokens={odysseyDesignTokens}>
+            {additionalActions}
+          </AdditionalActionsContainer>
+        )}
 
       {currentLayout === "table" && tableLayoutOptions && (
         <TableLayoutContent

--- a/packages/odyssey-react-mui/src/labs/DataView/componentTypes.ts
+++ b/packages/odyssey-react-mui/src/labs/DataView/componentTypes.ts
@@ -73,8 +73,19 @@ export type UniversalProps = {
   maxResultsPerPage?: number;
   metaText?: string;
   noResultsPlaceholder?: ReactNode;
+  /**
+   * @deprecated onChangeRowSelection is now onRowSelectionChange
+   */
   onChangeRowSelection?: (rowSelection: DataRowSelectionState) => void;
+  onPaginationChange?: ({
+    pageIndex,
+    pageSize,
+  }: {
+    pageIndex: number;
+    pageSize: number;
+  }) => void;
   onReorderRows?: ({ rowId, newRowIndex }: DataOnReorderRowsType) => void;
+  onRowSelectionChange?: (rowSelection: DataRowSelectionState) => void;
   paginationType?: (typeof paginationTypeValues)[number];
   resultsPerPage?: number;
   searchDelayTime?: number;

--- a/packages/odyssey-react-mui/src/labs/DataView/componentTypes.ts
+++ b/packages/odyssey-react-mui/src/labs/DataView/componentTypes.ts
@@ -71,6 +71,7 @@ export type UniversalProps = {
   isRowReorderingDisabled?: boolean;
   maxPages?: number;
   maxResultsPerPage?: number;
+  metaText?: string;
   noResultsPlaceholder?: ReactNode;
   onChangeRowSelection?: (rowSelection: DataRowSelectionState) => void;
   onReorderRows?: ({ rowId, newRowIndex }: DataOnReorderRowsType) => void;

--- a/packages/odyssey-storybook/src/components/odyssey-labs/DataView/DataView.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/DataView/DataView.stories.tsx
@@ -118,6 +118,9 @@ const storybookMeta: Meta<DataViewMetaProps> = {
     currentPage: {
       control: "number",
     },
+    metaText: {
+      control: "text",
+    },
     paginationType: {
       control: "select",
       options: paginationTypeValues,
@@ -417,6 +420,7 @@ const BaseStory: StoryObj<DataViewMetaProps> = {
         hasSearch={args.hasSearch}
         hasSearchSubmitButton={args.hasSearchSubmitButton}
         isPaginationMoreDisabled={args.isPaginationMoreDisabled}
+        metaText={args.metaText}
         searchDelayTime={args.searchDelayTime}
         errorMessage={args.errorMessage}
         initialLayout={args.initialLayout}
@@ -506,6 +510,7 @@ export const Everything: StoryObj<DataViewMetaProps> = {
     hasRowSelection: true,
     hasAdditionalActionButton: true,
     hasAdditionalActionMenuItems: true,
+    metaText: "Last updated 12 hours ago",
   },
 };
 

--- a/packages/odyssey-storybook/src/components/odyssey-labs/DataView/DataView.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/DataView/DataView.stories.tsx
@@ -989,3 +989,28 @@ export const LoadMore: StoryObj<DataViewMetaProps> = {
     hasFilters: true,
   },
 };
+
+export const PaginationHook: StoryObj<DataViewMetaProps> = {
+  render: function C() {
+    const [data, setData] = useState<Person[]>(personData);
+    const { getData } = useDataCallbacks(data, setData);
+
+    const onPaginationChange = (pagination: {
+      pageIndex: number;
+      pageSize: number;
+    }) => {
+      console.log(pagination);
+    };
+
+    return (
+      <DataView
+        hasPagination
+        onPaginationChange={onPaginationChange}
+        tableLayoutOptions={{
+          columns: personColumns,
+        }}
+        getData={getData}
+      />
+    );
+  },
+};


### PR DESCRIPTION
IGA needs an `onPaginationChange` hook in the DataView to make it work properly with their `react-query` implementation; any team using a cursor-based pagination approach in the backend will need this too.