### PR TITLE
[odyssey-react-mui] add onClick handler to Breadcrumb

### DIFF
--- a/packages/odyssey-react-mui/src/Breadcrumbs.tsx
+++ b/packages/odyssey-react-mui/src/Breadcrumbs.tsx
@@ -38,6 +38,7 @@ export type BreadcrumbProps = {
   children?: string;
   href: string;
   iconName?: "user" | "group";
+  onClick?: MouseEventHandler;
 };
 
 export type BreadcrumbsProps = {
@@ -61,8 +62,24 @@ const BreadcrumbContent = styled.span`
   text-overflow: ellipsis;
 `;
 
-export const Breadcrumb = ({ children, href, iconName }: BreadcrumbProps) => {
+export const Breadcrumb = ({
+  children,
+  href,
+  iconName,
+  onClick,
+}: BreadcrumbProps) => {
   const { breadcrumbType } = useContext(BreadcrumbContext);
+
+  const onClickHandler = useCallback<MouseEventHandler<HTMLAnchorElement>>(
+    (event) => {
+      if (onClick) {
+        event.preventDefault();
+        event.stopPropagation();
+        onClick(event);
+      }
+    },
+    [onClick],
+  );
 
   const breadcrumbContent = (
     <>
@@ -76,7 +93,11 @@ export const Breadcrumb = ({ children, href, iconName }: BreadcrumbProps) => {
   );
 
   if (breadcrumbType === "menuItem") {
-    return <MenuItem href={href}>{breadcrumbContent}</MenuItem>;
+    return (
+      <MenuItem onClick={onClickHandler} href={href}>
+        {breadcrumbContent}
+      </MenuItem>
+    );
   }
 
   if (breadcrumbType === "currentPage") {
@@ -90,7 +111,11 @@ export const Breadcrumb = ({ children, href, iconName }: BreadcrumbProps) => {
   // breadcrumbType === "listItem" is the default
   // Provided here without a conditional to get TS to be quiet
   // about potential undefined returns
-  return <ButtonBase href={href}>{breadcrumbContent}</ButtonBase>;
+  return (
+    <ButtonBase onClick={onClickHandler} href={href}>
+      {breadcrumbContent}
+    </ButtonBase>
+  );
 };
 
 const breadcrumbProviderValue: Record<
@@ -166,8 +191,11 @@ const BreadcrumbList = ({
         </ButtonBase>
       )}
 
-      {breadcrumbSections.beforeMenu.map((breadcrumb) => (
-        <BreadcrumbContext.Provider value={breadcrumbProviderValue.listItem}>
+      {breadcrumbSections.beforeMenu.map((breadcrumb, index) => (
+        <BreadcrumbContext.Provider
+          key={index}
+          value={breadcrumbProviderValue.listItem}
+        >
           {breadcrumb}
         </BreadcrumbContext.Provider>
       ))}
@@ -195,10 +223,11 @@ const BreadcrumbList = ({
         </>
       )}
 
-      {breadcrumbSections.remainingBreadcrumbs.map((breadcrumb, i) => {
-        if (i === breadcrumbSections.remainingBreadcrumbs.length - 1) {
+      {breadcrumbSections.remainingBreadcrumbs.map((breadcrumb, index) => {
+        if (index === breadcrumbSections.remainingBreadcrumbs.length - 1) {
           return (
             <BreadcrumbContext.Provider
+              key={index}
               value={breadcrumbProviderValue.currentPage}
             >
               {breadcrumb}
@@ -206,7 +235,10 @@ const BreadcrumbList = ({
           );
         }
         return (
-          <BreadcrumbContext.Provider value={breadcrumbProviderValue.listItem}>
+          <BreadcrumbContext.Provider
+            key={index}
+            value={breadcrumbProviderValue.listItem}
+          >
             {breadcrumb}
           </BreadcrumbContext.Provider>
         );

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -17,6 +17,7 @@ import {
 } from "@okta/odyssey-react-mui";
 import type { Meta, StoryObj } from "@storybook/react";
 import { expect, within } from "@storybook/test";
+import { action } from "@storybook/addon-actions";
 
 import { MuiThemeDecorator } from "../../../../.storybook/components/index.js";
 
@@ -128,5 +129,19 @@ export const Simple: StoryObj<BreadcrumbsProps> = {
   },
   render: (args: BreadcrumbsProps) => (
     <BreadcrumbList>{args.children}</BreadcrumbList>
+  ),
+};
+
+export const WithOnClick: StoryObj<BreadcrumbsProps> = {
+  args: {
+    homeHref: "#home",
+  },
+  render: (args) => (
+    <BreadcrumbList {...args}>
+      <Breadcrumb onClick={action("onClick")} href="#one">
+        One
+      </Breadcrumb>
+      <Breadcrumb href="#two">Two</Breadcrumb>
+    </BreadcrumbList>
   ),
 };


### PR DESCRIPTION

[OKTA-867708](https://oktainc.atlassian.net/browse/OKTA-867708)

## Summary

- feat: add onClick handler to Breadcrumb

Adding onClick to the component so it can be routing via the routing library of choice of the consumer. Keeping href required as to retain working functionality without JavaScript. onClick wrapper needs to prevent default and stop propagation.

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots
No visual implications with this work.
