### PR TITLE
fix: bug in SideNav when sideNavItems comes delayed

### DIFF
--- a/packages/odyssey-react-mui/src/labs/SideNav/SideNav.tsx
+++ b/packages/odyssey-react-mui/src/labs/SideNav/SideNav.tsx
@@ -29,7 +29,7 @@ import {
   useOdysseyDesignTokens,
 } from "../../OdysseyDesignTokensContext";
 import { OdysseyThemeProvider } from "../../OdysseyThemeProvider";
-import type { SideNavItem, SideNavProps } from "./types";
+import type { SideNavProps } from "./types";
 import { SideNavHeader } from "./SideNavHeader";
 import {
   SideNavItemContent,
@@ -299,8 +299,7 @@ const SideNav = ({
   const intersectionObserverRef = useRef<IntersectionObserver | null>(null);
   const odysseyDesignTokens: DesignTokens = useOdysseyDesignTokens();
   const { t } = useTranslation();
-  const [sideNavItemsList, updateSideNavItemsList] =
-    useState<SideNavItem[]>(sideNavItems);
+  const [sideNavItemsList, updateSideNavItemsList] = useState(sideNavItems);
 
   // The default value (sideNavItems) passed to useState is ONLY used by the useState hook for
   // the very first value. Subsequent updates to the prop (sideNavItems) need to cause the state

--- a/packages/odyssey-react-mui/src/labs/SideNav/SideNav.tsx
+++ b/packages/odyssey-react-mui/src/labs/SideNav/SideNav.tsx
@@ -29,7 +29,7 @@ import {
   useOdysseyDesignTokens,
 } from "../../OdysseyDesignTokensContext";
 import { OdysseyThemeProvider } from "../../OdysseyThemeProvider";
-import type { SideNavProps } from "./types";
+import type { SideNavItem, SideNavProps } from "./types";
 import { SideNavHeader } from "./SideNavHeader";
 import {
   SideNavItemContent,
@@ -299,9 +299,16 @@ const SideNav = ({
   const intersectionObserverRef = useRef<IntersectionObserver | null>(null);
   const odysseyDesignTokens: DesignTokens = useOdysseyDesignTokens();
   const { t } = useTranslation();
-  const [sideNavItemsList, updateSideNavItemsList] = useState(sideNavItems);
+  const [sideNavItemsList, updateSideNavItemsList] =
+    useState<SideNavItem[]>(sideNavItems);
+
+  // The default value (sideNavItems) passed to useState is ONLY used by the useState hook for
+  // the very first value. Subsequent updates to the prop (sideNavItems) need to cause the state
+  // to update!
+  useEffect(() => updateSideNavItemsList(sideNavItems), [sideNavItems]);
 
   useEffect(() => {
+    // This is called directly in this effect AND perhaps as a result of the ResizeObserver
     const updateIsContentScrollable = () => {
       if (
         scrollableContentRef.current &&
@@ -381,7 +388,7 @@ const SideNav = ({
       }
       cancelAnimationFrame(resizeObserverDebounceTimer); // Ensure timer is cleared on component unmount
     };
-  }, [sideNavItems]);
+  }, [sideNavItemsList]);
 
   const scrollIntoViewRef = useRef<HTMLLIElement>(null);
   /**
@@ -390,7 +397,7 @@ const SideNav = ({
    * call scrollIntoView in the effect
    */
   const firstSideNavItemIdWithIsSelected = useMemo(() => {
-    const flattenedItems = sideNavItems.flatMap((sideNavItem) =>
+    const flattenedItems = sideNavItemsList.flatMap((sideNavItem) =>
       sideNavItem.nestedNavItems
         ? [sideNavItem, ...sideNavItem.nestedNavItems]
         : sideNavItem,
@@ -399,7 +406,7 @@ const SideNav = ({
       (sideNavItem) => sideNavItem.isSelected,
     );
     return firstItemWithIsSelected?.id;
-  }, [sideNavItems]);
+  }, [sideNavItemsList]);
   /**
    * Once we've rendered and if we have an item to scroll to, do the scroll action.
    * This must rely on checking firstSideNavItemIdWithIsSelected or it will not run
@@ -409,7 +416,7 @@ const SideNav = ({
     if (firstSideNavItemIdWithIsSelected && scrollIntoViewRef.current) {
       scrollIntoViewRef.current.scrollIntoView();
     }
-  }, [firstSideNavItemIdWithIsSelected, scrollIntoViewRef]);
+  }, [firstSideNavItemIdWithIsSelected]);
 
   /**
    * We only want to put a ref on a node iff it is the first selected node.

--- a/packages/odyssey-storybook/src/components/odyssey-labs/SideNav/SideNav.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/SideNav/SideNav.stories.tsx
@@ -461,16 +461,27 @@ export const CustomLogoImage: StoryObj<typeof SideNav> = {
 };
 
 export const DelayedSideNavItems: StoryObj<typeof SideNav> = {
-  render: function C({ sideNavItems, ...props }) {
+  args: {
+    isLoading: true,
+  },
+  render: function C({ sideNavItems, isLoading, ...props }) {
     const [sideNavItemsInState, setSideNavItemsInState] = useState<
       SideNavItem[]
     >([]);
+    const [isLoadingInState, setIsLoadingInState] = useState(isLoading);
     useEffect(() => {
-      setTimeout(() => setSideNavItemsInState(sideNavItems), 1000);
+      setTimeout(() => {
+        setSideNavItemsInState(sideNavItems);
+        setIsLoadingInState(false);
+      }, 1000);
     });
     return (
       <div style={{ height: "100vh" }}>
-        <SideNav sideNavItems={sideNavItemsInState} {...props} />
+        <SideNav
+          sideNavItems={sideNavItemsInState}
+          isLoading={isLoadingInState}
+          {...props}
+        />
       </div>
     );
   },

--- a/packages/odyssey-storybook/src/components/odyssey-labs/SideNav/SideNav.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/SideNav/SideNav.stories.tsx
@@ -10,7 +10,11 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { SideNav, SideNavProps } from "@okta/odyssey-react-mui/labs";
+import {
+  SideNav,
+  SideNavItem,
+  SideNavProps,
+} from "@okta/odyssey-react-mui/labs";
 import { Meta, StoryObj } from "@storybook/react";
 import { MuiThemeDecorator } from "../../../../.storybook/components";
 import {
@@ -37,6 +41,7 @@ import {
 } from "@storybook/testing-library";
 import { PlaywrightProps } from "../../odyssey-mui/storybookTypes";
 import PlaceholderLogo from "../PickerWithOptionAdornment/PlaceholderLogo";
+import { useEffect, useState } from "react";
 
 const storybookMeta: Meta<SideNavProps> = {
   title: "Labs Components/SideNav",
@@ -450,6 +455,22 @@ export const CustomLogoImage: StoryObj<typeof SideNav> = {
     return (
       <div style={{ height: "100vh" }}>
         <SideNav {...props} />
+      </div>
+    );
+  },
+};
+
+export const DelayedSideNavItems: StoryObj<typeof SideNav> = {
+  render: function C({ sideNavItems, ...props }) {
+    const [sideNavItemsInState, setSideNavItemsInState] = useState<
+      SideNavItem[]
+    >([]);
+    useEffect(() => {
+      setTimeout(() => setSideNavItemsInState(sideNavItems), 1000);
+    });
+    return (
+      <div style={{ height: "100vh" }}>
+        <SideNav sideNavItems={sideNavItemsInState} {...props} />
       </div>
     );
   },


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[OKTA-832344](https://oktainc.atlassian.net/browse/OKTA-832344)

## Summary

Fixes bug in SideNav where sideNavItems are initially `[]`, then later populated with actual data (but are never rendered).

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
