### PR TITLE
fix: renderUiShell appRootElement inherits height

### DIFF
--- a/packages/odyssey-react-mui/src/ui-shell/renderUiShell.tsx
+++ b/packages/odyssey-react-mui/src/ui-shell/renderUiShell.tsx
@@ -73,8 +73,11 @@ export const renderUiShell = ({
   | "sideNavBackgroundColor"
   | "topNavBackgroundColor"
 >) => {
-  const appRootElement =
-    explicitAppRootElement || document.createElement("div");
+  let appRootElement = explicitAppRootElement;
+  if (!appRootElement) {
+    appRootElement = document.createElement("div");
+    appRootElement.style.height = "inherit";
+  }
 
   // Add this attribute so `PageTemplate` and potentially other components will know if they're in UI Shell with special padding already available.
   uiShellRootElement.setAttribute(uiShellDataAttribute, "");


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

https://oktainc.atlassian.net/browse/OKTA-876077

## Summary

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

fix: renderUiShell appRootElement inherits height

I made a enduser-dashboard specific fix in https://oktainc.atlassian.net/browse/OKTA-866730. This PR is to make the fix more broadly

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
