### PR TITLE
Update styles on compact cards

### DIFF
--- a/packages/odyssey-react-mui/src/labs/DataView/DataCard.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataView/DataCard.tsx
@@ -239,7 +239,7 @@ const DataCard = ({
 
     const shouldCenterContent =
       variant === "compact" &&
-      !(renderDetailPanel && isDetailPanelOpen) &&
+      (!renderDetailPanel || !isDetailPanelOpen) &&
       countDefinedProps([title, description, overline, button, children]) <= 2;
 
     return (

--- a/packages/odyssey-react-mui/src/labs/DataView/DataCard.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataView/DataCard.tsx
@@ -114,7 +114,10 @@ const MenuButtonContainer = styled("div", {
 }>(({ odysseyDesignTokens, variant }) => ({
   position: "absolute",
   right: odysseyDesignTokens.Spacing3,
-  top: odysseyDesignTokens.Spacing3,
+  top:
+    variant === "compact"
+      ? odysseyDesignTokens.Spacing4
+      : odysseyDesignTokens.Spacing3,
   height: variant === "compact" ? CARD_IMAGE_SIZE_COMPACT : "auto",
   display: "flex",
   alignItems: "center",
@@ -128,11 +131,14 @@ const CardInnerContainer = styled("div", {
 }));
 
 const CardImageAndContentContainer = styled("div", {
-  shouldForwardProp: (prop) => prop !== "variant",
-})<{ variant: (typeof cardVariantValues)[number] }>(({ variant }) => ({
-  display: "flex",
-  flexDirection: variant === "tile" ? "column" : "row",
-}));
+  shouldForwardProp: (prop) => prop !== "variant" && prop !== "centerContent",
+})<{ variant: (typeof cardVariantValues)[number]; centerContent: boolean }>(
+  ({ variant, centerContent }) => ({
+    display: "flex",
+    flexDirection: variant === "tile" ? "column" : "row",
+    alignItems: centerContent ? "center" : "flex-start",
+  }),
+);
 
 const CardContent = styled("div", {
   shouldForwardProp: (prop) => prop !== "odysseyDesignTokens",
@@ -140,8 +146,11 @@ const CardContent = styled("div", {
   odysseyDesignTokens: DesignTokens;
   variant: (typeof cardVariantValues)[number];
 }>(({ odysseyDesignTokens, variant }) => ({
-  "& > .MuiTypography-h5": {
+  "& > .MuiTypography-h5:not(:last-child)": {
     marginBlockEnd: `${variant === "compact" ? odysseyDesignTokens.Spacing1 : odysseyDesignTokens.Spacing3} !important`,
+  },
+  "& > *:last-child": {
+    marginBlockEnd: 0,
   },
 }));
 
@@ -221,11 +230,25 @@ const DataCard = ({
     variant,
   ]);
 
-  const cardContent = useMemo(
-    () => (
+  const cardContent = useMemo(() => {
+    const countDefinedProps = (
+      props: Array<string | ReactNode | undefined>,
+    ) => {
+      return props.filter((prop) => prop !== undefined).length;
+    };
+
+    const shouldCenterContent =
+      variant === "compact" &&
+      !(renderDetailPanel && isDetailPanelOpen) &&
+      countDefinedProps([title, description, overline, button, children]) <= 2;
+
+    return (
       <CardInnerContainer odysseyDesignTokens={odysseyDesignTokens}>
         {(AccessoryProp || renderDetailPanel) && <Box>{Accessory}</Box>}
-        <CardImageAndContentContainer variant={variant}>
+        <CardImageAndContentContainer
+          variant={variant}
+          centerContent={shouldCenterContent}
+        >
           {image && (
             <ImageContainer
               odysseyDesignTokens={odysseyDesignTokens}
@@ -268,24 +291,23 @@ const DataCard = ({
           </CardContent>
         </CardImageAndContentContainer>
       </CardInnerContainer>
-    ),
-    [
-      odysseyDesignTokens,
-      AccessoryProp,
-      renderDetailPanel,
-      Accessory,
-      variant,
-      image,
-      menuButtonChildren,
-      overline,
-      title,
-      description,
-      button,
-      children,
-      isDetailPanelOpen,
-      row,
-    ],
-  );
+    );
+  }, [
+    odysseyDesignTokens,
+    AccessoryProp,
+    renderDetailPanel,
+    Accessory,
+    variant,
+    image,
+    menuButtonChildren,
+    overline,
+    title,
+    description,
+    button,
+    children,
+    isDetailPanelOpen,
+    row,
+  ]);
 
   return (
     <MuiCard

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -847,8 +847,8 @@ export const components = ({
           transition: `all ${odysseyTokens.TransitionDurationMain} ${odysseyTokens.TransitionTimingMain}`,
 
           "&.ods-card-compact": {
-            marginBlockEnd: odysseyTokens.Spacing3,
-            padding: odysseyTokens.Spacing3,
+            marginBlockEnd: odysseyTokens.Spacing2,
+            padding: odysseyTokens.Spacing4,
           },
 
           "& img": {

--- a/packages/odyssey-storybook/src/components/odyssey-labs/DataView/DataView.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/DataView/DataView.stories.tsx
@@ -1045,7 +1045,6 @@ export const StackCards: StoryObj<DataViewMetaProps> = {
 
 const compactItemProps = (row: DataRow) => ({
   title: row.name,
-  description: `${row.name} is ${row.age} years old.`,
   variant: "compact" as DataCardProps["variant"],
   image: <img src="https://placehold.co/400" alt="Logo" />,
 });


### PR DESCRIPTION
This PR brings the style of the `compact` variant of `DataCards` (cards within `DataView`) into conformity with the Figma mocks and suggestions from Alex and Nick.

The biggest change, in terms of scope, is that the card content now changes alignment depending on how much content is present (only in the `compact` variant). If there's just a title, for example, it's centered alongside the image; if there's a title + description + overline + button, however, it's aligned to the top of the image. This sounds complex, but looks visually correct in practice:

<img width="1498" alt="Screenshot 2024-11-08 at 3 38 07 PM" src="https://github.com/user-attachments/assets/b732d15d-f362-4621-b10b-3f4049134001">
<img width="1494" alt="Screenshot 2024-11-08 at 3 38 39 PM" src="https://github.com/user-attachments/assets/3b910d9e-8ff5-4dd7-a536-f05a2aa9933e">
