### PR TITLE
feat: better first-render options for UiShell

### DIFF
--- a/packages/odyssey-react-mui/src/labs/UiShell/UiShell.tsx
+++ b/packages/odyssey-react-mui/src/labs/UiShell/UiShell.tsx
@@ -23,11 +23,8 @@ import {
 import { type ReactRootElements } from "../../web-component";
 
 export const defaultComponentProps: UiShellNavComponentProps = {
-  sideNavProps: {
-    appName: "",
-    sideNavItems: [],
-  },
-  topNavProps: {},
+  sideNavProps: undefined,
+  topNavProps: undefined,
 } as const;
 
 export type UiShellProps = {
@@ -49,7 +46,10 @@ export type UiShellProps = {
     ) => void,
   ) => () => void;
 } & Pick<ReactRootElements, "appRootElement" | "stylesRootElement"> &
-  Pick<UiShellContentProps, "appComponent" | "onError" | "optionalComponents">;
+  Pick<
+    UiShellContentProps,
+    "appComponent" | "initiallyVisible" | "onError" | "optionalComponents"
+  >;
 
 /**
  * Our new Unified Platform UI Shell.
@@ -61,6 +61,7 @@ export type UiShellProps = {
 const UiShell = ({
   appComponent,
   appRootElement,
+  initiallyVisible,
   onError = console.error,
   onSubscriptionCreated,
   optionalComponents,
@@ -94,6 +95,7 @@ const UiShell = ({
           <UiShellContent
             {...componentProps}
             appComponent={appComponent}
+            initiallyVisible={initiallyVisible}
             onError={onError}
             optionalComponents={optionalComponents}
           />

--- a/packages/odyssey-react-mui/src/labs/UiShell/UiShell.tsx
+++ b/packages/odyssey-react-mui/src/labs/UiShell/UiShell.tsx
@@ -48,7 +48,7 @@ export type UiShellProps = {
 } & Pick<ReactRootElements, "appRootElement" | "stylesRootElement"> &
   Pick<
     UiShellContentProps,
-    "appComponent" | "initiallyVisible" | "onError" | "optionalComponents"
+    "appComponent" | "initialVisibleSections" | "onError" | "optionalComponents"
   >;
 
 /**
@@ -61,7 +61,7 @@ export type UiShellProps = {
 const UiShell = ({
   appComponent,
   appRootElement,
-  initiallyVisible,
+  initialVisibleSections,
   onError = console.error,
   onSubscriptionCreated,
   optionalComponents,
@@ -95,7 +95,7 @@ const UiShell = ({
           <UiShellContent
             {...componentProps}
             appComponent={appComponent}
-            initiallyVisible={initiallyVisible}
+            initialVisibleSections={initialVisibleSections}
             onError={onError}
             optionalComponents={optionalComponents}
           />

--- a/packages/odyssey-react-mui/src/labs/UiShell/UiShellContent.tsx
+++ b/packages/odyssey-react-mui/src/labs/UiShell/UiShellContent.tsx
@@ -22,6 +22,8 @@ import {
 } from "../../OdysseyDesignTokensContext";
 import { useScrollState } from "./useScrollState";
 
+const emptySideNavItems = [] satisfies SideNavProps["sideNavItems"];
+
 const StyledAppContainer = styled("div", {
   shouldForwardProp: (prop) => prop !== "odysseyDesignTokens",
 })<{
@@ -65,9 +67,8 @@ const StyledTopNavContainer = styled("div")(() => ({
   gridArea: "top-nav",
 }));
 
-const TopNavComponent = "TopNav";
-const SideNavComponent = "SideNav";
-const AppSwitcherComponent = "AppSwitcher";
+const subComponentNames = ["TopNav", "SideNav", "AppSwitcher"] as const;
+type SubComponentName = (typeof subComponentNames)[number];
 
 export type UiShellNavComponentProps = {
   /**
@@ -89,11 +90,7 @@ export type UiShellContentProps = {
    * Which parts of the UI Shell should be visible initially? For example,
    * if sideNavProps is undefined, should the space for the sidenav be initially visible?
    */
-  initiallyVisible?: (
-    | typeof TopNavComponent
-    | typeof SideNavComponent
-    | typeof AppSwitcherComponent
-  )[];
+  initiallyVisible?: SubComponentName[];
   /**
    * Notifies when a React rendering error occurs. This could be useful for logging, flagging "p0"s, and recovering UI Shell when errors occur.
    */
