### PR TITLE
fix(odyssey-react-mui): wrap long menu items. Add sane max-height

### DIFF
--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -150,8 +150,6 @@ const ChipsInnerContainer = styled(MuiBox, {
   min-height: ${({ odysseyDesignTokens }) => odysseyDesignTokens.Spacing6};
 `;
 
-// const SelectStyleContainer = styled
-
 export type SelectValueType<HasMultipleChoices> =
   HasMultipleChoices extends true ? string[] : string;
 

--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -19,6 +19,7 @@ import {
   useState,
   useImperativeHandle,
 } from "react";
+import styled from "@emotion/styled";
 import {
   Box as MuiBox,
   Checkbox as MuiCheckbox,
@@ -27,9 +28,10 @@ import {
   ListSubheader,
   MenuItem as MuiMenuItem,
   Select as MuiSelect,
+  SelectProps as MuiSelectProps,
   SelectChangeEvent,
 } from "@mui/material";
-import { SelectProps as MuiSelectProps } from "@mui/material";
+
 import { Field } from "./Field";
 import {
   FieldComponentProps,
@@ -43,13 +45,12 @@ import {
   useInputValues,
   getControlState,
 } from "./inputUtils";
-import { normalizedKey } from "./useNormalizedKey";
-import styled from "@emotion/styled";
 import {
   useOdysseyDesignTokens,
   DesignTokens,
 } from "./OdysseyDesignTokensContext";
 import { TestSelector } from "./test-selectors";
+import { normalizedKey } from "./useNormalizedKey";
 
 export const SelectTestSelector = {
   accessibleText: {
@@ -148,6 +149,8 @@ const ChipsInnerContainer = styled(MuiBox, {
     isInteractive || isReadOnly ? 1 : 0};
   min-height: ${({ odysseyDesignTokens }) => odysseyDesignTokens.Spacing6};
 `;
+
+// const SelectStyleContainer = styled
 
 export type SelectValueType<HasMultipleChoices> =
   HasMultipleChoices extends true ? string[] : string;
@@ -508,6 +511,14 @@ const Select = <
             selectRef.current = el;
           }}
           labelId={labelElementId}
+          MenuProps={{
+            sx: {
+              ".MuiPaper-root": {
+                maxHeight: "50vh",
+                minHeight: "200px",
+              },
+            },
+          }}
           multiple={hasMultipleChoices}
           name={nameOverride ?? id}
           onBlur={onBlur}

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -2191,9 +2191,11 @@ export const components = ({
         root: ({ ownerState }) => ({
           gap: odysseyTokens.Spacing2,
           minHeight: "unset",
+          maxWidth: `calc(55ch - ${odysseyTokens.Spacing4})`,
           paddingBlock: odysseyTokens.Spacing3,
           paddingInline: odysseyTokens.Spacing4,
           borderRadius: odysseyTokens.BorderRadiusMain,
+          whiteSpace: "normal",
 
           [`& .${formControlLabelClasses.root}`]: {
             gap: "unset",


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[DES-6571](https://oktainc.atlassian.net/browse/DES-6571)

## Summary
- Wraps menu item when it gets long to ensure menu goes not grow in width

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots
### Before:
<img width="994" alt="image" src="https://github.com/user-attachments/assets/64beb171-b5d6-45c8-b415-2403867b8f58">

### After:
<img width="552" alt="image" src="https://github.com/user-attachments/assets/cbcd5438-8952-47b0-8b3c-c594890a3a81">

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
