### PR TITLE
Ensure storybook demo of row reordering actually reorders rows

### DIFF
--- a/packages/odyssey-storybook/src/components/odyssey-labs/DataView/dataFunctions.ts
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/DataView/dataFunctions.ts
@@ -158,10 +158,11 @@ export const reorderData = <Data extends Person>({
     return data;
   }
 
+  const [removedRow] = data.splice(rowIndex, 1);
+
   const reorderedData = [
-    ...data.slice(0, rowIndex),
-    ...data.slice(rowIndex + 1, newRowIndex),
-    data[rowIndex],
+    ...data.slice(0, newRowIndex),
+    removedRow,
     ...data.slice(newRowIndex),
   ];
 


### PR DESCRIPTION
There was a glitch in the code we provided to demonstrate how reordering works in the DataView. This fixes it.