@@ -118,7 +115,7 @@ export type UiShellContentProps = {
  */
 const UiShellContent = ({
   appComponent,
-  initiallyVisible = [TopNavComponent, SideNavComponent, AppSwitcherComponent],
+  initiallyVisible = ["TopNav", "SideNav", "AppSwitcher"],
   onError = console.error,
   optionalComponents,
   sideNavProps,
@@ -136,9 +133,9 @@ const UiShellContent = ({
       <StyledSideNavContainer>
         {
           /* If SideNav should be initially visible and we have not yet received props, render SideNav with minimal inputs */
-          initiallyVisible?.includes(SideNavComponent) && !sideNavProps && (
+          initiallyVisible?.includes("SideNav") && !sideNavProps && (
             <ErrorBoundary fallback={null} onError={onError}>
-              <SideNav isLoading appName="" sideNavItems={[]} />
+              <SideNav isLoading appName="" sideNavItems={emptySideNavItems} />
             </ErrorBoundary>
           )
         }
@@ -167,7 +164,7 @@ const UiShellContent = ({
       <StyledTopNavContainer>
         {
           /* If TopNav should be initially visible and we have not yet received props, render Topnav with minimal inputs */
-          initiallyVisible?.includes(TopNavComponent) && !topNavProps && (
+          initiallyVisible?.includes("TopNav") && !topNavProps && (
             <ErrorBoundary fallback={null} onError={onError}>
               <TopNav />
             </ErrorBoundary>

--- a/packages/odyssey-react-mui/src/labs/UiShell/UiShellContent.tsx
+++ b/packages/odyssey-react-mui/src/labs/UiShell/UiShellContent.tsx
@@ -65,6 +65,10 @@ const StyledTopNavContainer = styled("div")(() => ({
   gridArea: "top-nav",
 }));
 
+const TopNavComponent = "TopNav";
+const SideNavComponent = "SideNav";
+const AppSwitcherComponent = "AppSwitcher";
+
 export type UiShellNavComponentProps = {
   /**
    * Object that gets pass directly to the side nav component.
@@ -73,7 +77,7 @@ export type UiShellNavComponentProps = {
   /**
    * Object that gets pass directly to the top nav component.
    */
-  topNavProps: Omit<TopNavProps, "leftSideComponent" | "rightSideComponent">;
+  topNavProps?: Omit<TopNavProps, "leftSideComponent" | "rightSideComponent">;
 };
 
 export type UiShellContentProps = {
@@ -81,6 +85,15 @@ export type UiShellContentProps = {
    * React app component that renders as children in the correct location of the shell.
    */
   appComponent: ReactNode;
+  /**
+   * Which parts of the UI Shell should be visible initially? For example,
+   * if sideNavProps is undefined, should the space for the sidenav be initially visible?
+   */
+  initiallyVisible?: (
+    | typeof TopNavComponent
+    | typeof SideNavComponent
+    | typeof AppSwitcherComponent
+  )[];
   /**
    * Notifies when a React rendering error occurs. This could be useful for logging, flagging "p0"s, and recovering UI Shell when errors occur.
    */
@@ -105,6 +118,7 @@ export type UiShellContentProps = {
  */
 const UiShellContent = ({
   appComponent,
+  initiallyVisible = [TopNavComponent, SideNavComponent, AppSwitcherComponent],
   onError = console.error,
   optionalComponents,
   sideNavProps,
@@ -120,6 +134,14 @@ const UiShellContent = ({
       </StyledBannersContainer>
 
       <StyledSideNavContainer>
+        {
+          /* If SideNav should be initially visible and we have not yet received props, render SideNav with minimal inputs */
+          initiallyVisible?.includes(SideNavComponent) && !sideNavProps && (
+            <ErrorBoundary fallback={null} onError={onError}>
+              <SideNav isLoading appName="" sideNavItems={[]} />
+            </ErrorBoundary>
+          )
+        }
         {sideNavProps && (
           <ErrorBoundary fallback={null} onError={onError}>
             <SideNav
@@ -143,14 +165,24 @@ const UiShellContent = ({
       </StyledSideNavContainer>
 
       <StyledTopNavContainer>
-        <ErrorBoundary fallback={null} onError={onError}>
-          <TopNav
-            {...topNavProps}
-            isScrolled={isContentScrolled}
-            leftSideComponent={optionalComponents?.topNavLeftSide}
-            rightSideComponent={optionalComponents?.topNavRightSide}
-          />
-        </ErrorBoundary>
+        {
+          /* If TopNav should be initially visible and we have not yet received props, render Topnav with minimal inputs */
+          initiallyVisible?.includes(TopNavComponent) && !topNavProps && (
+            <ErrorBoundary fallback={null} onError={onError}>
+              <TopNav />
+            </ErrorBoundary>
+          )
+        }
+        {topNavProps && (
+          <ErrorBoundary fallback={null} onError={onError}>
+            <TopNav
+              {...topNavProps}
+              isScrolled={isContentScrolled}
+              leftSideComponent={optionalComponents?.topNavLeftSide}
+              rightSideComponent={optionalComponents?.topNavRightSide}
+            />
+          </ErrorBoundary>
+        )}
       </StyledTopNavContainer>
 
       <StyledAppContainer

--- a/packages/odyssey-react-mui/src/labs/UiShell/UiShellContent.tsx
+++ b/packages/odyssey-react-mui/src/labs/UiShell/UiShellContent.tsx
@@ -90,7 +90,7 @@ export type UiShellContentProps = {
    * Which parts of the UI Shell should be visible initially? For example,
    * if sideNavProps is undefined, should the space for the sidenav be initially visible?
    */
-  initiallyVisible?: SubComponentName[];
+  initialVisibleSections?: SubComponentName[];
   /**
    * Notifies when a React rendering error occurs. This could be useful for logging, flagging "p0"s, and recovering UI Shell when errors occur.
    */
@@ -115,7 +115,7 @@ export type UiShellContentProps = {
  */
 const UiShellContent = ({
   appComponent,
-  initiallyVisible = ["TopNav", "SideNav", "AppSwitcher"],
+  initialVisibleSections = ["TopNav", "SideNav", "AppSwitcher"],
   onError = console.error,
   optionalComponents,
   sideNavProps,
@@ -133,7 +133,7 @@ const UiShellContent = ({
       <StyledSideNavContainer>
         {
           /* If SideNav should be initially visible and we have not yet received props, render SideNav with minimal inputs */
-          initiallyVisible?.includes("SideNav") && !sideNavProps && (
+          initialVisibleSections?.includes("SideNav") && !sideNavProps && (
             <ErrorBoundary fallback={null} onError={onError}>
               <SideNav isLoading appName="" sideNavItems={emptySideNavItems} />
             </ErrorBoundary>
@@ -164,7 +164,7 @@ const UiShellContent = ({
       <StyledTopNavContainer>
         {
           /* If TopNav should be initially visible and we have not yet received props, render Topnav with minimal inputs */
-          initiallyVisible?.includes("TopNav") && !topNavProps && (
+          initialVisibleSections?.includes("TopNav") && !topNavProps && (
             <ErrorBoundary fallback={null} onError={onError}>
               <TopNav />
             </ErrorBoundary>

--- a/packages/odyssey-react-mui/src/labs/UiShell/renderUiShell.tsx
+++ b/packages/odyssey-react-mui/src/labs/UiShell/renderUiShell.tsx
@@ -42,7 +42,7 @@ export const optionalComponentSlotNames: Record<
  */
 export const renderUiShell = ({
   appRootElement: explicitAppRootElement,
-  initiallyVisible,
+  initialVisibleSections,
   onError = console.error,
   uiShellRootElement,
 }: {
@@ -58,7 +58,7 @@ export const renderUiShell = ({
    * HTML element used as the root for UI Shell.
    */
   uiShellRootElement: HTMLElement;
-} & Pick<UiShellProps, "initiallyVisible">) => {
+} & Pick<UiShellProps, "initialVisibleSections">) => {
   const appRootElement =
     explicitAppRootElement || document.createElement("div");
 
@@ -104,7 +104,7 @@ export const renderUiShell = ({
         <UiShell
           appComponent={appComponent}
           appRootElement={reactRootElements.appRootElement}
-          initiallyVisible={initiallyVisible}
+          initialVisibleSections={initialVisibleSections}
           onError={onError}
           onSubscriptionCreated={publishSubscriptionCreated}
           // `optionalComponents` doesn't need to be memoized because gets passed in once.

--- a/packages/odyssey-react-mui/src/labs/UiShell/renderUiShell.tsx
+++ b/packages/odyssey-react-mui/src/labs/UiShell/renderUiShell.tsx
@@ -42,6 +42,7 @@ export const optionalComponentSlotNames: Record<
  */
 export const renderUiShell = ({
   appRootElement: explicitAppRootElement,
+  initiallyVisible,
   onError = console.error,
   uiShellRootElement,
 }: {
@@ -49,6 +50,10 @@ export const renderUiShell = ({
    * HTML element used as the root for a React app.
    */
   appRootElement?: HTMLDivElement;
+  /**
+   * Initial visbility of UiShell components.
+   */
+  initiallyVisible?: UiShellProps["initiallyVisible"];
   /**
    * Notifies when a React rendering error occurs. This could be useful for logging, reporting priority 0 issues, and recovering UI Shell when errors occur.
    */
@@ -103,6 +108,7 @@ export const renderUiShell = ({
         <UiShell
           appComponent={appComponent}
           appRootElement={reactRootElements.appRootElement}
+          initiallyVisible={initiallyVisible}
           onError={onError}
           onSubscriptionCreated={publishSubscriptionCreated}
           // `optionalComponents` doesn't need to be memoized because gets passed in once.

--- a/packages/odyssey-react-mui/src/labs/UiShell/renderUiShell.tsx
+++ b/packages/odyssey-react-mui/src/labs/UiShell/renderUiShell.tsx
@@ -51,10 +51,6 @@ export const renderUiShell = ({
    */
   appRootElement?: HTMLDivElement;
   /**
-   * Initial visbility of UiShell components.
-   */
-  initiallyVisible?: UiShellProps["initiallyVisible"];
-  /**
    * Notifies when a React rendering error occurs. This could be useful for logging, reporting priority 0 issues, and recovering UI Shell when errors occur.
    */
   onError?: () => void;
@@ -62,7 +58,7 @@ export const renderUiShell = ({
    * HTML element used as the root for UI Shell.
    */
   uiShellRootElement: HTMLElement;
-}) => {
+} & Pick<UiShellProps, "initiallyVisible">) => {
   const appRootElement =
     explicitAppRootElement || document.createElement("div");
 

--- a/packages/odyssey-storybook/src/components/odyssey-labs/UiShell/UiShell.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/UiShell/UiShell.stories.tsx
@@ -47,7 +47,7 @@ const storybookMeta: Meta<UiShellProps> = {
         },
       },
     },
-    initiallyVisible: {
+    initialVisibleSections: {
       control: "text",
       description:
         "A list of UiShell components that should be (minimally) rendered initially, with their isLoading property set when applicable. Allows the initial visibility of UiShell components to be influenced.",
@@ -208,13 +208,13 @@ export const LoadingFirstRender: StoryObj<UiShellProps> = {};
 
 export const InvisibleFirstRender: StoryObj<UiShellProps> = {
   args: {
-    initiallyVisible: [],
+    initialVisibleSections: [],
   },
 };
 
 export const TopNavOnly: StoryObj<UiShellProps> = {
   args: {
-    initiallyVisible: ["TopNav", "AppSwitcher"],
+    initialVisibleSections: ["TopNav", "AppSwitcher"],
     optionalComponents: sharedOptionalComponents,
     subscribeToPropChanges: (subscriber) => {
       subscriber({

--- a/packages/odyssey-storybook/src/components/odyssey-labs/UiShell/UiShell.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/UiShell/UiShell.stories.tsx
@@ -47,6 +47,16 @@ const storybookMeta: Meta<UiShellProps> = {
         },
       },
     },
+    initiallyVisible: {
+      control: "text",
+      description:
+        "A list of UiShell components that should be (minimally) rendered initially, with their isLoading property set when applicable. Allows the initial visibility of UiShell components to be influenced.",
+      table: {
+        type: {
+          summary: "string",
+        },
+      },
+    },
     onError: {
       control: "function",
       description:
@@ -179,10 +189,32 @@ const sharedOptionalComponents: UiShellProps["optionalComponents"] = {
   ),
 };
 
-export const Default: StoryObj<UiShellProps> = {};
+export const Default: StoryObj<UiShellProps> = {
+  args: {
+    subscribeToPropChanges: (subscriber) => {
+      subscriber({
+        sideNavProps: {
+          appName: "Odyssey Storybook",
+          sideNavItems: [],
+        },
+      });
+
+      return () => {};
+    },
+  },
+};
+
+export const LoadingFirstRender: StoryObj<UiShellProps> = {};
+
+export const InvisibleFirstRender: StoryObj<UiShellProps> = {
+  args: {
+    initiallyVisible: [],
+  },
+};
 
 export const TopNavOnly: StoryObj<UiShellProps> = {
   args: {
+    initiallyVisible: ["TopNav", "AppSwitcher"],
     optionalComponents: sharedOptionalComponents,
     subscribeToPropChanges: (subscriber) => {
       subscriber({


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[OKTA-832948](https://oktainc.atlassian.net/browse/OKTA-832948)

## Summary

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

Improves the first-render of the UiShell. Allows consumers to opt into which components should be initially visible during the phase before they're able to influence things via a call to setComponentProps. If present, SideNav has `isLoading`.

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
