### PR TITLE
Disabled tag style updates for icon

### DIFF
--- a/packages/odyssey-react-mui/src/Tag.tsx
+++ b/packages/odyssey-react-mui/src/Tag.tsx
@@ -65,91 +65,115 @@ const getChipColors = (
       ...(contrastMode === "lowContrast" && {
         background: odysseyDesignTokens.HueNeutral200,
         text: odysseyDesignTokens.HueNeutral700,
+        textDisabled: odysseyDesignTokens.HueNeutral400,
       }),
       ...(contrastMode === "highContrast" && {
         background: odysseyDesignTokens.HueNeutral100,
         text: odysseyDesignTokens.HueNeutral700,
+        textDisabled: odysseyDesignTokens.HueNeutral300,
       }),
       hover: odysseyDesignTokens.HueNeutral200,
       active: odysseyDesignTokens.HueNeutral300,
       border: odysseyDesignTokens.HueNeutral200,
       deleteIcon: odysseyDesignTokens.HueNeutral500,
       deleteIconHover: odysseyDesignTokens.HueNeutral700,
+      icon: odysseyDesignTokens.HueNeutral700,
+      iconDisabled: odysseyDesignTokens.HueNeutral300,
     },
     info: {
       ...(contrastMode === "lowContrast" && {
         background: odysseyDesignTokens.HueBlue200,
         text: odysseyDesignTokens.HueBlue700,
+        textDisabled: odysseyDesignTokens.HueBlue400,
       }),
       ...(contrastMode === "highContrast" && {
         background: odysseyDesignTokens.HueBlue100,
         text: odysseyDesignTokens.HueBlue700,
+        textDisabled: odysseyDesignTokens.HueBlue300,
       }),
       hover: odysseyDesignTokens.HueBlue200,
       active: odysseyDesignTokens.HueBlue300,
       border: odysseyDesignTokens.HueBlue200,
       deleteIcon: odysseyDesignTokens.HueBlue500,
       deleteIconHover: odysseyDesignTokens.HueBlue700,
+      icon: odysseyDesignTokens.HueBlue700,
+      iconDisabled: odysseyDesignTokens.HueBlue300,
     },
     accentOne: {
       ...(contrastMode === "lowContrast" && {
         background: odysseyDesignTokens.HueAccentOne200,
         text: odysseyDesignTokens.HueAccentOne700,
+        textDisabled: odysseyDesignTokens.HueAccentOne400,
       }),
       ...(contrastMode === "highContrast" && {
         background: odysseyDesignTokens.HueAccentOne100,
         text: odysseyDesignTokens.HueAccentOne700,
+        textDisabled: odysseyDesignTokens.HueAccentOne300,
       }),
       hover: odysseyDesignTokens.HueAccentOne200,
       active: odysseyDesignTokens.HueAccentOne300,
       border: odysseyDesignTokens.HueAccentOne200,
       deleteIcon: odysseyDesignTokens.HueAccentOne500,
       deleteIconHover: odysseyDesignTokens.HueAccentOne700,
+      icon: odysseyDesignTokens.HueAccentOne700,
+      iconDisabled: odysseyDesignTokens.HueAccentOne300,
     },
     accentTwo: {
       ...(contrastMode === "lowContrast" && {
         background: odysseyDesignTokens.HueAccentTwo200,
         text: odysseyDesignTokens.HueAccentTwo800,
+        textDisabled: odysseyDesignTokens.HueAccentTwo400,
       }),
       ...(contrastMode === "highContrast" && {
         background: odysseyDesignTokens.HueAccentTwo100,
         text: odysseyDesignTokens.HueAccentTwo700,
+        textDisabled: odysseyDesignTokens.HueAccentTwo300,
       }),
       hover: odysseyDesignTokens.HueAccentTwo200,
       active: odysseyDesignTokens.HueAccentTwo300,
       border: odysseyDesignTokens.HueAccentTwo200,
       deleteIcon: odysseyDesignTokens.HueAccentTwo500,
       deleteIconHover: odysseyDesignTokens.HueAccentTwo700,
+      icon: odysseyDesignTokens.HueAccentTwo700,
+      iconDisabled: odysseyDesignTokens.HueAccentTwo300,
     },
     accentThree: {
       ...(contrastMode === "lowContrast" && {
         background: odysseyDesignTokens.HueAccentThree200,
         text: odysseyDesignTokens.HueAccentThree700,
+        textDisabled: odysseyDesignTokens.HueAccentThree400,
       }),
       ...(contrastMode === "highContrast" && {
         background: odysseyDesignTokens.HueAccentThree100,
         text: odysseyDesignTokens.HueAccentThree700,
+        textDisabled: odysseyDesignTokens.HueAccentThree300,
       }),
       hover: odysseyDesignTokens.HueAccentThree200,
       active: odysseyDesignTokens.HueAccentThree300,
       border: odysseyDesignTokens.HueAccentThree200,
       deleteIcon: odysseyDesignTokens.HueAccentThree500,
       deleteIconHover: odysseyDesignTokens.HueAccentThree700,
+      icon: odysseyDesignTokens.HueAccentThree700,
+      iconDisabled: odysseyDesignTokens.HueAccentThree300,
     },
     accentFour: {
       ...(contrastMode === "lowContrast" && {
         background: odysseyDesignTokens.HueAccentFour200,
         text: odysseyDesignTokens.HueAccentFour700,
+        textDisabled: odysseyDesignTokens.HueAccentFour400,
       }),
       ...(contrastMode === "highContrast" && {
         background: odysseyDesignTokens.HueAccentFour100,
         text: odysseyDesignTokens.HueAccentFour700,
+        textDisabled: odysseyDesignTokens.HueAccentFour300,
       }),
       hover: odysseyDesignTokens.HueAccentFour200,
       active: odysseyDesignTokens.HueAccentFour300,
       border: odysseyDesignTokens.HueAccentFour200,
       deleteIcon: odysseyDesignTokens.HueAccentFour500,
       deleteIconHover: odysseyDesignTokens.HueAccentFour700,
+      icon: odysseyDesignTokens.HueAccentFour700,
+      iconDisabled: odysseyDesignTokens.HueAccentFour300,
     },
   };
 
