### PR TITLE
Smarter column expansion in DataView

### DIFF
--- a/packages/odyssey-react-mui/src/labs/DataView/TableLayoutContent.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataView/TableLayoutContent.tsx
@@ -308,6 +308,8 @@ const TableLayoutContent = ({
     ],
   );
 
+  const hasColumnWithGrow = columns.some((column) => column.grow === true);
+
   const dataTable = useMaterialReactTable({
     data: !isEmpty && !isNoResults ? data : [],
     columns,
@@ -332,7 +334,7 @@ const TableLayoutContent = ({
       >),
       "mrt-row-actions": {
         header: "",
-        grow: true,
+        grow: !hasColumnWithGrow,
         muiTableBodyCellProps: {
           align: "right" as const,
           sx: {
@@ -372,7 +374,9 @@ const TableLayoutContent = ({
       ref: tableContentRef,
       className:
         !shouldDisplayRowActions && tableLayoutOptions.hasColumnResizing
-          ? "ods-hide-spacer-column"
+          ? hasColumnWithGrow
+            ? "ods-hide-spacer-column"
+            : "ods-hide-spacer-column ods-column-grow"
           : "",
     },
     muiTableContainerProps: {

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -2824,11 +2824,15 @@ export const components = ({
             {
               borderTopRightRadius: odysseyTokens.Spacing2,
               borderBottomRightRadius: odysseyTokens.Spacing2,
-              flexGrow: 1,
 
               [`& .Mui-TableHeadCell-ResizeHandle-Wrapper`]: {
                 display: "none",
               },
+            },
+
+          [`.ods-column-grow .${tableHeadClasses.root} &:nth-last-of-type(2), .ods-column-grow .${tableBodyClasses.root} &:nth-last-of-type(2)`]:
+            {
+              flexGrow: 1,
             },
 
           ...(ownerState.variant === "number" && {

--- a/packages/odyssey-storybook/src/components/odyssey-labs/DataView/DataView.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/DataView/DataView.stories.tsx
@@ -1069,3 +1069,79 @@ export const CompactCards: StoryObj<DataViewMetaProps> = {
     );
   },
 };
+
+export const GrowColumnWithoutActions: StoryObj<DataViewMetaProps> = {
+  render: function C() {
+    const [data, setData] = useState<Person[]>(personData);
+    const { getData } = useDataCallbacks(data, setData);
+
+    const columns: DataColumns = [
+      {
+        accessorKey: "order",
+        header: "ID",
+        enableColumnFilter: false,
+        grow: true,
+      },
+      {
+        accessorKey: "name",
+        header: "Name",
+      },
+      {
+        accessorKey: "city",
+        header: "City",
+      },
+    ];
+
+    return (
+      <DataView
+        availableLayouts={["table"]}
+        getData={getData}
+        tableLayoutOptions={{
+          columns: columns,
+          hasColumnResizing: true,
+        }}
+      />
+    );
+  },
+};
+
+export const GrowColumnWithActions: StoryObj<DataViewMetaProps> = {
+  render: function C() {
+    const [data, setData] = useState<Person[]>(personData);
+    const { getData } = useDataCallbacks(data, setData);
+
+    const columns: DataColumns = [
+      {
+        accessorKey: "order",
+        header: "ID",
+        enableColumnFilter: false,
+        grow: true,
+      },
+      {
+        accessorKey: "name",
+        header: "Name",
+      },
+      {
+        accessorKey: "city",
+        header: "City",
+      },
+    ];
+
+    const rowActions = useCallback(
+      () => <Button variant="secondary" label="Action" size="small" />,
+      [],
+    );
+
+    return (
+      <DataView
+        availableLayouts={["table"]}
+        getData={getData}
+        tableLayoutOptions={{
+          hasColumnResizing: true,
+          columns: columns,
+          rowActionButtons: rowActions,
+        }}
+      />
+    );
+  },
+};


### PR DESCRIPTION
In DataView, the last column automatically expands to fill the remaining space. This is the intended behavior in _most_ scenarios.

In some cases, though, a team will manually set a different column to grow to fill the remaining space. Before this PR, that column would compete with the final column for space.

Now, DataView detects if any table columns have `grow: true` set. If they do, it won't force the last column to fill the remaining space.

Before:
<img width="1494" alt="Screenshot 2024-10-30 at 12 46 02 PM" src="https://github.com/user-attachments/assets/3552f0f9-b231-473e-91fb-c027dbcc20c9">
<img width="1486" alt="Screenshot 2024-10-30 at 12 46 25 PM" src="https://github.com/user-attachments/assets/c6c23b27-3d68-4422-852c-b4ba47b358ec">


After:
<img width="1487" alt="Screenshot 2024-10-30 at 12 45 30 PM" src="https://github.com/user-attachments/assets/cbfd54aa-015f-438a-8433-9c3ea75d66a2">
<img width="1485" alt="Screenshot 2024-10-30 at 12 45 39 PM" src="https://github.com/user-attachments/assets/c43856c8-f838-4898-9b04-a13835dd5bd8">
