### PR TITLE
fix: enforce AppTile image heighgt

### DIFF
--- a/packages/odyssey-react-mui/src/labs/AppTile.tsx
+++ b/packages/odyssey-react-mui/src/labs/AppTile.tsx
@@ -99,7 +99,8 @@ const ImageContainer = styled("div", {
   maxHeight: APP_TILE_IMAGE_HEIGHT,
   marginBlockEnd: odysseyDesignTokens.Spacing5,
 
-  ["& img"]: {
+  ["img"]: {
+    height: APP_TILE_IMAGE_HEIGHT,
     maxWidth: "100%",
   },
 }));


### PR DESCRIPTION
Fixes a regression in the AppTile image dimensions spotted by @stephanieyoshimoto-okta.