### PR TITLE
fix: empty tables creating scrollbar when table is virtualized

### DIFF
--- a/packages/odyssey-react-mui/src/labs/DataView/TableLayoutContent.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataView/TableLayoutContent.tsx
@@ -400,6 +400,19 @@ const TableLayoutContent = <TData extends MRT_RowData>({
     muiTableBodyProps: () => ({
       className: rowDensityClassName,
       tabIndex: 0,
+      /**
+       * This is a fix for an issue related to the empty state creating a
+       * vertical scrollbar when virtualization is enabled. The root cause
+       * is tablebody having height: 0 when virtualization is enabled and there
+       * being no data
+       * https://okta.slack.com/archives/C7T2H3KNJ/p1742842106148929
+       */
+      sx:
+        isEmpty || isNoResults
+          ? {
+              height: "unset",
+            }
+          : undefined,
     }),
     enableColumnResizing: tableLayoutOptions.hasColumnResizing,
     defaultColumn: {


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

https://oktainc.atlassian.net/browse/OKTA-905097

## Summary

Before:
![image](https://github.com/user-attachments/assets/9aeca24b-ad0e-4221-93bc-6b5b49a0498f)

After:
![image](https://github.com/user-attachments/assets/c768289e-1fd3-4ce3-9dc0-79ef1a0bee17)

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
