### PR TITLE
feat: add noninteractive mode to breadcrumb item (by making href optional)

### DIFF
--- a/packages/odyssey-react-mui/src/Breadcrumbs.tsx
+++ b/packages/odyssey-react-mui/src/Breadcrumbs.tsx
@@ -36,7 +36,7 @@ export type BreadcrumbType = "listItem" | "menuItem" | "currentPage";
 
 export type BreadcrumbProps = {
   children?: string;
-  href: string;
+  href?: string;
   iconName?: "user" | "group";
   onClick?: MouseEventHandler;
 };
@@ -91,6 +91,10 @@ export const Breadcrumb = ({
       <BreadcrumbContent>{children}</BreadcrumbContent>
     </>
   );
+
+  if (!href) {
+    return <Subordinate color="textPrimary">{breadcrumbContent}</Subordinate>;
+  }
 
   if (breadcrumbType === "menuItem") {
     return (

--- a/packages/odyssey-storybook/src/components/odyssey-mui/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/odyssey-storybook/src/components/odyssey-mui/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -145,3 +145,16 @@ export const WithOnClick: StoryObj<BreadcrumbsProps> = {
     </BreadcrumbList>
   ),
 };
+
+export const Subordinate: StoryObj<BreadcrumbsProps> = {
+  args: {
+    homeHref: "#home",
+  },
+  render: (args) => (
+    <BreadcrumbList {...args}>
+      <Breadcrumb>One</Breadcrumb>
+      <Breadcrumb href="#two">Two</Breadcrumb>
+      <Breadcrumb href="#three">Three</Breadcrumb>
+    </BreadcrumbList>
+  ),
+};


### PR DESCRIPTION
[OKTA-869652](https://oktainc.atlassian.net/browse/OKTA-869652)

## Summary
feat: add noninteractive mode to breadcrumb item (by making href optional)

## Testing & Screenshots
<img width="207" alt="Screenshot 2025-02-18 at 11 16 58 AM" src="https://github.com/user-attachments/assets/ebdf622d-02ed-49c6-933a-7eb3204989d2" />

- [x] I have confirmed this change with my designer and the Odyssey Design Team.