### PR TITLE
fix: adds inner shadow to app container and not top nav

### DIFF
--- a/packages/odyssey-react-mui/src/ui-shell/InnerAppContainer.tsx
+++ b/packages/odyssey-react-mui/src/ui-shell/InnerAppContainer.tsx
@@ -1,0 +1,73 @@
+/*!
+ * Copyright (c) 2025-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import styled from "@emotion/styled";
+import { memo } from "react";
+
+// Shared styles for fake inset shadow. Not rendered anywhere.
+const StyledAppContainerShadowShared = styled("div")({
+  left: 0,
+  position: "absolute",
+  top: 0,
+  width: "100%",
+});
+
+export const StyledAppContainerShadow1 = styled(StyledAppContainerShadowShared)(
+  {
+    background: `linear-gradient(
+    to bottom,
+    rgba(39, 39, 39, 0.08) 0%,
+    transparent 100%
+  )`,
+    height: "4px",
+  },
+);
+
+export const StyledAppContainerShadow2 = styled(StyledAppContainerShadowShared)(
+  {
+    background: `linear-gradient(
+    to bottom,
+    rgba(39, 39, 39, 0.01) 0%,
+    transparent 100%
+  )`,
+    height: "6px",
+  },
+);
+
+export const StyledAppContainerShadow3 = styled(StyledAppContainerShadowShared)(
+  {
+    background: `linear-gradient(
+    to bottom,
+    rgba(39, 39, 39, 0.05) 0%,
+    transparent 100%
+  )`,
+    height: "15px",
+  },
+);
+
+export type InnerAppContainerProps = {
+  isContentScrolled: boolean;
+};
+
+const InnerAppContainer = ({ isContentScrolled }: InnerAppContainerProps) =>
+  isContentScrolled ? (
+    <>
+      <StyledAppContainerShadow1 />
+      <StyledAppContainerShadow2 />
+      <StyledAppContainerShadow3 />
+    </>
+  ) : null;
+
+const MemoizedInnerAppContainer = memo(InnerAppContainer);
+MemoizedInnerAppContainer.displayName = "InnerAppContainer";
+
+export { MemoizedInnerAppContainer as InnerAppContainer };

--- a/packages/odyssey-react-mui/src/ui-shell/NarrowUiShellContent.tsx
+++ b/packages/odyssey-react-mui/src/ui-shell/NarrowUiShellContent.tsx
@@ -26,6 +26,7 @@ import { Button } from "../Buttons/Button.js";
 import type { HtmlProps } from "../HtmlProps.js";
 import { CloseIcon } from "../icons.generated/Close.js";
 import { MoreIcon } from "../icons.generated/More.js";
+import { InnerAppContainer } from "./InnerAppContainer.js";
 import {
   DesignTokens,
   useOdysseyDesignTokens,
@@ -436,7 +437,9 @@ const NarrowUiShellContent = ({
             appBackgroundColor={uiShellContext?.appBackgroundColor}
             tabIndex={0}
             ref={uiShellAppAreaRef}
-          />
+          >
+            <InnerAppContainer isContentScrolled={isContentScrolled} />
+          </StyledAppContainer>
         </StyledAppContentArea>
       </StyledUiShellContainer>
     </>

--- a/packages/odyssey-react-mui/src/ui-shell/TopNav/TopNav.tsx
+++ b/packages/odyssey-react-mui/src/ui-shell/TopNav/TopNav.tsx
@@ -37,18 +37,13 @@ const StyledRightSideContainer = styled("div")(() => ({
 
 const StyledTopNavContainer = styled("div", {
   shouldForwardProp: (prop) =>
-    prop !== "odysseyDesignTokens" &&
-    prop !== "isScrolled" &&
-    prop !== "topNavBackgroundColor",
+    prop !== "odysseyDesignTokens" && prop !== "topNavBackgroundColor",
 })<{
-  isScrolled?: boolean;
   odysseyDesignTokens: DesignTokens;
   topNavBackgroundColor?: UiShellColors["topNavBackgroundColor"];
-}>(({ odysseyDesignTokens, isScrolled, topNavBackgroundColor }) => ({
+}>(({ odysseyDesignTokens, topNavBackgroundColor }) => ({
   alignItems: "center",
   backgroundColor: topNavBackgroundColor,
-  boxShadow: isScrolled ? odysseyDesignTokens.DepthMedium : undefined,
-  clipPath: "inset(0 0 -100vh 0)",
   display: "flex",
   gap: odysseyDesignTokens.Spacing4,
   height: "100%",
@@ -81,18 +76,13 @@ export type TopNavProps = {
   rightSideComponent?: ReactElement;
 } & Pick<HtmlProps, "testId">;
 
-const TopNav = ({
-  isScrolled,
-  leftSideComponent,
-  rightSideComponent,
-}: TopNavProps) => {
+const TopNav = ({ leftSideComponent, rightSideComponent }: TopNavProps) => {
   const odysseyDesignTokens = useOdysseyDesignTokens();
   const uiShellContext = useUiShellContext();
 
   return (
     <StyledTopNavContainer
       odysseyDesignTokens={odysseyDesignTokens}
-      isScrolled={isScrolled}
       topNavBackgroundColor={uiShellContext?.topNavBackgroundColor}
     >
       <StyledLeftSideContainer>

--- a/packages/odyssey-react-mui/src/ui-shell/WideUiShellContent.tsx
+++ b/packages/odyssey-react-mui/src/ui-shell/WideUiShellContent.tsx
@@ -15,18 +15,19 @@ import { memo, useRef } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 
 import { AppSwitcher } from "./AppSwitcher/index.js";
+import { InnerAppContainer } from "./InnerAppContainer.js";
 import {
   useOdysseyDesignTokens,
   type DesignTokens,
 } from "../OdysseyDesignTokensContext.js";
-import {
-  UiShellNavComponentProps,
-  UiShellContentProps,
-} from "./uiShellContentTypes.js";
 import { SideNav } from "./SideNav/index.js";
 import { TopNav } from "./TopNav/index.js";
 import { useScrollState } from "./useScrollState.js";
 import { useMatchAppElementToUiShellAppArea } from "./useMatchAppElementToUiShellAppArea.js";
+import {
+  UiShellNavComponentProps,
+  UiShellContentProps,
+} from "./uiShellContentTypes.js";
 import { UiShellColors, useUiShellContext } from "./UiShellProvider.js";
 import { emptySideNavItems } from "./uiShellSharedConstants.js";
 
@@ -36,8 +37,9 @@ const StyledAppContainer = styled("div", {
 })<{
   appBackgroundColor?: UiShellColors["appBackgroundColor"];
 }>(({ appBackgroundColor }) => ({
-  gridArea: "app-content",
   backgroundColor: appBackgroundColor,
+  gridArea: "app-content",
+  position: "relative",
 }));
 
 const StyledAppSwitcherContainer = styled("div")({
@@ -195,7 +197,6 @@ const WideUiShellContent = ({
           <ErrorBoundary fallback={null} onError={onError}>
             <TopNav
               {...topNavProps}
-              isScrolled={isContentScrolled}
               leftSideComponent={optionalComponents?.topNavLeftSide}
               rightSideComponent={optionalComponents?.topNavRightSide}
             />
@@ -207,7 +208,9 @@ const WideUiShellContent = ({
         appBackgroundColor={uiShellContext?.appBackgroundColor}
         tabIndex={0}
         ref={uiShellAppAreaRef}
-      />
+      >
+        <InnerAppContainer isContentScrolled={isContentScrolled} />
+      </StyledAppContainer>
     </StyledShellContainer>
   );
 };

--- a/packages/odyssey-react-mui/src/ui-shell/useMatchAppElementToUiShellAppArea.ts
+++ b/packages/odyssey-react-mui/src/ui-shell/useMatchAppElementToUiShellAppArea.ts
@@ -101,12 +101,14 @@ export const useMatchAppElementToUiShellAppArea = ({
             paddingInline: odysseyDesignTokens.Spacing8,
           }
         : {}),
+
       ...(paddingMode === "compact"
         ? {
             paddingBlock: odysseyDesignTokens.Spacing5,
             paddingInline: odysseyDesignTokens.Spacing5,
           }
         : {}),
+
       ...(appElementScrollingMode === "horizontal" ||
       appElementScrollingMode === "both"
         ? {
@@ -115,6 +117,7 @@ export const useMatchAppElementToUiShellAppArea = ({
         : {
             overflowX: "hidden",
           }),
+
       ...(appElementScrollingMode === "vertical" ||
       appElementScrollingMode === "both"
         ? {


### PR DESCRIPTION
This fixes the weird `clip-path` issues that keep appearing

<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[OKTA-876439](https://oktainc.atlassian.net/browse/OKTA-876439)

## Summary

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

Potential fix for an issue we ran into with click events on `clip-path`.

This fix removes `clip-path` entirely..

## Testing & Screenshots

- [X] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
The new one is a bit darker, but it's as close as I could get it.

## Before
![image](https://github.com/user-attachments/assets/ed783c42-047d-4cb6-adbe-6a2a99a4fcef)

## After
![image](https://github.com/user-attachments/assets/8e5f84bd-a79a-4c49-adb6-06cef5aeec4a)