### PR TITLE
Update Button styles + support for aria-expanded

### DIFF
--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -667,7 +667,8 @@ export const components = ({
               color: odysseyTokens.TypographyColorBody,
 
               "&:hover": {
-                backgroundColor: odysseyTokens.HueNeutral100,
+                backgroundColor: odysseyTokens.HueNeutral300,
+                borderColor: odysseyTokens.HueNeutral400,
               },
 
               "&:active": {
@@ -677,17 +678,9 @@ export const components = ({
               },
 
               "&:disabled": {
-                ...(contrastMode === "highContrast" && {
-                  backgroundColor: odysseyTokens.HueNeutral200,
-                  borderColor: "transparent",
-                  color: odysseyTokens.TypographyColorDisabled,
-                }),
-
-                ...(contrastMode === "lowContrast" && {
-                  backgroundColor: odysseyTokens.HueNeutral100,
-                  borderColor: "transparent",
-                  color: odysseyTokens.TypographyColorDisabled,
-                }),
+                backgroundColor: odysseyTokens.HueNeutral200,
+                borderColor: "transparent",
+                color: odysseyTokens.TypographyColorDisabled,
               },
             }),
 
@@ -719,7 +712,8 @@ export const components = ({
               color: odysseyTokens.PaletteDangerMain,
 
               "&:hover": {
-                backgroundColor: odysseyTokens.HueNeutral100,
+                backgroundColor: odysseyTokens.HueNeutral200,
+                borderColor: odysseyTokens.HueNeutral400,
                 color: odysseyTokens.PaletteDangerMain,
               },
 
@@ -730,8 +724,8 @@ export const components = ({
               },
 
               "&:disabled": {
-                backgroundColor: "transparent",
-                borderColor: odysseyTokens.PaletteDangerLight,
+                backgroundColor: odysseyTokens.PaletteDangerHighlight,
+                borderColor: "transparent",
                 color: odysseyTokens.PaletteDangerLight,
               },
             }),
@@ -741,11 +735,13 @@ export const components = ({
               color: odysseyTokens.TypographyColorBody,
 
               "&:hover": {
-                backgroundColor: odysseyTokens.HueNeutral100,
+                backgroundColor: odysseyTokens.HueNeutral200,
               },
 
               "&:active": {
-                backgroundColor: odysseyTokens.HueNeutral200,
+                backgroundColor: "transparent",
+                color: odysseyTokens.HueBlue600,
+                borderColor: odysseyTokens.HueBlue600,
               },
 
               "&:disabled": {
@@ -759,11 +755,12 @@ export const components = ({
               color: odysseyTokens.TypographyColorAction,
 
               "&:hover": {
-                backgroundColor: odysseyTokens.HueNeutral100,
+                backgroundColor: odysseyTokens.HueNeutral200,
               },
 
               "&:active": {
-                backgroundColor: odysseyTokens.HueNeutral200,
+                backgroundColor: "transparent",
+                borderColor: odysseyTokens.HueBlue600,
               },
 
               "&:disabled": {

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -651,7 +651,7 @@ export const components = ({
                 backgroundColor: odysseyTokens.PalettePrimaryDark,
               },
 
-              "&:active": {
+              "&:active, &[aria-expanded='true']": {
                 backgroundColor: odysseyTokens.PalettePrimaryDarker,
               },
 
@@ -671,7 +671,7 @@ export const components = ({
                 borderColor: odysseyTokens.HueNeutral400,
               },
 
-              "&:active": {
+              "&:active, &[aria-expanded='true']": {
                 backgroundColor: "transparent",
                 borderColor: odysseyTokens.BorderColorPrimaryControl,
                 color: odysseyTokens.TypographyColorAction,
@@ -696,7 +696,7 @@ export const components = ({
                 boxShadow: `0 0 0 2px ${odysseyTokens.HueNeutralWhite}, 0 0 0 4px ${odysseyTokens.PaletteDangerMain}`,
               },
 
-              "&:active": {
+              "&:active, &[aria-expanded='true']": {
                 backgroundColor: odysseyTokens.PaletteDangerDarker,
               },
 
@@ -717,7 +717,7 @@ export const components = ({
                 color: odysseyTokens.PaletteDangerMain,
               },
 
-              "&:active": {
+              "&:active, &[aria-expanded='true']": {
                 backgroundColor: "transparent",
                 borderColor: odysseyTokens.PaletteDangerMain,
                 color: odysseyTokens.PaletteDangerMain,
@@ -738,7 +738,7 @@ export const components = ({
                 backgroundColor: odysseyTokens.HueNeutral200,
               },
 
-              "&:active": {
+              "&:active, &[aria-expanded='true']": {
                 backgroundColor: "transparent",
                 color: odysseyTokens.HueBlue600,
                 borderColor: odysseyTokens.HueBlue600,
@@ -758,7 +758,7 @@ export const components = ({
                 backgroundColor: odysseyTokens.HueNeutral200,
               },
 
-              "&:active": {
+              "&:active, &[aria-expanded='true']": {
                 backgroundColor: "transparent",
                 borderColor: odysseyTokens.HueBlue600,
               },

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -667,7 +667,7 @@ export const components = ({
               color: odysseyTokens.TypographyColorBody,
 
               "&:hover": {
-                backgroundColor: odysseyTokens.HueNeutral300,
+                backgroundColor: odysseyTokens.HueNeutral200,
                 borderColor: odysseyTokens.HueNeutral400,
               },
 


### PR DESCRIPTION
[DES-6770](https://oktainc.atlassian.net/browse/DES-6770)

## Summary
Updates `Button` styles to match Nick's latest updates in Figma

**States that have changed:**
* Secondary hover
* Secondary Active
* Secondary disabled
* Floating/FloatingAction Hover
* Floating/FloatingAction Active
* Danger Secondary Hover
* Danger Secondary Disabled

This PR also adds support for the `MenuButton`'s "open" state aka `&[aria-expanded='true']` and applies the `:active` state styles when a `MenuButton` is in this state.

## Testing & Screenshots

- [x] I have confirmed this change with my designer and the Odyssey Design Team.

