### PR TITLE
[UI] [package: odyssey-react-mui] Add box sizing border box to app container element

### DIFF
--- a/packages/odyssey-react-mui/src/ui-shell/useMatchAppElementToUiShellAppArea.ts
+++ b/packages/odyssey-react-mui/src/ui-shell/useMatchAppElementToUiShellAppArea.ts
@@ -50,7 +50,6 @@ export const setStylesToMatchElement = ({
     "height",
     `${appContentReferenceRectangle.height}px`,
   );
-  appContainerElement.style.setProperty("z-index", "1");
 
   (
     Object.entries(additionalStyles) as Array<
@@ -96,6 +95,7 @@ export const useMatchAppElementToUiShellAppArea = ({
   const appContainerElementStyles = useMemo<CSSProperties>(
     () => ({
       boxSizing: "border-box",
+      zIndex: 1,
       ...(paddingMode === "comfortable"
         ? {
             paddingBlock: odysseyDesignTokens.Spacing5,

--- a/packages/odyssey-react-mui/src/ui-shell/useMatchAppElementToUiShellAppArea.ts
+++ b/packages/odyssey-react-mui/src/ui-shell/useMatchAppElementToUiShellAppArea.ts
@@ -95,6 +95,7 @@ export const useMatchAppElementToUiShellAppArea = ({
 
   const appContainerElementStyles = useMemo<CSSProperties>(
     () => ({
+      boxSizing: "border-box",
       ...(paddingMode === "comfortable"
         ? {
             paddingBlock: odysseyDesignTokens.Spacing5,


### PR DESCRIPTION
[OKTA-907628](https://oktainc.atlassian.net/browse/OKTA-907628)

## Summary

When updating SPA to use the Unified Look & Feel UI Shell component there was an issue where the content of the page was overflowing such that the page was extending beyond the visible screen. After debugging with @KevinGhadyani-Okta the issue was identified as the box-sizing property on the app container element needing to be set to border-box.

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.

<img width="1723" alt="before" src="https://github.com/user-attachments/assets/1f6d3a3f-0f76-476f-b319-f5c8b30010eb" />

<img width="1723" alt="after" src="https://github.com/user-attachments/assets/083d0dcb-e24a-4360-9f22-460ad3f51cd8" />