### PR TITLE
fix: generate scss file to include in published package

### DIFF
--- a/packages/odyssey-design-tokens/config.cjs
+++ b/packages/odyssey-design-tokens/config.cjs
@@ -27,5 +27,16 @@ module.exports = {
         },
       ],
     },
+    scss: {
+      transformGroup: "scss",
+      buildPath: "dist/",
+      files: [
+        {
+          format: "scss/map-deep",
+          destination: "index.scss",
+          mapName: "ods-tokens",
+        },
+      ],
+    },
   },
 };


### PR DESCRIPTION


[OKTA-857768](https://oktainc.atlassian.net/browse/OKTA-857768)

## Summary
Generate scss file and include it in the generated source that is to be published for this package.
Creates a `dist/index.scss` file of the ODS tokens.
<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
