### PR TITLE
OKTA-811934: Custom filtering prop for Autocomplete

### DIFF
--- a/packages/odyssey-react-mui/src/Autocomplete.tsx
+++ b/packages/odyssey-react-mui/src/Autocomplete.tsx
@@ -10,13 +10,14 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import styled from "@emotion/styled";
 import {
+  AutocompleteRenderInputParams,
+  AutocompleteValue,
+  InputBase,
   Autocomplete as MuiAutocomplete,
   AutocompleteProps as MuiAutocompleteProps,
-  InputBase,
   UseAutocompleteProps,
-  AutocompleteValue,
-  AutocompleteRenderInputParams,
 } from "@mui/material";
 import {
   createContext,
@@ -31,17 +32,16 @@ import {
   useRef,
   useState,
 } from "react";
-import styled from "@emotion/styled";
-import { VariableSizeList, ListChildComponentProps } from "react-window";
 import { useTranslation } from "react-i18next";
+import { ListChildComponentProps, VariableSizeList } from "react-window";
 
 import { Field } from "./Field";
 import { FieldComponentProps } from "./FieldComponentProps";
 import type { HtmlProps } from "./HtmlProps";
 import {
   ComponentControlledState,
-  useInputValues,
   getControlState,
+  useInputValues,
 } from "./inputUtils";
 import { TestSelector } from "./test-selectors";
 
@@ -217,6 +217,11 @@ export type AutocompleteProps<
   getIsOptionEqualToValue?: (option: OptionType, value: OptionType) => boolean;
 
   /**
+   * Used to customize the filtering logic for the options in the dropdown
+   */
+  getOptions?: (options: OptionType[], inputValue: string) => OptionType[];
+
+  /**
    * If this component is required to display a virtualized list of options,
    * then this value needs to be set to true.
    * It is recommended if you're options are on the order of 10's of hundreds or more.
@@ -271,6 +276,7 @@ const Autocomplete = <
   options,
   value,
   getIsOptionEqualToValue,
+  getOptions,
   testId,
   translate,
 }: AutocompleteProps<OptionType, HasMultipleChoices, IsCustomValueAllowed>) => {
@@ -555,6 +561,21 @@ const Autocomplete = <
     [onInputChangeProp],
   );
 
+  const filterOptions: MuiAutocompleteProps<
+    OptionType,
+    HasMultipleChoices,
+    undefined,
+    IsCustomValueAllowed
+  >["filterOptions"] = useCallback(
+    (options: OptionType[], { inputValue }: { inputValue: string }) => {
+      if (getOptions) {
+        return getOptions(options, inputValue);
+      }
+      return options;
+    },
+    [getOptions],
+  );
+
   return (
     <MuiAutocomplete
       {...valueProps}
@@ -586,6 +607,7 @@ const Autocomplete = <
       renderInput={renderInput}
       isOptionEqualToValue={getIsOptionEqualToValue}
       translate={translate}
+      filterOptions={filterOptions}
     />
   );
 };

--- a/packages/odyssey-react-mui/src/Autocomplete.tsx
+++ b/packages/odyssey-react-mui/src/Autocomplete.tsx
@@ -219,7 +219,12 @@ export type AutocompleteProps<
   /**
    * Used to customize the filtering logic for the options in the dropdown
    */
-  getOptions?: (options: OptionType[], inputValue: string) => OptionType[];
+  getOptions?: MuiAutocompleteProps<
+    OptionType,
+    HasMultipleChoices,
+    undefined,
+    IsCustomValueAllowed
+  >["filterOptions"];
 
   /**
    * If this component is required to display a virtualized list of options,
@@ -561,21 +566,6 @@ const Autocomplete = <
     [onInputChangeProp],
   );
 
-  const filterOptions: MuiAutocompleteProps<
-    OptionType,
-    HasMultipleChoices,
-    undefined,
-    IsCustomValueAllowed
-  >["filterOptions"] = useCallback(
-    (options: OptionType[], { inputValue }: { inputValue: string }) => {
-      if (getOptions) {
-        return getOptions(options, inputValue);
-      }
-      return options;
-    },
-    [getOptions],
-  );
-
   return (
     <MuiAutocomplete
       {...valueProps}
@@ -591,6 +581,7 @@ const Autocomplete = <
       disableCloseOnSelect={hasMultipleChoices}
       disabled={isDisabled}
       freeSolo={isCustomValueAllowed}
+      filterOptions={getOptions}
       filterSelectedOptions={true}
       id={idOverride}
       fullWidth={isFullWidth}
@@ -607,7 +598,6 @@ const Autocomplete = <
       renderInput={renderInput}
       isOptionEqualToValue={getIsOptionEqualToValue}
       translate={translate}
-      filterOptions={filterOptions}
     />
   );
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
@@ -652,7 +652,10 @@ export const CustomFilterAutocomplete: StoryObj<
       label: `Option ${numberWords[i]}`,
       value: i,
     }));
-    const getOptions = (options: OptionType[], inputValue: string) => {
+    const getOptions = (
+      options: OptionType[],
+      { inputValue }: { inputValue: string },
+    ) => {
       return options.filter(
         (option) =>
           option.label.toLowerCase().includes(inputValue.toLowerCase()) ||

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Autocomplete/Autocomplete.stories.tsx
@@ -606,3 +606,71 @@ export const ControlledMultipleVirtualizedAutocomplete: StoryObj<
     return <Autocomplete {...props} value={localValue} onChange={onChange} />;
   },
 };
+
+type OptionType = {
+  id: string;
+  label: string;
+  value: number;
+};
+
+export const CustomFilterAutocomplete: StoryObj<
+  typeof Autocomplete<OptionType, boolean, boolean>
+> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Searching by an attribute other than the label, `value` in this example",
+      },
+    },
+  },
+  args: {
+    hasMultipleChoices: true as const,
+    isVirtualized: true,
+    isReadOnly: false,
+    label: "label",
+    hint: 'Try searching "1" to get "Option One" and "Option Ten"',
+    getIsOptionEqualToValue: (option, value) => option.id === value.id,
+  },
+  render: function C(props) {
+    const numberWords = [
+      "Zero",
+      "One",
+      "Two",
+      "Three",
+      "Four",
+      "Five",
+      "Six",
+      "Seven",
+      "Eight",
+      "Nine",
+      "Ten",
+    ];
+
+    const options = Array.from({ length: 11 }, (_, i) => ({
+      id: `id-${i}`,
+      label: `Option ${numberWords[i]}`,
+      value: i,
+    }));
+    const getOptions = (options: OptionType[], inputValue: string) => {
+      return options.filter(
+        (option) =>
+          option.label.toLowerCase().includes(inputValue.toLowerCase()) ||
+          option.value.toString().includes(inputValue.toLowerCase()),
+      );
+    };
+
+    return (
+      <Autocomplete<OptionType, true, false>
+        {...props}
+        defaultValue={undefined}
+        hasMultipleChoices
+        isCustomValueAllowed={false}
+        getOptions={getOptions}
+        value={undefined}
+        onChange={undefined}
+        options={options}
+      />
+    );
+  },
+};


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[OKTA-811934](https://oktainc.atlassian.net/browse/OKTA-811934)

## Summary

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->
- Allows custom filtering logic to show/hide options based on attributes other than `label`.
- Adds an extra Storybook entry on Autocomplete to show an example filter based on `id` as well as `label`.

## Testing & Screenshots

- [x] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
<img width="517" alt="image" src="https://github.com/user-attachments/assets/4e3b151c-ab89-4bdb-a234-e9432a12829e">
