### PR TITLE
Pass translate to profile button and misc height issue fixes

### DIFF
--- a/packages/odyssey-react-mui/src/Select.tsx
+++ b/packages/odyssey-react-mui/src/Select.tsx
@@ -513,7 +513,6 @@ const Select = <
             sx: {
               ".MuiPaper-root": {
                 maxHeight: "50vh",
-                minHeight: "200px",
               },
             },
           }}

--- a/packages/odyssey-react-mui/src/labs/OdysseyPickers/PickerVirtualizationListBox.tsx
+++ b/packages/odyssey-react-mui/src/labs/OdysseyPickers/PickerVirtualizationListBox.tsx
@@ -122,7 +122,7 @@ const PickerVirtualizationListBox = forwardRef<
       return 9999;
     } else {
       const itemsHeightCalculated = sizeMapRef.current
-        .slice(0, itemData.length - 1)
+        .slice(0, itemData.length)
         .map((_, index) => sizeMapRef.current[index] || 0)
         .reduce(
           (prevItemHeight, nextItemHeight) => prevItemHeight + nextItemHeight,

--- a/packages/odyssey-react-mui/src/labs/SideNav/SideNavItemContent.tsx
+++ b/packages/odyssey-react-mui/src/labs/SideNav/SideNavItemContent.tsx
@@ -246,10 +246,8 @@ const SideNavItemContent = ({
     MouseEventHandler<HTMLDivElement | HTMLAnchorElement>
   >(
     (event) => {
-      return () => {
-        onItemSelected?.(id);
-        onClick?.(event);
-      };
+      onItemSelected?.(id);
+      onClick?.(event);
     },
     [id, onClick, onItemSelected],
   );

--- a/packages/odyssey-react-mui/src/labs/SideNav/SideNavLogo.tsx
+++ b/packages/odyssey-react-mui/src/labs/SideNav/SideNavLogo.tsx
@@ -11,8 +11,16 @@
  */
 
 import { memo, useMemo } from "react";
+import styled from "@emotion/styled";
+
 import { OktaLogo } from "./OktaLogo";
 import { SideNavLogoProps } from "./types";
+
+const StyledLogoLink = styled("a")(() => ({
+  display: "flex",
+  alignItems: "center",
+  height: "100%",
+}));
 
 const SideNavLogo = ({
   imageAltText,
@@ -32,7 +40,13 @@ const SideNavLogo = ({
     return <OktaLogo />;
   }, [imageAltText, logoComponent, imageUrl]);
 
-  return href ? <a href={href}>{logo}</a> : logo;
+  return href ? (
+    <StyledLogoLink data-se="sidenav-header-logo" href={href}>
+      {logo}
+    </StyledLogoLink>
+  ) : (
+    logo
+  );
 };
 
 const MemoizedSideNavLogo = memo(SideNavLogo);

--- a/packages/odyssey-react-mui/src/labs/SideNav/SideNavLogo.tsx
+++ b/packages/odyssey-react-mui/src/labs/SideNav/SideNavLogo.tsx
@@ -16,6 +16,12 @@ import styled from "@emotion/styled";
 import { OktaLogo } from "./OktaLogo";
 import { SideNavLogoProps } from "./types";
 
+const StyledLogoContainer = styled("div")(() => ({
+  display: "flex",
+  alignItems: "center",
+  height: "100%",
+}));
+
 const StyledLogoLink = styled("a")(() => ({
   display: "flex",
   alignItems: "center",
@@ -24,9 +30,9 @@ const StyledLogoLink = styled("a")(() => ({
 
 const SideNavLogo = ({
   imageAltText,
-  href,
   logoComponent,
   imageUrl,
+  ...optionalProps
 }: SideNavLogoProps) => {
   const logo = useMemo(() => {
     if (logoComponent) {
@@ -40,12 +46,16 @@ const SideNavLogo = ({
     return <OktaLogo />;
   }, [imageAltText, logoComponent, imageUrl]);
 
-  return href ? (
-    <StyledLogoLink data-se="sidenav-header-logo" href={href}>
+  return "href" in optionalProps && "ariaLabel" in optionalProps ? (
+    <StyledLogoLink
+      aria-label={optionalProps.ariaLabel}
+      data-se="sidenav-header-logo"
+      href={optionalProps.href}
+    >
       {logo}
     </StyledLogoLink>
   ) : (
-    logo
+    <StyledLogoContainer role="presentation">{logo}</StyledLogoContainer>
   );
 };
 

--- a/packages/odyssey-react-mui/src/labs/SideNav/SideNavToggleButton.tsx
+++ b/packages/odyssey-react-mui/src/labs/SideNav/SideNavToggleButton.tsx
@@ -199,6 +199,7 @@ const SideNavToggleButton = ({
           aria-controls={ariaControls}
           aria-expanded={!isSideNavCollapsed}
           aria-label={toggleLabel}
+          data-se="sidenav-toggle-button"
           data-sidenav-toggle={true}
           id={id}
           isSideNavCollapsed={isSideNavCollapsed}

--- a/packages/odyssey-react-mui/src/labs/SideNav/types.ts
+++ b/packages/odyssey-react-mui/src/labs/SideNav/types.ts
@@ -14,40 +14,48 @@ import type { ReactElement, SyntheticEvent } from "react";
 import type { HtmlProps } from "../../HtmlProps";
 import type { statusSeverityValues } from "../../Status";
 
-export type SideNavLogoProps = {
-  href?: string;
-} & (
-  | {
-      /**
-       * a component to render as the logo
-       */
-      logoComponent: ReactElement;
-      imageAltText?: never;
-      imageUrl?: never;
-    }
-  | {
-      /**
-       * The src url to render in an `img` tag
-       */
-      imageUrl: string;
-      /**
-       * alt text for the img logo
-       */
-      imageAltText: string;
-      logoComponent?: never;
-    }
-  | {
-      /**
-       * The src url to render in an `img` tag
-       */
-      imageUrl?: never;
-      /**
-       * alt text for the img logo
-       */
-      imageAltText?: never;
-      logoComponent?: never;
-    }
-);
+type LogoWithLink = {
+  href: string;
+  ariaLabel: string;
+};
+type LogoWithNoLink = {
+  href?: never;
+  ariaLabel?: never;
+};
+
+export type SideNavLogoProps = (LogoWithLink | LogoWithNoLink) &
+  (
+    | {
+        /**
+         * a component to render as the logo
+         */
+        logoComponent: ReactElement;
+        imageAltText?: never;
+        imageUrl?: never;
+      }
+    | {
+        /**
+         * The src url to render in an `img` tag
+         */
+        imageUrl: string;
+        /**
+         * alt text for the img logo
+         */
+        imageAltText: string;
+        logoComponent?: never;
+      }
+    | {
+        /**
+         * The src url to render in an `img` tag
+         */
+        imageUrl?: never;
+        /**
+         * alt text for the img logo
+         */
+        imageAltText?: never;
+        logoComponent?: never;
+      }
+  );
 
 export type SideNavProps = {
   /**

--- a/packages/odyssey-react-mui/src/labs/TopNav/UserProfile.tsx
+++ b/packages/odyssey-react-mui/src/labs/TopNav/UserProfile.tsx
@@ -13,12 +13,13 @@
 import styled from "@emotion/styled";
 import { memo, type ReactElement } from "react";
 
+import { Box } from "../../Box";
+import { HtmlProps } from "../../HtmlProps";
 import {
   DesignTokens,
   useOdysseyDesignTokens,
 } from "../../OdysseyDesignTokensContext";
 import { Subordinate } from "../../Typography";
-import { Box } from "../../Box";
 
 const UserProfileContainer = styled("div", {
   shouldForwardProp: (prop) => prop !== "odysseyDesignTokens",
@@ -42,6 +43,7 @@ const UserProfileInfoContainer = styled("div")(() => ({
 }));
 
 export type UserProfileProps = {
+  hasTranslatedUserAndOrgName?: HtmlProps["translate"];
   /**
    * Logged in user profile icon to be displayed in the top nav
    */
@@ -61,6 +63,7 @@ export type UserProfileProps = {
 };
 
 const UserProfile = ({
+  hasTranslatedUserAndOrgName,
   profileIcon,
   userName,
   orgName,
@@ -76,7 +79,7 @@ const UserProfile = ({
         </UserProfileIconContainer>
       )}
 
-      <UserProfileInfoContainer>
+      <UserProfileInfoContainer translate={hasTranslatedUserAndOrgName}>
         {userNameEndIcon ? (
           <Box
             sx={{

--- a/packages/odyssey-react-mui/src/labs/TopNav/UserProfile.tsx
+++ b/packages/odyssey-react-mui/src/labs/TopNav/UserProfile.tsx
@@ -43,7 +43,6 @@ const UserProfileInfoContainer = styled("div")(() => ({
 }));
 
 export type UserProfileProps = {
-  translateUserAndOrgName?: HtmlProps["translate"];
   /**
    * Logged in user profile icon to be displayed in the top nav
    */
@@ -60,13 +59,13 @@ export type UserProfileProps = {
    * The icon element to display after the username
    */
   userNameEndIcon?: ReactElement;
-};
+} & Pick<HtmlProps, "translate">;
 
 const UserProfile = ({
-  translateUserAndOrgName,
   profileIcon,
   userName,
   orgName,
+  translate,
   userNameEndIcon,
 }: UserProfileProps) => {
   const odysseyDesignTokens = useOdysseyDesignTokens();
@@ -79,7 +78,7 @@ const UserProfile = ({
         </UserProfileIconContainer>
       )}
 
-      <UserProfileInfoContainer translate={translateUserAndOrgName}>
+      <UserProfileInfoContainer translate={translate}>
         {userNameEndIcon ? (
           <Box
             sx={{

--- a/packages/odyssey-react-mui/src/labs/TopNav/UserProfile.tsx
+++ b/packages/odyssey-react-mui/src/labs/TopNav/UserProfile.tsx
@@ -43,7 +43,7 @@ const UserProfileInfoContainer = styled("div")(() => ({
 }));
 
 export type UserProfileProps = {
-  hasTranslatedUserAndOrgName?: HtmlProps["translate"];
+  translateUserAndOrgName?: HtmlProps["translate"];
   /**
    * Logged in user profile icon to be displayed in the top nav
    */
@@ -63,7 +63,7 @@ export type UserProfileProps = {
 };
 
 const UserProfile = ({
-  hasTranslatedUserAndOrgName,
+  translateUserAndOrgName,
   profileIcon,
   userName,
   orgName,
@@ -79,7 +79,7 @@ const UserProfile = ({
         </UserProfileIconContainer>
       )}
 
-      <UserProfileInfoContainer translate={hasTranslatedUserAndOrgName}>
+      <UserProfileInfoContainer translate={translateUserAndOrgName}>
         {userNameEndIcon ? (
           <Box
             sx={{

--- a/packages/odyssey-react-mui/src/labs/TopNav/UserProfileMenuButton.tsx
+++ b/packages/odyssey-react-mui/src/labs/TopNav/UserProfileMenuButton.tsx
@@ -50,7 +50,7 @@ const UserProfileMenuButton = ({
           profileIcon={profileIcon}
           userName={userName}
           orgName={orgName}
-          translateUserAndOrgName={translate}
+          translate={translate}
           userNameEndIcon={userNameEndIcon ?? <ChevronDownIcon />}
         />
       }

--- a/packages/odyssey-react-mui/src/labs/TopNav/UserProfileMenuButton.tsx
+++ b/packages/odyssey-react-mui/src/labs/TopNav/UserProfileMenuButton.tsx
@@ -50,7 +50,7 @@ const UserProfileMenuButton = ({
           profileIcon={profileIcon}
           userName={userName}
           orgName={orgName}
-          hasTranslatedUserAndOrgName={translate}
+          translateUserAndOrgName={translate}
           userNameEndIcon={userNameEndIcon ?? <ChevronDownIcon />}
         />
       }

--- a/packages/odyssey-react-mui/src/labs/TopNav/UserProfileMenuButton.tsx
+++ b/packages/odyssey-react-mui/src/labs/TopNav/UserProfileMenuButton.tsx
@@ -24,16 +24,22 @@ export type UserProfileMenuButtonProps = Omit<
   "endIcon" | "variant"
 > &
   AdditionalBaseMenuButtonProps &
-  UserProfileProps;
+  UserProfileProps & {
+    /**
+     *
+     * NOTE: In this case, attribute only applies to user name and org name
+     */
+    translate?: string;
+  };
 
-const UserProfileMenuButton = (props: UserProfileMenuButtonProps) => {
-  const {
-    profileIcon,
-    userName,
-    orgName,
-    userNameEndIcon,
-    ...menuButtonProps
-  } = props;
+const UserProfileMenuButton = ({
+  profileIcon,
+  userName,
+  orgName,
+  translate,
+  userNameEndIcon,
+  ...menuButtonProps
+}: UserProfileMenuButtonProps) => {
   return (
     <BaseMenuButton
       {...menuButtonProps}
@@ -44,6 +50,7 @@ const UserProfileMenuButton = (props: UserProfileMenuButtonProps) => {
           profileIcon={profileIcon}
           userName={userName}
           orgName={orgName}
+          hasTranslatedUserAndOrgName={translate}
           userNameEndIcon={userNameEndIcon ?? <ChevronDownIcon />}
         />
       }

--- a/packages/odyssey-storybook/src/components/odyssey-labs/SideNav/SideNav.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/SideNav/SideNav.stories.tsx
@@ -498,6 +498,22 @@ export const CustomLogoImage: StoryObj<typeof SideNav> = {
   },
 };
 
+export const LogoWithLink: StoryObj<typeof SideNav> = {
+  args: {
+    logoProps: {
+      href: "/",
+      logoComponent: <PlaceholderLogo.One />,
+    },
+  },
+  render: (props) => {
+    return (
+      <div style={{ height: "100vh" }}>
+        <SideNav {...props} />
+      </div>
+    );
+  },
+};
+
 export const CustomFooterContent: StoryObj<typeof SideNav> = {
   args: {
     footerItems: undefined,

--- a/packages/odyssey-storybook/src/components/odyssey-labs/SideNav/SideNav.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/SideNav/SideNav.stories.tsx
@@ -503,6 +503,7 @@ export const LogoWithLink: StoryObj<typeof SideNav> = {
     logoProps: {
       href: "/",
       logoComponent: <PlaceholderLogo.One />,
+      ariaLabel: "My custom image logo",
     },
   },
   render: (props) => {


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[DES-6951](https://oktainc.atlassian.net/browse/DES-6951)

## Summary
- Allows `translate` prop to be passed through to `UserProfile`'s `userName` and `orgName`
- Fixes virtualized listbox not calculating height correctly when one item is present
- Removes min-height on select menu
- Adds hard coded test selectors for sidenav toggle and logo
<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
