### PR TITLE
fix: add data-se to narrow UI Shell

### DIFF
--- a/packages/odyssey-react-mui/src/ui-shell/NarrowUiShellContent.tsx
+++ b/packages/odyssey-react-mui/src/ui-shell/NarrowUiShellContent.tsx
@@ -331,6 +331,7 @@ const NarrowUiShellContent = ({
                   <Button
                     onClick={toggleLeftSideMenu}
                     startIcon={<HamburgerMenuIcon />}
+                    testId="sidenav-menu--icon"
                     variant="floating"
                   />
 
@@ -352,6 +353,7 @@ const NarrowUiShellContent = ({
                     startIcon={
                       isRightSideMenuOpen ? <CloseIcon /> : <MoreIcon />
                     }
+                    testId="userprofile-menu--icon"
                     variant="floating"
                   />
                 )}

--- a/packages/odyssey-react-mui/src/ui-shell/SideNav/SideNavLogo.tsx
+++ b/packages/odyssey-react-mui/src/ui-shell/SideNav/SideNavLogo.tsx
@@ -21,24 +21,25 @@ const StyledLogoContainer = styled("div", {
 })<{
   isLogoInteractive?: boolean;
 }>(({ isLogoInteractive }) => ({
-  display: "flex",
   alignItems: "center",
+  display: "flex",
   height: "100%",
+
   ...(isLogoInteractive && {
     cursor: "pointer",
   }),
 }));
 
 const StyledLogoLink = styled("a")(() => ({
-  display: "flex",
   alignItems: "center",
+  display: "flex",
   height: "100%",
 }));
 
 const SideNavLogo = ({
   imageAltText,
-  logoComponent,
   imageUrl,
+  logoComponent,
   ...optionalProps
 }: SideNavLogoProps) => {
   const logo = useMemo(() => {


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[OKTA-887123](https://oktainc.atlassian.net/browse/OKTA-887123)

## Summary

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->
Narrow UI Shell's icons to open the side nav and user profile were missing `data-se` props used by existing Selenium tests.

## Testing & Screenshots

- [X] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
