### PR TITLE
feat: Fix name collision issues with renderReactInWebComponent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ __vitest-screenshots/
 
 # Jetbrains
 .idea/
+*.iml
 
 # Lerna
 lerna-debug.log

--- a/packages/odyssey-react-mui/package.json
+++ b/packages/odyssey-react-mui/package.json
@@ -99,7 +99,7 @@
     "generate:icons": "yarn generate:icons:clean && yarn generate:icons:components && yarn generate:icons:index",
     "playwright-install": "NODE_TLS_REJECT_UNAUTHORIZED=0 yarn playwright install --with-deps chromium",
     "test": "NODE_ENV=test vitest run --reporter=default",
-    "generate:wcVersion": "tsx scripts/updateWebComponentVersion.ts",
+    "generate:webComponentVersion": "tsx scripts/updateWebComponentVersion.ts",
     "typecheck": "tsc --noEmit --rootDir ./"
   },
   "repository": {

--- a/packages/odyssey-react-mui/package.json
+++ b/packages/odyssey-react-mui/package.json
@@ -99,6 +99,7 @@
     "generate:icons": "yarn generate:icons:clean && yarn generate:icons:components && yarn generate:icons:index",
     "playwright-install": "NODE_TLS_REJECT_UNAUTHORIZED=0 yarn playwright install --with-deps chromium",
     "test": "NODE_ENV=test vitest run --reporter=default",
+    "generate:wcVersion": "tsx scripts/updateWebComponentVersion.ts",
     "typecheck": "tsc --noEmit --rootDir ./"
   },
   "repository": {

--- a/packages/odyssey-react-mui/scripts/updateWebComponentVersion.ts
+++ b/packages/odyssey-react-mui/scripts/updateWebComponentVersion.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright (c) 2024-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import * as path from "path";
+import { version } from "../package.json" with { type: "json" };
+
+const content = `/*!
+ * Copyright (c) 2024-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+ 
+ /**
+  * DO NOT UPDATE THIS FILE MANUALLY
+  * This file is managed by scripts/updateWebComponentVersion.ts and any changes made will be overwritten
+  * This script only needs to be run during release, and shouldn't be used during local development.
+  */
+export default "${version.replaceAll(".", "-")}";
+`;
+
+const repoPath = path.resolve(fileURLToPath(import.meta.url), "../../");
+const versionFile = path.resolve(
+  repoPath,
+  "src/web-component/odysseyWebComponentVersion.generated.ts",
+);
+await writeFile(versionFile, content, "utf8");

--- a/packages/odyssey-react-mui/scripts/updateWebComponentVersion.ts
+++ b/packages/odyssey-react-mui/scripts/updateWebComponentVersion.ts
@@ -11,7 +11,6 @@
  */
 
 import { writeFile } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
 import * as path from "path";
 import { version } from "../package.json" with { type: "json" };
 
@@ -35,7 +34,7 @@ const content = `/*!
 export default "${version.replaceAll(".", "-")}";
 `;
 
-const repoPath = path.resolve(fileURLToPath(import.meta.url), "../../");
+const repoPath = path.resolve(import.meta.dirname, "../");
 const versionFile = path.resolve(
   repoPath,
   "src/web-component/odysseyWebComponentVersion.generated.ts",

--- a/packages/odyssey-react-mui/src/ui-shell/renderUiShell.browser.test.ts
+++ b/packages/odyssey-react-mui/src/ui-shell/renderUiShell.browser.test.ts
@@ -14,11 +14,11 @@ import { act, waitFor } from "@testing-library/react";
 
 import { renderUiShell } from "./renderUiShell.js";
 import {
-  seleniumAttrName,
+  webComponentDataAttributeName,
   versionedWebComponentName,
 } from "../web-component/renderReactInWebComponent.js";
 import { appRootElementId } from "../web-component/createReactRootElements.js";
-const webComponentSelector = `[${seleniumAttrName}]`;
+const webComponentSelector = `[${webComponentDataAttributeName}]`;
 
 describe(renderUiShell.name, () => {
   afterEach(async () => {

--- a/packages/odyssey-react-mui/src/ui-shell/renderUiShell.browser.test.ts
+++ b/packages/odyssey-react-mui/src/ui-shell/renderUiShell.browser.test.ts
@@ -14,10 +14,11 @@ import { act, waitFor } from "@testing-library/react";
 
 import { renderUiShell } from "./renderUiShell.js";
 import {
-  ReactInWebComponentElement,
-  reactWebComponentElementName,
+  seleniumAttrName,
+  versionedWebComponentName,
 } from "../web-component/renderReactInWebComponent.js";
 import { appRootElementId } from "../web-component/createReactRootElements.js";
+const webComponentSelector = `[${seleniumAttrName}]`;
 
 describe(renderUiShell.name, () => {
   afterEach(async () => {
@@ -76,7 +77,7 @@ describe(renderUiShell.name, () => {
         parentElement,
       });
 
-      expect(uiShellElement).toBeInstanceOf(ReactInWebComponentElement);
+      expect(uiShellElement.elementName).toEqual(versionedWebComponentName);
     });
   });
 
@@ -96,8 +97,7 @@ describe(renderUiShell.name, () => {
 
     expect(
       Array.from(
-        parentElement.querySelector(reactWebComponentElementName)!.shadowRoot!
-          .children,
+        parentElement.querySelector(webComponentSelector)!.shadowRoot!.children,
       ).length,
     ).toBeGreaterThan(0);
   });
@@ -138,7 +138,7 @@ describe(renderUiShell.name, () => {
     await waitFor(() => {
       expect(
         parentElement
-          .querySelector(reactWebComponentElementName)!
+          .querySelector(webComponentSelector)!
           .shadowRoot?.getElementById(appRootElementId),
       ).toHaveTextContent(appName);
     });
@@ -170,7 +170,7 @@ describe(renderUiShell.name, () => {
     await waitFor(() => {
       expect(
         parentElement
-          .querySelector(reactWebComponentElementName)!
+          .querySelector(webComponentSelector)!
           .shadowRoot?.getElementById(appRootElementId),
       ).toHaveTextContent(appName);
     });
@@ -212,7 +212,7 @@ describe(renderUiShell.name, () => {
 
       expect(
         parentElement
-          .querySelector(reactWebComponentElementName)!
+          .querySelector(webComponentSelector)!
           .shadowRoot?.querySelector("[data-error]"),
       ).toBeInstanceOf(HTMLDivElement);
     });

--- a/packages/odyssey-react-mui/src/web-component/odysseyWebComponentVersion.generated.ts
+++ b/packages/odyssey-react-mui/src/web-component/odysseyWebComponentVersion.generated.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright (c) 2024-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+/**
+ * DO NOT UPDATE THIS FILE MANUALLY
+ * This file is managed by scripts/updateWebComponentVersion.ts and any changes made will be overwritten
+ * This script only needs to be run during release, and shouldn't be used during local development.
+ */
+export default "1-35-0";

--- a/packages/odyssey-react-mui/src/web-component/renderReactInWebComponent.browser.test.tsx
+++ b/packages/odyssey-react-mui/src/web-component/renderReactInWebComponent.browser.test.tsx
@@ -13,9 +13,9 @@
 import { waitFor } from "@testing-library/dom";
 
 import {
-  ReactInWebComponentElement,
-  reactWebComponentElementName,
   renderReactInWebComponent,
+  seleniumAttrName,
+  versionedWebComponentName,
 } from "./renderReactInWebComponent.js";
 
 describe(renderReactInWebComponent.name, () => {
@@ -37,8 +37,8 @@ describe(renderReactInWebComponent.name, () => {
     });
 
     await waitFor(() => {
-      expect(reactInWebComponentElement).toBeInstanceOf(
-        ReactInWebComponentElement,
+      expect(reactInWebComponentElement.elementName).toEqual(
+        versionedWebComponentName,
       );
       expect(reactInWebComponentElement.shadowRoot).toBeInstanceOf(ShadowRoot);
       expect(reactInWebComponentElement).toBeInTheDocument();
@@ -80,9 +80,7 @@ describe(renderReactInWebComponent.name, () => {
       webComponentParentElement: rootElement,
     });
 
-    expect(
-      document.querySelectorAll(reactWebComponentElementName),
-    ).toHaveLength(2);
+    expect(document.querySelectorAll(`[${seleniumAttrName}]`)).toHaveLength(2);
   });
 
   test("renders a single element as children of the web component", () => {

--- a/packages/odyssey-react-mui/src/web-component/renderReactInWebComponent.browser.test.tsx
+++ b/packages/odyssey-react-mui/src/web-component/renderReactInWebComponent.browser.test.tsx
@@ -14,7 +14,7 @@ import { waitFor } from "@testing-library/dom";
 
 import {
   renderReactInWebComponent,
-  seleniumAttrName,
+  webComponentDataAttributeName,
   versionedWebComponentName,
 } from "./renderReactInWebComponent.js";
 
@@ -80,7 +80,9 @@ describe(renderReactInWebComponent.name, () => {
       webComponentParentElement: rootElement,
     });
 
-    expect(document.querySelectorAll(`[${seleniumAttrName}]`)).toHaveLength(2);
+    expect(
+      document.querySelectorAll(`[${webComponentDataAttributeName}]`),
+    ).toHaveLength(2);
   });
 
   test("renders a single element as children of the web component", () => {

--- a/packages/odyssey-react-mui/src/web-component/renderReactInWebComponent.ts
+++ b/packages/odyssey-react-mui/src/web-component/renderReactInWebComponent.ts
@@ -25,10 +25,10 @@ interface GetReactWebComponentOptions {
 }
 
 // Used by selenium when selecting for odyssey web components regardless of their name.
-export const seleniumAttrName = "odyssey-react-web-component";
+export const webComponentDataAttributeName = "data-odyssey-react-web-component";
 // Unique name to avoid multiple versions of odyssey overwriting each other's implementations
 export const versionedWebComponentName =
-  `odyssey-react-wc-${version}`.toLowerCase();
+  `odyssey-react-web-component-${version}`.toLowerCase();
 
 const SsrFriendlyHtmlElementClass =
   "HTMLElement" in globalThis
@@ -142,7 +142,7 @@ export const getReactWebComponent = ({
     typeof WebComponentClass
   >;
   // Set selenium attribute so this can be selected
-  element.setAttribute(seleniumAttrName, "");
+  element.setAttribute(webComponentDataAttributeName, "");
   // function used for creating react content
   element.setGetReactComponent(getReactComponent);
   return element;

--- a/packages/odyssey-react-mui/src/web-component/renderReactInWebComponent.ts
+++ b/packages/odyssey-react-mui/src/web-component/renderReactInWebComponent.ts
@@ -35,7 +35,7 @@ const SsrFriendlyHtmlElementClass =
     ? HTMLElement
     : (class {} as unknown as typeof globalThis.HTMLElement);
 
-class WebComponentClass extends SsrFriendlyHtmlElementClass {
+export class WebComponentClass extends SsrFriendlyHtmlElementClass {
   #getReactComponent: GetReactComponentInWebComponent | null = null;
   readonly #reactRootElements: ReactRootElements;
   public readonly elementName: string = this.localName;

--- a/packages/odyssey-react-mui/src/web-component/renderReactInWebComponent.ts
+++ b/packages/odyssey-react-mui/src/web-component/renderReactInWebComponent.ts
@@ -12,56 +12,82 @@
 
 import { type ReactNode } from "react";
 import type { Root } from "react-dom/client";
+import version from "./odysseyWebComponentVersion.generated.js";
 
 import {
   createReactRootElements,
   type ReactRootElements,
 } from "./createReactRootElements.js";
 
-export const reactWebComponentElementName = "odyssey-react-web-component";
+interface GetReactWebComponentOptions {
+  webComponentName?: string;
+  getReactComponent: (reactRootElements: ReactRootElements) => ReactNode;
+}
 
-export type GetReactComponentInWebComponent = (
-  reactRootElements: ReactRootElements,
-) => ReactNode;
+// Used by selenium when selecting for odyssey web components regardless of their name.
+export const seleniumAttrName = "odyssey-react-web-component";
+// Unique name to avoid multiple versions of odyssey overwriting each other's implementations
+export const versionedWebComponentName =
+  `odyssey-react-wc-${version}`.toLowerCase();
 
 const SsrFriendlyHtmlElementClass =
   "HTMLElement" in globalThis
     ? HTMLElement
     : (class {} as unknown as typeof globalThis.HTMLElement);
 
-export class ReactInWebComponentElement extends SsrFriendlyHtmlElementClass {
-  getReactComponent: GetReactComponentInWebComponent;
-  reactRootElements: ReactRootElements;
-  reactRootPromise: Promise<Root | null> = Promise.resolve(null);
+class WebComponentClass extends SsrFriendlyHtmlElementClass {
+  #getReactComponent: GetReactComponentInWebComponent | null = null;
+  readonly #reactRootElements: ReactRootElements;
+  public readonly elementName: string = this.localName;
+  // public for testing
+  public reactRootPromise: Promise<Root | null> = Promise.resolve(null);
 
-  constructor(getReactComponent: GetReactComponentInWebComponent) {
+  constructor() {
     super();
 
-    this.getReactComponent = getReactComponent;
-    this.reactRootElements = createReactRootElements();
+    this.#reactRootElements = createReactRootElements();
+    const { appRootElement, stylesRootElement } = this.#reactRootElements;
 
-    const styleElement = document.createElement("style");
     const shadowRoot = this.attachShadow({ mode: "open" });
+    shadowRoot.appendChild(stylesRootElement);
+    shadowRoot.appendChild(appRootElement);
 
-    styleElement.innerHTML = `
+    const styleHostElement = document.createElement("style");
+    styleHostElement.setAttribute("nonce", window.cspNonce);
+    styleHostElement.innerHTML = `
       :host {
         all: initial;
         contain: content;
       }
     `;
+    stylesRootElement.appendChild(styleHostElement);
+  }
 
-    styleElement.setAttribute("nonce", window.cspNonce);
+  /**
+   * Provides the function used to initialize react content that is specific to this instance
+   * of the web component, which is used later in the connectedCallback.
+   *
+   * Always set immediately after creation via document.createElement
+   */
+  setGetReactComponent(getReactComponent: GetReactComponentInWebComponent) {
+    this.reactRootPromise = this.reactRootPromise.then((reactRoot) => {
+      this.#getReactComponent = getReactComponent;
+      if (reactRoot) {
+        // connectedCallback has already been fired. Need to mount this content to the existing root
+        reactRoot.render(this.#getReactComponent(this.#reactRootElements));
+      } else {
+        // Nothing to do. Content will be mounted when connectedCallback is called
+      }
 
-    this.reactRootElements.stylesRootElement.appendChild(styleElement);
-    shadowRoot.appendChild(this.reactRootElements.stylesRootElement);
-    shadowRoot.appendChild(this.reactRootElements.appRootElement);
+      return reactRoot;
+    });
   }
 
   connectedCallback() {
     this.reactRootPromise = this.reactRootPromise
       .then((reactRoot) => {
         if (reactRoot) {
-          // Shouldn't ever happen
+          // Shouldn't ever happen. connected and disconnected should never be called out of order
           throw new Error(
             `connectedCallback fired when reactRoot is already mounted.`,
           );
@@ -70,11 +96,15 @@ export class ReactInWebComponentElement extends SsrFriendlyHtmlElementClass {
         // Ensure react root is available before mounting
         // If we want to support React v17 in the future, we can use a try-catch on the import to grab the old `ReactDOM.render` function if `react-dom/client` errors. --Kevin Ghadyani
         return import("react-dom/client").then(({ createRoot }) =>
-          createRoot(this.reactRootElements.appRootElement),
+          createRoot(this.#reactRootElements.appRootElement),
         );
       })
       .then((reactRoot) => {
-        reactRoot.render(this.getReactComponent(this.reactRootElements));
+        if (!this.#getReactComponent) {
+          // getReactComponent hasn't been set yet. Content will be mounted once it's set.
+        } else {
+          reactRoot.render(this.#getReactComponent(this.#reactRootElements));
+        }
         return reactRoot;
       });
   }
@@ -95,17 +125,39 @@ export class ReactInWebComponentElement extends SsrFriendlyHtmlElementClass {
   }
 }
 
-if (
-  "customElements" in globalThis &&
-  !customElements.get(reactWebComponentElementName)
-) {
-  customElements.define(
-    reactWebComponentElementName,
-    ReactInWebComponentElement,
-  );
-}
+/**
+ * Returns a constructed web component which manages it's own shadow dom and react dom roots
+ * A custom name can be specified, otherwise a default is provided
+ */
+export const getReactWebComponent = ({
+  webComponentName = versionedWebComponentName,
+  getReactComponent,
+}: GetReactWebComponentOptions) => {
+  // This name hasn't been defined yet. Add a definition for it before constructing one.
+  if (!customElements.get(webComponentName)) {
+    customElements.define(webComponentName, WebComponentClass);
+  }
+
+  const element = document.createElement(webComponentName) as InstanceType<
+    typeof WebComponentClass
+  >;
+  // Set selenium attribute so this can be selected
+  element.setAttribute(seleniumAttrName, "");
+  // function used for creating react content
+  element.setGetReactComponent(getReactComponent);
+  return element;
+};
+
+export type GetReactComponentInWebComponent = (
+  reactRootElements: ReactRootElements,
+) => ReactNode;
 
 export type RenderReactInWebComponentProps = {
+  /**
+   * Optional name given to this web component.
+   * Defaults to a 'odyssey-react-wc-' plus the current odyssey version
+   */
+  webComponentName?: string;
   /**
    * This is a callback function for rendering your React component or app in the Web Component.
    * It gives you access to the Shadow DOM elements if you need them for Odyssey, Emotion, or MUI.
@@ -148,12 +200,16 @@ export type RenderReactInWebComponentProps = {
  * This is useful when global styles are causing conflicts with your React components.
  */
 export const renderReactInWebComponent = ({
+  webComponentName,
   getReactComponent,
   webComponentChildren,
   webComponentParentElement,
   webComponentRootElement,
 }: RenderReactInWebComponentProps) => {
-  const reactElement = new ReactInWebComponentElement(getReactComponent);
+  const reactElement = getReactWebComponent({
+    getReactComponent,
+    webComponentName,
+  });
 
   if (webComponentChildren) {
     (Array.isArray(webComponentChildren)

--- a/packages/odyssey-react-mui/tsconfig.json
+++ b/packages/odyssey-react-mui/tsconfig.json
@@ -11,6 +11,12 @@
     "sourceMap": true,
     "types": ["@vitest/browser/matchers", "vitest/globals"]
   },
-  "include": ["*", "**/src/**/*", "**/properties/**/*", "**/scripts/**/*"],
+  "include": [
+    "*",
+    "**/src/**/*",
+    "**/properties/**/*",
+    "**/scripts/**/*",
+    "package.json"
+  ],
   "exclude": ["**/dist/**/*"]
 }

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -32,6 +32,8 @@ for PATH_AND_FILE in $FILES_TO_UPDATE_VERSION; do
   git update-index --assume-unchanged $FULL_PATH
 done
 
+yarn workspace @okta/odyssey-react-mui generate:wcVersion
+
 echo "Publishing to artifactory"
 if ! lerna_publish; then
   echo "ERROR: Lerna Publish has failed."

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -32,7 +32,7 @@ for PATH_AND_FILE in $FILES_TO_UPDATE_VERSION; do
   git update-index --assume-unchanged $FULL_PATH
 done
 
-yarn workspace @okta/odyssey-react-mui generate:wcVersion
+yarn workspace @okta/odyssey-react-mui generate:webComponentVersion
 
 echo "Publishing to artifactory"
 if ! lerna_publish; then


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

- adds script for generating versioned web component name
This is needed so that different versions of odyssey with 
possibly different web component implementations can coexist
without overwriting eachother.

- add role selector for web component
Allows tests to find the web component without it having a 
consistent name

- add webComponentName parameter
Allows users to define their own web component name if needed.
Defaults to the standard versioned name.

- update web component class to use document.createElement(wcName)
Web component spec indicates that document.createElement and the
`new` style of constructing should be equivalent. As part of that
I removed the getReactComponent function from the constructor 
parameters, since that's not possible with createElement.
Also updates visibility of public/private fields

- add web component version script call to bacon publish script

[OKTA-906754](https://oktainc.atlassian.net/browse/OKTA-906754)

## Summary

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
