### PR TITLE
fix: sidenav footer component does not use the theme background color

### DIFF
--- a/packages/odyssey-react-mui/src/ui-shell/SideNav/SideNav.tsx
+++ b/packages/odyssey-react-mui/src/ui-shell/SideNav/SideNav.tsx
@@ -257,14 +257,18 @@ const SideNavFooter = styled("div", {
 
 const PersistentSideNavFooter = styled(SideNavFooter, {
   shouldForwardProp: (prop) =>
-    prop !== "isContentScrollable" && prop !== "odysseyDesignTokens",
+    prop !== "isContentScrollable" &&
+    prop !== "odysseyDesignTokens" &&
+    prop !== "sideNavBackgroundColor",
 })(
   ({
     isContentScrollable,
     odysseyDesignTokens,
+    sideNavBackgroundColor,
   }: {
     isContentScrollable: boolean;
     odysseyDesignTokens: DesignTokens;
+    sideNavBackgroundColor?: UiShellColors["sideNavBackgroundColor"];
   }) => ({
     transitionProperty: "box-shadow",
     transitionDuration: odysseyDesignTokens.TransitionDurationMain,
@@ -273,6 +277,9 @@ const PersistentSideNavFooter = styled(SideNavFooter, {
     // The box shadow should appear above the footer only if the scrollable region has overflow
     ...(isContentScrollable && {
       boxShadow: "0px -8px 8px -8px rgba(39, 39, 39, 0.08)",
+    }),
+    ...(sideNavBackgroundColor && {
+      backgroundColor: sideNavBackgroundColor,
     }),
   }),
 );
@@ -785,6 +792,7 @@ const SideNav = ({
               <PersistentSideNavFooter
                 isContentScrollable={isContentScrollable}
                 odysseyDesignTokens={odysseyDesignTokens}
+                sideNavBackgroundColor={uiShellContext?.sideNavBackgroundColor}
               >
                 {footerComponent}
               </PersistentSideNavFooter>


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[860405](https://oktainc.atlassian.net/browse/860405)

## Summary

fix: sidenav footer component does not use the theme background color

## Testing & Screenshots

Before:
![image](https://github.com/user-attachments/assets/8bb3a9be-5e4b-45bb-a368-0a19071dfd11)

After:
![image](https://github.com/user-attachments/assets/9a02032b-6f76-4c5d-b62a-897478e00a96)

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
