### PR TITLE
fix: make sidenav nested items sortable by default

### DIFF
--- a/packages/odyssey-react-mui/src/labs/SideNav/SideNav.tsx
+++ b/packages/odyssey-react-mui/src/labs/SideNav/SideNav.tsx
@@ -41,6 +41,7 @@ import { SideNavToggleButton } from "./SideNavToggleButton";
 import { SortableList } from "./SortableList/SortableList";
 import { Overline } from "../../Typography";
 import { arrayMove } from "@dnd-kit/sortable";
+import { UniqueIdentifier } from "@dnd-kit/core";
 
 export const DEFAULT_SIDE_NAV_WIDTH = "300px";
 
@@ -512,7 +513,12 @@ const SideNav = ({
   );
 
   const setSortedItems = useCallback(
-    (parentId: string, activeIndex: number, overIndex: number) => {
+    (
+      parentId: string,
+      activeId: UniqueIdentifier,
+      activeIndex: number,
+      overIndex: number,
+    ) => {
       const sortedSideNavItems = sideNavItemsList.map((item) =>
         item.id === parentId && item.nestedNavItems
           ? {
@@ -526,7 +532,7 @@ const SideNav = ({
           : item,
       );
       updateSideNavItemsList(sortedSideNavItems);
-      onSort?.(sortedSideNavItems);
+      onSort?.(sortedSideNavItems, parentId, activeId, activeIndex, overIndex);
     },
     [onSort, sideNavItemsList],
   );

--- a/packages/odyssey-react-mui/src/labs/SideNav/SortableList/SortableList.tsx
+++ b/packages/odyssey-react-mui/src/labs/SideNav/SortableList/SortableList.tsx
@@ -42,7 +42,12 @@ export interface BaseItem {
 interface ListProps<T extends BaseItem> {
   parentId: string;
   items: T[];
-  onChange: (parentId: string, activeIndex: number, overIndex: number) => void;
+  onChange: (
+    parentId: string,
+    activeId: UniqueIdentifier,
+    activeIndex: number,
+    overIndex: number,
+  ) => void;
   renderItem: (item: T) => ReactNode;
 }
 
@@ -100,8 +105,9 @@ export const SortableList = <T extends BaseItem>({
         if (over && active.id !== over?.id) {
           const activeIndex = items.findIndex(({ id }) => id === active.id);
           const overIndex = items.findIndex(({ id }) => id === over.id);
-          if (items[overIndex].isSortable) {
-            onChange(parentId, activeIndex, overIndex);
+          // allow sorting by default except when isSortable is set to false explicitly
+          if (items[overIndex].isSortable !== false) {
+            onChange(parentId, active.id, activeIndex, overIndex);
           }
         }
         setActive(null);

--- a/packages/odyssey-react-mui/src/labs/SideNav/types.ts
+++ b/packages/odyssey-react-mui/src/labs/SideNav/types.ts
@@ -13,6 +13,7 @@
 import type { ReactElement, SyntheticEvent } from "react";
 import type { HtmlProps } from "../../HtmlProps";
 import type { statusSeverityValues } from "../../Status";
+import { UniqueIdentifier } from "@dnd-kit/core";
 
 type LogoWithLink = {
   href: string;
@@ -89,7 +90,13 @@ export type SideNavProps = {
   /**
    *  Triggers when the item is reordered
    */
-  onSort?: (reorderedItems: SideNavItem[]) => void;
+  onSort?: (
+    reorderedItems: SideNavItem[],
+    parentId: string,
+    activeId: UniqueIdentifier,
+    activeIndex: number,
+    overIndex: number,
+  ) => void;
   /**
    * Nav items in the side nav
    */

--- a/packages/odyssey-storybook/src/components/odyssey-labs/SideNav/SideNav.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-labs/SideNav/SideNav.stories.tsx
@@ -409,17 +409,14 @@ export const SortableSideNav: StoryObj<typeof SideNav> = {
           {
             id: "item17-2",
             label: "Work",
-            isSortable: true,
           },
           {
             id: "item17-3",
             label: "Group 1",
-            isSortable: true,
           },
           {
             id: "item17-4",
             label: "Group 2",
-            isSortable: true,
           },
           {
             id: "item17-5",


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[OKTA-853942](https://oktainc.atlassian.net/browse/OKTA-853942)

## Summary

fix: make sidenav nested items sortable by default

## Testing & Screenshots

- [X] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
