### PR TITLE
Add `Borderless` variant to Accordion

### DIFF
--- a/packages/odyssey-react-mui/src/Accordion.tsx
+++ b/packages/odyssey-react-mui/src/Accordion.tsx
@@ -88,7 +88,6 @@ const Accordion = ({
   return (
     <MuiAccordion
       data-se={testId}
-      data-ods-type="accordion"
       data-ods-variant={variant}
       defaultExpanded={isDefaultExpanded}
       disabled={isDisabled}

--- a/packages/odyssey-react-mui/src/Accordion.tsx
+++ b/packages/odyssey-react-mui/src/Accordion.tsx
@@ -22,6 +22,8 @@ import { ChevronDownIcon } from "./icons.generated";
 import { Support } from "./Typography";
 import { useUniqueId } from "./useUniqueId";
 
+export const accordionVariantValues = ["default", "borderless"] as const;
+
 export type AccordionProps = {
   /**
    * The content of the Accordion itself
@@ -50,6 +52,10 @@ export type AccordionProps = {
   /**
    * Event fired when the expansion state of the accordion is changed
    */
+  /**
+   * Visual style for the accordion (default or borderless)
+   */
+  variant?: (typeof accordionVariantValues)[number];
   onChange?: MuiAccordionProps["onChange"];
 } & (
   | {
@@ -73,6 +79,7 @@ const Accordion = ({
   onChange,
   testId,
   translate,
+  variant = "default",
 }: AccordionProps) => {
   const id = useUniqueId(idOverride);
   const headerId = `${id}-header`;
@@ -81,6 +88,8 @@ const Accordion = ({
   return (
     <MuiAccordion
       data-se={testId}
+      data-ods-type="accordion"
+      data-ods-variant={variant}
       defaultExpanded={isDefaultExpanded}
       disabled={isDisabled}
       disableGutters

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -83,6 +83,9 @@ export const getComponents = ({
           borderRadius: 0,
           boxShadow: "none",
 
+          '&[data-ods-type="accordion"][data-ods-variant="borderless"]': {
+            border: "none",
+          },
           "&.Mui-disabled": {
             backgroundColor: odysseyTokens.HueNeutralWhite,
             color: odysseyTokens.TypographyColorDisabled,

--- a/packages/odyssey-react-mui/src/theme/components.tsx
+++ b/packages/odyssey-react-mui/src/theme/components.tsx
@@ -83,9 +83,14 @@ export const getComponents = ({
           borderRadius: 0,
           boxShadow: "none",
 
-          '&[data-ods-type="accordion"][data-ods-variant="borderless"]': {
+          "&.MuiPaper-root.MuiAccordion-root[data-ods-variant='borderless']": {
             border: "none",
+
+            "&::before": {
+              display: "none",
+            },
           },
+
           "&.Mui-disabled": {
             backgroundColor: odysseyTokens.HueNeutralWhite,
             color: odysseyTokens.TypographyColorDisabled,

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Accordion/Accordion.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Accordion/Accordion.stories.tsx
@@ -36,7 +36,7 @@ const storybookMeta: Meta<AccordionProps> = {
       description: "",
       table: {
         type: {
-          summary: "ReactNode",
+          summary: "string",
         },
       },
     },
@@ -58,12 +58,24 @@ const storybookMeta: Meta<AccordionProps> = {
         },
       },
     },
+    variant: {
+      control: "select",
+      options: ["default", "borderless"],
+      description: "Visual style for the accordion",
+      table: {
+        type: {
+          summary: "string",
+        },
+        defaultValue: { summary: "default" },
+      },
+    },
   },
   args: {
     children: "Lorem ipsum dolor sit amet.",
     isDisabled: false,
     isExpanded: undefined,
     label: "Label",
+    variant: "default",
   },
   decorators: [MuiThemeDecorator],
 };
@@ -80,6 +92,7 @@ export const Single: StoryObj<AccordionProps> = {
         label={props.label}
         isDisabled={props.isDisabled}
         isExpanded={props.isExpanded}
+        variant={props.variant}
       >
         {props.children}
       </Accordion>
@@ -87,6 +100,24 @@ export const Single: StoryObj<AccordionProps> = {
   },
 };
 
+export const Borderless: StoryObj<AccordionProps> = {
+  args: {
+    children: "This is the content of the box.",
+    variant: "borderless",
+  },
+  render: function C(props: AccordionProps) {
+    return (
+      <Accordion
+        label={props.label}
+        isDisabled={props.isDisabled}
+        isExpanded={props.isExpanded}
+        variant={props.variant}
+      >
+        {props.children}
+      </Accordion>
+    );
+  },
+};
 export const Multi: StoryObj<AccordionProps> = {
   args: {
     children: "This is the content of the box.",


### PR DESCRIPTION

[DES-6886](https://oktainc.atlassian.net/browse/DES-6886)

## Summary

* Adds `borderless` variant to accordion to match Figma 
* Updates accordion storybook docs with correct prop type for label (`string` not `ReactNode`)


## Testing & Screenshots
![CleanShot 2024-12-19 at 14 27 32@2x](https://github.com/user-attachments/assets/05c1070d-7ed7-40a9-8534-b7a00dc572fa)

- [x] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
