### PR TITLE
Add loading state to AppTile

### DIFF
--- a/packages/odyssey-react-mui/src/labs/AppTile.tsx
+++ b/packages/odyssey-react-mui/src/labs/AppTile.tsx
@@ -21,6 +21,7 @@ import {
 import {
   Card as MuiCard,
   CardActionArea as MuiCardActionArea,
+  Skeleton as MuiSkeleton,
 } from "@mui/material";
 import styled from "@emotion/styled";
 
@@ -43,6 +44,8 @@ export type AppTileProps = {
   description?: string;
   // An image or icon at the top of the tile
   image?: ReactElement;
+  // If true, the AppTile is loading
+  isLoading?: boolean;
   // Event handler for when the user clicks the tile
   onClick: MouseEventHandler;
   // An 'eyebrow' of text above the title
@@ -124,6 +127,7 @@ const AppTile = ({
   children,
   description,
   image,
+  isLoading,
   onActionClick,
   onClick,
   overline,
@@ -134,24 +138,50 @@ const AppTile = ({
   const tileContent = useMemo(
     () => (
       <ContentContainer>
-        <Box>
+        <Box sx={{ width: "100%" }}>
           {image && (
             <ImageContainer
               odysseyDesignTokens={odysseyDesignTokens}
               hasAction={Boolean(onActionClick)}
             >
-              {image}
+              {isLoading ? (
+                <MuiSkeleton
+                  height={APP_TILE_IMAGE_HEIGHT}
+                  width={APP_TILE_IMAGE_HEIGHT}
+                  variant="rectangular"
+                />
+              ) : (
+                image
+              )}
             </ImageContainer>
           )}
 
-          {overline && <Support component="div">{overline}</Support>}
-          {title && <Heading5 component="div">{title}</Heading5>}
+          {overline && (
+            <Support component="div">
+              {isLoading ? <MuiSkeleton /> : overline}
+            </Support>
+          )}
+          {title && (
+            <Heading5 component="div">
+              {isLoading ? <MuiSkeleton /> : title}
+            </Heading5>
+          )}
           {description && (
-            <Paragraph color="textSecondary">{description}</Paragraph>
+            <Paragraph color="textSecondary">
+              {isLoading ? <MuiSkeleton /> : description}
+            </Paragraph>
           )}
           {children && (
             <ChildrenContainer odysseyDesignTokens={odysseyDesignTokens}>
-              {children}
+              {isLoading ? (
+                <MuiSkeleton
+                  variant="rounded"
+                  width="100%"
+                  height={odysseyDesignTokens.Spacing6}
+                />
+              ) : (
+                children
+              )}
             </ChildrenContainer>
           )}
         </Box>
@@ -161,6 +191,7 @@ const AppTile = ({
       image,
       odysseyDesignTokens,
       onActionClick,
+      isLoading,
       overline,
       title,
       description,
@@ -174,8 +205,10 @@ const AppTile = ({
 
       {(onActionClick || auxiliaryText) && (
         <ActionContainer odysseyDesignTokens={odysseyDesignTokens}>
-          {auxiliaryText && <Subordinate>{auxiliaryText}</Subordinate>}
-          {onActionClick && (
+          {auxiliaryText && !isLoading && (
+            <Subordinate>{auxiliaryText}</Subordinate>
+          )}
+          {onActionClick && !isLoading && (
             <Button
               endIcon={actionIcon}
               ariaLabel={actionLabel}

--- a/packages/odyssey-storybook/src/components/odyssey-labs/AppTile/AppTile.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/AppTile/AppTile.stories.tsx
@@ -115,6 +115,15 @@ const storybookMeta: Meta<AppTileProps> = {
         },
       },
     },
+    isLoading: {
+      control: null,
+      description: "If true, the component will display a loading state",
+      table: {
+        type: {
+          summary: "boolean",
+        },
+      },
+    },
     onActionClick: {
       control: null,
       description:
@@ -314,6 +323,44 @@ export const CustomContent: StoryObj<AppTileProps> = {
           }
         />
       </Box>
+    );
+  },
+};
+
+export const Loading: StoryObj<AppTileProps> = {
+  render: function C() {
+    const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(false);
+
+    return (
+      <>
+        <Drawer
+          isOpen={isDrawerOpen}
+          onClose={() => setIsDrawerOpen(false)}
+          showDividers={false}
+        />
+        <Box sx={{ maxWidth: 262 }}>
+          <AppTile
+            actionAriaControls=""
+            actionAriaExpanded={isDrawerOpen}
+            actionAriaHasPopup="menu"
+            actionIcon={<SettingsIcon />}
+            actionLabel="Open app settings"
+            auxiliaryText="Single sign-on"
+            onActionClick={() => setIsDrawerOpen(true)}
+            onClick={() => alert("Open the app")}
+            title="App name"
+            description="This is a description of the app."
+            image={<img src="https://placehold.co/128" alt="Example logo" />}
+            isLoading
+            children={
+              <TagList>
+                <Tag label="Tag 1" />
+                <Tag label="Tag 2" />
+              </TagList>
+            }
+          />
+        </Box>
+      </>
     );
   },
 };


### PR DESCRIPTION
This PR adds a loading/skeleton state to the `AppTile`, activated via the `isLoading` prop.

Only elements that are toggled will have a skeleton — for instance, if the `AppTile` doesn't contain a description, there won't be a skeleton description either.

If `children` is defined (`children` being the slot for content that the consumer can completely customize), the component can't infer the height of the contents, so the skeleton uses a common height. (It uses a height similar to that of the `TagList`, since that's a use case we know consumers will have for `children`). Future additions might include some way to pass the loading state to the `children` so consumers can define the loading state themself. This is overkill for now, though.

This PR also adds a Storybook story displaying the loading functionality.

<img width="295" alt="Screenshot 2024-10-09 at 11 02 09 PM" src="https://github.com/user-attachments/assets/97b82713-218d-47c8-ae6e-bdb3a7b0ea57">
