### PR TITLE
[odyssey-react-mui] add variant functionality to Card component

### DIFF
--- a/packages/odyssey-storybook/src/components/odyssey-mui/Card/Card.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Card/Card.stories.tsx
@@ -196,3 +196,47 @@ export const ButtonWithoutImage: Story = {
     </Box>
   ),
 };
+
+export const TileVariant: Story = {
+  render: (args) => {
+    return (
+      <Box sx={{ maxWidth: 262 }}>
+        <Card
+          title={args.title}
+          description={args.description}
+          overline={args.overline}
+          image={<img src="https://placehold.co/128" alt="Example logo" />}
+          variant="tile"
+        />
+      </Box>
+    );
+  },
+};
+
+export const StackVariant: Story = {
+  render: (args) => {
+    return (
+      <Card
+        title={args.title}
+        description={args.description}
+        overline={args.overline}
+        image={<img src="https://placehold.co/128" alt="Example logo" />}
+        variant="stack"
+      />
+    );
+  },
+};
+
+export const CompactVariant: Story = {
+  render: (args) => {
+    return (
+      <Card
+        title={args.title}
+        description={args.description}
+        overline={args.overline}
+        image={<img src="https://placehold.co/128" alt="Example logo" />}
+        variant="compact"
+      />
+    );
+  },
+};


### PR DESCRIPTION
[OKTA-867706](https://oktainc.atlassian.net/browse/OKTA-867706)

## Summary

Adds tile, stack and compact variants to the `Card` component

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [x] I have confirmed this change with my designer and the Odyssey Design Team.

<img width="282" alt="Screenshot 2025-02-10 at 1 56 06 PM" src="https://github.com/user-attachments/assets/d57cd9dc-a6a8-488f-9657-b9bfa2497c7c" />
<img width="841" alt="Screenshot 2025-02-10 at 1 56 16 PM" src="https://github.com/user-attachments/assets/604e4dc8-9b87-49b1-9ba7-c2bcc649ea67" />
<img width="841" alt="Screenshot 2025-02-10 at 1 56 09 PM" src="https://github.com/user-attachments/assets/2d9ab320-7323-4a86-97ff-cd0df0c0bceb" />

