### PR TITLE
fix: move translate attribute to paragraph element

### DIFF
--- a/packages/odyssey-react-mui/src/labs/UserProfile.tsx
+++ b/packages/odyssey-react-mui/src/labs/UserProfile.tsx
@@ -90,7 +90,9 @@ const UserProfile = ({
             {userName}
           </Subordinate>
         )}
-        <Subordinate color="textSecondary" translate={translate}>{orgName}</Subordinate>
+        <Subordinate color="textSecondary" translate={translate}>
+          {orgName}
+        </Subordinate>
       </div>
     </UserProfileContainer>
   );

--- a/packages/odyssey-react-mui/src/labs/UserProfile.tsx
+++ b/packages/odyssey-react-mui/src/labs/UserProfile.tsx
@@ -71,7 +71,7 @@ const UserProfile = ({
         </UserProfileIconContainer>
       )}
 
-      <div translate={translate}>
+      <div>
         {userNameEndIcon ? (
           <Box
             sx={{
@@ -80,13 +80,17 @@ const UserProfile = ({
               gap: odysseyDesignTokens.Spacing2,
             }}
           >
-            <Subordinate color="textPrimary">{userName}</Subordinate>
+            <Subordinate color="textPrimary" translate={translate}>
+              {userName}
+            </Subordinate>
             {userNameEndIcon}
           </Box>
         ) : (
-          <Subordinate color="textPrimary">{userName}</Subordinate>
+          <Subordinate color="textPrimary" translate={translate}>
+            {userName}
+          </Subordinate>
         )}
-        <Subordinate color="textSecondary">{orgName}</Subordinate>
+        <Subordinate color="textSecondary" translate={translate}>{orgName}</Subordinate>
       </div>
     </UserProfileContainer>
   );


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[OKTA-856128](https://oktainc.atlassian.net/browse/OKTA-856128)

## Summary

When the translate="no" attribute is placed on the container (and test infrastructure looks for these to rule out english leaks), the resulting text content is all combined. The pre-Odyssey behavior is that the attribute is instead on the individual elements within this area. This updates where the translate attribute is placed to be more explicit.
<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
