### PR TITLE
Truncate chips when rendered inside multi-selects

### DIFF
--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -511,6 +511,12 @@ export const components = ({
               borderColor: "transparent",
             },
           }),
+
+          ".MuiChip-root": {
+            // using 55ch - (48px(padding + clear button) + 4px) for spacing between chip and clear button to account for the 24px of padding on the right side of the container and the width of the clear button.
+            // Ensures chip does not enlarge the container or overlap the clear button
+            maxWidth: `calc(${odysseyTokens.TypographyLineLengthMax} - (${odysseyTokens.Spacing6} + ${odysseyTokens.Spacing6} + ${odysseyTokens.Spacing1}))`,
+          },
         }),
       },
     },
@@ -1757,6 +1763,12 @@ export const components = ({
           },
           [`&:has(+ [data-file-preview-container])`]: {
             marginBlockEnd: 0,
+          },
+
+          ".MuiChip-root": {
+            // using 55ch - 24px to account for the 24px of padding on the right side of the container.
+            // Ensures chip does not enlarge the container
+            maxWidth: `calc(${odysseyTokens.TypographyLineLengthMax} - ${odysseyTokens.Spacing6})`,
           },
         }),
       },


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[DES-6605](https://oktainc.atlassian.net/browse/DES-6605)

## Summary
Tags could be very long when 'selected'. This change limits them to ~55ch
<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots
### Select
#### Before:
<img width="1163" alt="image" src="https://github.com/user-attachments/assets/777160b1-39df-45a6-9b41-f4c34bc8723d">

#### After: 
<img width="587" alt="image" src="https://github.com/user-attachments/assets/cc2a4584-b8f7-41be-8d49-451f40f51361">

### Autocomplete
#### Before:
covers up 'clear' button
<img width="581" alt="image" src="https://github.com/user-attachments/assets/5d8f0b33-d152-448d-8e69-c1da7cebc84d">

#### After:
'clear' button unobstructed
<img width="563" alt="image" src="https://github.com/user-attachments/assets/10ea2bbe-0988-4a84-a127-d6506fd41d8b">

- [X] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