@@ -166,13 +190,21 @@ const StyledTag = styled(MuiChip, {
   contrastMode: ContrastMode;
   odysseyDesignTokens: DesignTokens;
   as?: React.ElementType; // Allow the 'as' prop to be forwarded
-}>(({ colorVariant, contrastMode, odysseyDesignTokens }) => {
+  clickable?: boolean;
+}>(({ colorVariant, contrastMode, odysseyDesignTokens, clickable }) => {
   const colors = getChipColors(colorVariant, odysseyDesignTokens, contrastMode);
 
   return {
     backgroundColor: colors.background,
     color: colors.text,
-    borderColor: colors.border,
+
+    ...(clickable === true && {
+      border: `1px solid ${colors.border}`,
+    }),
+
+    ...(clickable === false && {
+      border: "none",
+    }),
 
     "&.MuiChip-clickable:hover": {
       backgroundColor: colors.hover,
@@ -183,14 +215,18 @@ const StyledTag = styled(MuiChip, {
     },
 
     "&.Mui-disabled": {
-      "& .MuiChip-deleteIcon": {
-        color: odysseyDesignTokens.HueNeutral300,
+      color: colors.textDisabled,
+      border: `1px solid ${colors.border}`,
+      "& .MuiChip-icon, & .MuiChip-deleteIcon": {
+        color: colors.iconDisabled,
       },
     },
 
+    "& .MuiChip-icon": {
+      color: colors.icon,
+    },
     "& .MuiChip-deleteIcon": {
       color: colors.deleteIcon,
-
       "&:hover": {
         color: colors.deleteIconHover,
       },

--- a/packages/odyssey-react-mui/src/Tag.tsx
+++ b/packages/odyssey-react-mui/src/Tag.tsx
@@ -199,11 +199,11 @@ const StyledTag = styled(MuiChip, {
     color: colors.text,
 
     ...(clickable === true && {
-      border: `1px solid ${colors.border}`,
+      borderColor: colors.border,
     }),
 
     ...(clickable === false && {
-      border: "none",
+      borderColor: "transparent",
     }),
 
     "&.MuiChip-clickable:hover": {
@@ -216,7 +216,7 @@ const StyledTag = styled(MuiChip, {
 
     "&.Mui-disabled": {
       color: colors.textDisabled,
-      border: `1px solid ${colors.border}`,
+      borderColor: colors.border,
       "& .MuiChip-icon, & .MuiChip-deleteIcon": {
         color: colors.iconDisabled,
       },

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -1057,6 +1057,10 @@ export const components = ({
               [`& .${chipClasses.deleteIcon}`]: {
                 color: odysseyTokens.HueNeutral300,
               },
+
+              [`& .${chipClasses.icon}`]: {
+                color: odysseyTokens.HueNeutral300,
+              },
             },
 
             ...(ownerState.clickable && {


### PR DESCRIPTION
[DES-6564](https://oktainc.atlassian.net/browse/DES-6564)

## Summary
* Adds disabled style for icon in `Tag` 
* Updates border behavior to align with Figma (Border only on disabled or clickable/selectable Tags)
* Adds Disabled `lowContrast`/`highContrast` specific style for text to align with Figma


## Testing & Screenshots

- [x] I have confirmed this change with my designer and the Odyssey Design Team.

![CleanShot 2024-10-07 at 14 59 28@2x](https://github.com/user-attachments/assets/f5a5ccec-9b4d-4d0a-a6f9-8d9dacb6e998)
![CleanShot 2024-10-07 at 15 03 49@2x](https://github.com/user-attachments/assets/58876ee0-5203-41a9-a7df-b8a5f8a94e44)

