### PR TITLE
Small `Tag` variant

### DIFF
--- a/packages/odyssey-react-mui/src/Tag.tsx
+++ b/packages/odyssey-react-mui/src/Tag.tsx
@@ -225,7 +225,6 @@ const StyledTag = styled(MuiChip, {
 
     ...(size === "small" && {
       paddingBlock: `calc(0.31875rem - ${odysseyDesignTokens.BorderWidthMain})`,
-      height: "26px",
     }),
 
     "&.MuiChip-clickable:hover": {

--- a/packages/odyssey-react-mui/src/Tag.tsx
+++ b/packages/odyssey-react-mui/src/Tag.tsx
@@ -24,6 +24,8 @@ import {
 } from "./OdysseyDesignTokensContext";
 import { TagListContext } from "./TagListContext";
 
+export const tagSizeValues = ["medium", "small"] as const;
+
 export const tagColorVariants = [
   "default",
   "info",
@@ -34,6 +36,7 @@ export const tagColorVariants = [
 ] as const;
 
 type TagColorVariant = (typeof tagColorVariants)[number];
+type TagSize = (typeof tagSizeValues)[number];
 
 export type TagProps = {
   icon?: ReactElement;
@@ -54,6 +57,10 @@ export type TagProps = {
    * Color variant of the Tag, affecting its appearance
    */
   colorVariant?: TagColorVariant;
+  /*
+   *  Size variant of the Tag
+   */
+  size?: TagSize;
 } & Pick<HtmlProps, "testId" | "translate">;
 
 const getChipColors = ({
@@ -187,16 +194,17 @@ const getChipColors = ({
 
 const StyledTag = styled(MuiChip, {
   shouldForwardProp: (prop) =>
-    !["colorVariant", "contrastMode", "odysseyDesignTokens"].includes(
+    !["colorVariant", "contrastMode", "odysseyDesignTokens", "size"].includes(
       prop as string,
     ),
 })<{
+  as?: React.ElementType; // Allow the 'as' prop to be forwarded
+  clickable?: boolean;
   colorVariant: TagColorVariant;
   contrastMode: ContrastMode;
   odysseyDesignTokens: DesignTokens;
-  as?: React.ElementType; // Allow the 'as' prop to be forwarded
-  clickable?: boolean;
-}>(({ colorVariant, contrastMode, odysseyDesignTokens, clickable }) => {
+  size?: TagSize;
+}>(({ colorVariant, contrastMode, odysseyDesignTokens, clickable, size }) => {
   const colors = getChipColors({
     colorVariant,
     odysseyDesignTokens,
@@ -213,6 +221,11 @@ const StyledTag = styled(MuiChip, {
 
     ...(clickable === false && {
       borderColor: "transparent",
+    }),
+
+    ...(size === "small" && {
+      paddingBlock: `calc(0.31875rem - ${odysseyDesignTokens.BorderWidthMain})`,
+      height: "26px",
     }),
 
     "&.MuiChip-clickable:hover": {
@@ -234,6 +247,7 @@ const StyledTag = styled(MuiChip, {
     "& .MuiChip-icon": {
       color: colors.icon,
     },
+
     "& .MuiChip-deleteIcon": {
       color: colors.deleteIcon,
       "&:hover": {
@@ -250,6 +264,7 @@ const Tag = ({
   label,
   onClick,
   onRemove,
+  size = "medium",
   testId,
   translate,
 }: TagProps) => {
@@ -261,34 +276,36 @@ const Tag = ({
     (muiProps: MuiPropsContextType) => (
       <StyledTag
         {...muiProps}
-        as={chipElementType}
         aria-disabled={isDisabled}
+        as={chipElementType}
         clickable={Boolean(onClick)}
-        data-se={testId}
         colorVariant={colorVariant}
-        odysseyDesignTokens={odysseyDesignTokens}
         contrastMode={contrastMode}
+        data-se={testId}
+        deleteIcon={<CloseCircleFilledIcon />}
         disabled={isDisabled}
         icon={icon}
         label={label}
+        odysseyDesignTokens={odysseyDesignTokens}
         onClick={onClick}
         onDelete={onRemove}
-        deleteIcon={<CloseCircleFilledIcon />}
+        size={size}
         translate={translate}
       />
     ),
     [
       chipElementType,
+      colorVariant,
+      contrastMode,
       icon,
       isDisabled,
       label,
+      odysseyDesignTokens,
       onClick,
       onRemove,
+      size,
       testId,
       translate,
-      colorVariant,
-      odysseyDesignTokens,
-      contrastMode,
     ],
   );
 

--- a/packages/odyssey-react-mui/src/Tag.tsx
+++ b/packages/odyssey-react-mui/src/Tag.tsx
@@ -224,7 +224,7 @@ const StyledTag = styled(MuiChip, {
     }),
 
     ...(size === "small" && {
-      paddingBlock: `calc(0.31875rem - ${odysseyDesignTokens.BorderWidthMain})`,
+      paddingBlock: `calc(${odysseyDesignTokens.Spacing1})`,
     }),
 
     "&.MuiChip-clickable:hover": {

--- a/packages/odyssey-react-mui/src/Tag.tsx
+++ b/packages/odyssey-react-mui/src/Tag.tsx
@@ -10,29 +10,29 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { memo, ReactElement, useCallback, useContext } from "react";
 import { Chip as MuiChip, ChipProps as MuiChipProps } from "@mui/material";
+import { memo, ReactElement, useCallback, useContext } from "react";
 import styled from "@emotion/styled";
 
-import { useContrastModeContext, ContrastMode } from "./useContrastMode";
-import { HtmlProps } from "./HtmlProps";
 import { CloseCircleFilledIcon } from "./icons.generated";
+import { HtmlProps } from "./HtmlProps";
 import { MuiPropsContext, MuiPropsContextType } from "./MuiPropsContext";
 import {
   DesignTokens,
   useOdysseyDesignTokens,
 } from "./OdysseyDesignTokensContext";
 import { TagListContext } from "./TagListContext";
+import { ContrastMode, useContrastModeContext } from "./useContrastMode";
 
-export const tagSizeValues = ["medium", "small"] as const;
+const tagSizeValues = ["medium", "small"] as const;
 
 export const tagColorVariants = [
+  "accentFour",
+  "accentOne",
+  "accentThree",
+  "accentTwo",
   "default",
   "info",
-  "accentOne",
-  "accentTwo",
-  "accentThree",
-  "accentFour",
 ] as const;
 
 type TagColorVariant = (typeof tagColorVariants)[number];

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
@@ -140,13 +140,6 @@ export const Default: StoryObj<TagProps> = {
   },
 };
 
-export const Small: StoryObj<TagProps> = {
-  args: {
-    label: "Starship",
-    size: "small",
-  },
-};
-
 export const Info: StoryObj<TagProps> = {
   args: {
     label: "Starship",
@@ -198,6 +191,13 @@ export const List: StoryObj<TagProps> = {
   },
   args: {
     label: "Default tag",
+  },
+};
+
+export const Small: StoryObj<TagProps> = {
+  args: {
+    label: "Starship",
+    size: "small",
   },
 };
 
@@ -253,34 +253,5 @@ export const Disabled: StoryObj<TagProps> = {
   args: {
     label: "Starship",
     isDisabled: true,
-  },
-};
-
-export const SizeInteraction: StoryObj<TagProps> = {
-  args: {
-    label: "Starship",
-  },
-  play: async ({ canvasElement, step }) => {
-    await step("verify size differences", async () => {
-      const canvas = within(canvasElement);
-      const defaultTag = canvas.getByText("Starship");
-
-      // Get computed styles for default size
-      const defaultStyles = window.getComputedStyle(defaultTag);
-      const defaultHeight = defaultStyles.height;
-
-      // Update to small size
-      defaultTag.setAttribute("size", "small");
-
-      // Get computed styles for small size
-      const smallStyles = window.getComputedStyle(defaultTag);
-      const smallHeight = smallStyles.height;
-
-      // Verify sizes are different
-      expect(defaultHeight).not.toBe(smallHeight);
-      expect(smallHeight).toBe("26px");
-
-      await axeRun("Size Interaction Tag");
-    });
   },
 };

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
@@ -180,7 +180,6 @@ export const List: StoryObj<TagProps> = {
     return (
       <TagList>
         <Tag label={args.label} />
-        <Tag label="Small tag" size="small" />
         <Tag label="Info tag" colorVariant="info" />
         <Tag label="AccentOne tag" colorVariant="accentOne" />
         <Tag label="AccentTwo tag" colorVariant="accentTwo" />
@@ -205,14 +204,6 @@ export const Icon: StoryObj<TagProps> = {
   args: {
     label: "Crew",
     icon: <GroupIcon />,
-  },
-};
-
-export const SmallIcon: StoryObj<TagProps> = {
-  args: {
-    label: "Crew",
-    icon: <GroupIcon />,
-    size: "small",
   },
 };
 

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Tag/Tag.stories.tsx
@@ -107,10 +107,26 @@ const storybookMeta: Meta<TagProps> = {
         },
       },
     },
+    size: {
+      control: {
+        type: "select",
+      },
+      options: ["default", "small"],
+      description: "The size of the tag",
+      table: {
+        type: {
+          summary: "string",
+        },
+        defaultValue: {
+          summary: "default",
+        },
+      },
+    },
   },
   args: {
     label: "Starship",
     colorVariant: "default",
+    size: "medium",
   },
   decorators: [MuiThemeDecorator],
   tags: ["autodocs"],
@@ -121,6 +137,13 @@ export default storybookMeta;
 export const Default: StoryObj<TagProps> = {
   args: {
     label: "Starship",
+  },
+};
+
+export const Small: StoryObj<TagProps> = {
+  args: {
+    label: "Starship",
+    size: "small",
   },
 };
 
@@ -164,6 +187,7 @@ export const List: StoryObj<TagProps> = {
     return (
       <TagList>
         <Tag label={args.label} />
+        <Tag label="Small tag" size="small" />
         <Tag label="Info tag" colorVariant="info" />
         <Tag label="AccentOne tag" colorVariant="accentOne" />
         <Tag label="AccentTwo tag" colorVariant="accentTwo" />
@@ -181,6 +205,14 @@ export const Icon: StoryObj<TagProps> = {
   args: {
     label: "Crew",
     icon: <GroupIcon />,
+  },
+};
+
+export const SmallIcon: StoryObj<TagProps> = {
+  args: {
+    label: "Crew",
+    icon: <GroupIcon />,
+    size: "small",
   },
 };
 
@@ -221,5 +253,34 @@ export const Disabled: StoryObj<TagProps> = {
   args: {
     label: "Starship",
     isDisabled: true,
+  },
+};
+
+export const SizeInteraction: StoryObj<TagProps> = {
+  args: {
+    label: "Starship",
+  },
+  play: async ({ canvasElement, step }) => {
+    await step("verify size differences", async () => {
+      const canvas = within(canvasElement);
+      const defaultTag = canvas.getByText("Starship");
+
+      // Get computed styles for default size
+      const defaultStyles = window.getComputedStyle(defaultTag);
+      const defaultHeight = defaultStyles.height;
+
+      // Update to small size
+      defaultTag.setAttribute("size", "small");
+
+      // Get computed styles for small size
+      const smallStyles = window.getComputedStyle(defaultTag);
+      const smallHeight = smallStyles.height;
+
+      // Verify sizes are different
+      expect(defaultHeight).not.toBe(smallHeight);
+      expect(smallHeight).toBe("26px");
+
+      await axeRun("Size Interaction Tag");
+    });
   },
 };


### PR DESCRIPTION
[DES-6489](https://oktainc.atlassian.net/browse/DES-6489)

## Summary

* Adds `small` tag variant to align with Figma
* Follows MUI sizing conventions for `Chip` (default Tag is called medium)

## Testing & Screenshots

- [x] I have confirmed this change with my designer and the Odyssey Design Team.
![CleanShot 2024-10-28 at 11 56 27@2x](https://github.com/user-attachments/assets/ad45a9df-97e7-488d-9a7e-3b3ca908fbdd)

