### PR TITLE
Optionally remove content area padding in ui…

### DIFF
--- a/packages/odyssey-react-mui/src/ui-shell/UiShell/UiShell.tsx
+++ b/packages/odyssey-react-mui/src/ui-shell/UiShell/UiShell.tsx
@@ -50,6 +50,7 @@ export type UiShellProps = {
     UiShellContentProps,
     | "appBackgroundContrastMode"
     | "appComponent"
+    | "hasStandardAppContentPadding"
     | "initialVisibleSections"
     | "onError"
     | "optionalComponents"
@@ -66,6 +67,7 @@ const UiShell = ({
   appBackgroundContrastMode,
   appComponent,
   appRootElement,
+  hasStandardAppContentPadding,
   initialVisibleSections,
   onError = console.error,
   onSubscriptionCreated,
@@ -101,6 +103,7 @@ const UiShell = ({
             {...componentProps}
             appBackgroundContrastMode={appBackgroundContrastMode}
             appComponent={appComponent}
+            hasStandardAppContentPadding={hasStandardAppContentPadding}
             initialVisibleSections={initialVisibleSections}
             onError={onError}
             optionalComponents={optionalComponents}

--- a/packages/odyssey-react-mui/src/ui-shell/UiShell/UiShellContent.tsx
+++ b/packages/odyssey-react-mui/src/ui-shell/UiShell/UiShellContent.tsx
@@ -216,18 +216,16 @@ const UiShellContent = ({
           </ErrorBoundary>
         )}
       </StyledSideNavContainer>
-      {
-        /* If TopNav should be initially visible and we have not yet received props, render Topnav with minimal inputs */
-        initialVisibleSections?.includes("TopNav") && !topNavProps && (
-          <StyledTopNavContainer>
+      <StyledTopNavContainer>
+        {
+          /* If TopNav should be initially visible and we have not yet received props, render Topnav with minimal inputs */
+          initialVisibleSections?.includes("TopNav") && !topNavProps && (
             <ErrorBoundary fallback={null} onError={onError}>
               <TopNav />
             </ErrorBoundary>
-          </StyledTopNavContainer>
-        )
-      }
-      {topNavProps && (
-        <StyledTopNavContainer>
+          )
+        }
+        {topNavProps && (
           <ErrorBoundary fallback={null} onError={onError}>
             <TopNav
               {...topNavProps}
@@ -236,8 +234,8 @@ const UiShellContent = ({
               rightSideComponent={optionalComponents?.topNavRightSide}
             />
           </ErrorBoundary>
-        </StyledTopNavContainer>
-      )}
+        )}
+      </StyledTopNavContainer>
 
       <StyledAppContainer
         appBackgroundContrastMode={appBackgroundContrastMode}

--- a/packages/odyssey-react-mui/src/ui-shell/UiShell/UiShellContent.tsx
+++ b/packages/odyssey-react-mui/src/ui-shell/UiShell/UiShellContent.tsx
@@ -28,21 +28,33 @@ const emptySideNavItems = [] satisfies SideNavProps["sideNavItems"];
 
 const StyledAppContainer = styled("div", {
   shouldForwardProp: (prop) =>
-    prop !== "odysseyDesignTokens" && prop !== "appBackgroundContrastMode",
+    prop !== "odysseyDesignTokens" &&
+    prop !== "appBackgroundContrastMode" &&
+    prop !== "hasStandardAppContentPadding",
 })<{
   appBackgroundContrastMode: ContrastMode;
+  hasStandardAppContentPadding: UiShellContentProps["hasStandardAppContentPadding"];
   odysseyDesignTokens: DesignTokens;
-}>(({ appBackgroundContrastMode, odysseyDesignTokens }) => ({
-  gridArea: "app-content",
-  overflowX: "hidden",
-  overflowY: "auto",
-  paddingBlock: odysseyDesignTokens.Spacing5,
-  paddingInline: odysseyDesignTokens.Spacing8,
-  backgroundColor:
-    appBackgroundContrastMode === "highContrast"
-      ? odysseyDesignTokens.HueNeutralWhite
-      : odysseyDesignTokens.HueNeutral50,
-}));
+}>(
+  ({
+    appBackgroundContrastMode,
+    hasStandardAppContentPadding,
+    odysseyDesignTokens,
+  }) => ({
+    gridArea: "app-content",
+    overflowX: "hidden",
+    overflowY: "auto",
+    backgroundColor:
+      appBackgroundContrastMode === "highContrast"
+        ? odysseyDesignTokens.HueNeutralWhite
+        : odysseyDesignTokens.HueNeutral50,
+
+    ...(hasStandardAppContentPadding && {
+      paddingBlock: odysseyDesignTokens.Spacing5,
+      paddingInline: odysseyDesignTokens.Spacing8,
+    }),
+  }),
+);
 
 const StyledBannersContainer = styled("div")(() => ({
   gridArea: "banners",
@@ -107,6 +119,10 @@ export type UiShellContentProps = {
    */
   appComponent: ReactNode;
   /**
+   * defaults to `true`. If `false`, the content area will have no padding provided
+   */
+  hasStandardAppContentPadding?: boolean;
+  /**
    * Which parts of the UI Shell should be visible initially? For example,
    * if sideNavProps is undefined, should the space for the sidenav be initially visible?
    */
@@ -136,6 +152,7 @@ export type UiShellContentProps = {
 const UiShellContent = ({
   appBackgroundContrastMode = "lowContrast",
   appComponent,
+  hasStandardAppContentPadding = true,
   initialVisibleSections = ["TopNav", "SideNav", "AppSwitcher"],
   onError = console.error,
   optionalComponents,
@@ -145,7 +162,7 @@ const UiShellContent = ({
 }: UiShellContentProps) => {
   const odysseyDesignTokens = useOdysseyDesignTokens();
   const { isContentScrolled, scrollableContentRef } = useScrollState();
-
+  console.log({ hasStandardAppContentPadding });
   return (
     <StyledShellContainer odysseyDesignTokens={odysseyDesignTokens}>
       <StyledBannersContainer>
@@ -199,17 +216,18 @@ const UiShellContent = ({
           </ErrorBoundary>
         )}
       </StyledSideNavContainer>
-
-      <StyledTopNavContainer>
-        {
-          /* If TopNav should be initially visible and we have not yet received props, render Topnav with minimal inputs */
-          initialVisibleSections?.includes("TopNav") && !topNavProps && (
+      {
+        /* If TopNav should be initially visible and we have not yet received props, render Topnav with minimal inputs */
+        initialVisibleSections?.includes("TopNav") && !topNavProps && (
+          <StyledTopNavContainer>
             <ErrorBoundary fallback={null} onError={onError}>
               <TopNav />
             </ErrorBoundary>
-          )
-        }
-        {topNavProps && (
+          </StyledTopNavContainer>
+        )
+      }
+      {topNavProps && (
+        <StyledTopNavContainer>
           <ErrorBoundary fallback={null} onError={onError}>
             <TopNav
               {...topNavProps}
@@ -218,12 +236,13 @@ const UiShellContent = ({
               rightSideComponent={optionalComponents?.topNavRightSide}
             />
           </ErrorBoundary>
-        )}
-      </StyledTopNavContainer>
+        </StyledTopNavContainer>
+      )}
 
       <StyledAppContainer
-        odysseyDesignTokens={odysseyDesignTokens}
         appBackgroundContrastMode={appBackgroundContrastMode}
+        hasStandardAppContentPadding={hasStandardAppContentPadding}
+        odysseyDesignTokens={odysseyDesignTokens}
         ref={scrollableContentRef}
         tabIndex={0}
       >

--- a/packages/odyssey-react-mui/src/ui-shell/UiShell/renderUiShell.tsx
+++ b/packages/odyssey-react-mui/src/ui-shell/UiShell/renderUiShell.tsx
@@ -42,6 +42,7 @@ export const optionalComponentSlotNames: Record<
 export const renderUiShell = ({
   appBackgroundContrastMode,
   appRootElement: explicitAppRootElement,
+  hasStandardAppContentPadding,
   initialVisibleSections,
   onError = console.error,
   uiShellRootElement,
@@ -60,7 +61,9 @@ export const renderUiShell = ({
   uiShellRootElement: HTMLElement;
 } & Pick<
   UiShellProps,
-  "appBackgroundContrastMode" | "initialVisibleSections"
+  | "appBackgroundContrastMode"
+  | "hasStandardAppContentPadding"
+  | "initialVisibleSections"
 >) => {
   const appRootElement =
     explicitAppRootElement || document.createElement("div");
@@ -108,6 +111,7 @@ export const renderUiShell = ({
           appBackgroundContrastMode={appBackgroundContrastMode}
           appComponent={appComponent}
           appRootElement={reactRootElements.appRootElement}
+          hasStandardAppContentPadding={hasStandardAppContentPadding}
           initialVisibleSections={initialVisibleSections}
           onError={onError}
           onSubscriptionCreated={publishSubscriptionCreated}

--- a/packages/odyssey-storybook/src/components/odyssey-ui-shell/UiShell/UiShell.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-ui-shell/UiShell/UiShell.stories.tsx
@@ -46,6 +46,16 @@ const storybookMeta: Meta<UiShellProps> = {
         },
       },
     },
+    hasStandardAppContentPadding: {
+      control: "boolean",
+      description:
+        "defaults to `true`. If `false`, the content area will have no padding provided",
+      table: {
+        type: {
+          summary: "boolean",
+        },
+      },
+    },
     initialVisibleSections: {
       control: "text",
       description:
@@ -255,6 +265,7 @@ export const TopNavOnly: StoryObj<UiShellProps> = {
 
 export const AppSwitcherOnly: StoryObj<UiShellProps> = {
   args: {
+    hasStandardAppContentPadding: false,
     initialVisibleSections: ["AppSwitcher"],
     subscribeToPropChanges: (subscriber) => {
       subscriber({

--- a/packages/odyssey-storybook/src/components/odyssey-ui-shell/UiShell/UiShell.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-ui-shell/UiShell/UiShell.stories.tsx
@@ -269,7 +269,6 @@ export const AppSwitcherOnly: StoryObj<UiShellProps> = {
     initialVisibleSections: ["AppSwitcher"],
     subscribeToPropChanges: (subscriber) => {
       subscriber({
-        topNavProps: {},
         appSwitcherProps: sharedAppSwitcherProps,
       });
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[DES-6867](https://oktainc.atlassian.net/browse/DES-6867)

## Summary
- Allow consumers to render app content without standard padding
<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
