### PR TITLE
fix: sidenav expand element z-index should be higher than topnav

### DIFF
--- a/packages/odyssey-react-mui/src/ui-shell/SideNav/SideNav.tsx
+++ b/packages/odyssey-react-mui/src/ui-shell/SideNav/SideNav.tsx
@@ -142,7 +142,7 @@ const StyledSideNav = styled("nav", {
       transform: `translateX(0)`,
       transition: `opacity ${odysseyDesignTokens.TransitionDurationMain}, transform ${odysseyDesignTokens.TransitionDurationMain}`,
       width: odysseyDesignTokens.Spacing2,
-      zIndex: 2,
+      zIndex: 200,
     },
 
     "&:has([data-sidenav-toggle='true']:hover), &:has([data-sidenav-toggle='true']:focus-visible)":


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[870600](https://oktainc.atlassian.net/browse/870600)

## Summary

fix: sidenav expand element z-index should be higher than topnav

## Testing & Screenshots

Before: 
![image](https://github.com/user-attachments/assets/7586607c-6e94-43f2-aa5d-f8c3bde8aabd)

After:
![image](https://github.com/user-attachments/assets/8b9c8fc1-1d96-4e91-9531-cb31eac8822d)

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
