### PR TITLE
fix: side nav stuck closed after clicking item in narrow view

### DIFF
--- a/packages/odyssey-react-mui/src/ui-shell/NarrowUiShellContent.tsx
+++ b/packages/odyssey-react-mui/src/ui-shell/NarrowUiShellContent.tsx
@@ -418,6 +418,7 @@ const NarrowUiShellContent = ({
                     isCollapsed={false}
                     isCollapsible={false}
                     isObtrusive
+                    onCollapse={closeSideMenus}
                   />
                 </StyledSideNavContainer>
               </ErrorBoundary>

--- a/packages/odyssey-react-mui/src/ui-shell/SideNav/SideNav.tsx
+++ b/packages/odyssey-react-mui/src/ui-shell/SideNav/SideNav.tsx
@@ -638,10 +638,21 @@ const SideNav = ({
       updateSideNavItemsList(updatedSideNavItems);
 
       if (isCollapsed || isObtrusive) {
-        uiShellContext?.closeSideNavMenu();
+        if (isCollapsible) {
+          uiShellContext?.closeSideNavMenu();
+        } else {
+          onCollapse?.();
+        }
       }
     },
-    [isCollapsed, isObtrusive, sideNavItemsList, uiShellContext],
+    [
+      isCollapsed,
+      isCollapsible,
+      isObtrusive,
+      onCollapse,
+      sideNavItemsList,
+      uiShellContext,
+    ],
   );
 
   const processedSideNavItems = useMemo(() => {

--- a/packages/odyssey-react-mui/src/ui-shell/WideUiShellContent.tsx
+++ b/packages/odyssey-react-mui/src/ui-shell/WideUiShellContent.tsx
@@ -42,7 +42,6 @@ const StyledAppContainer = styled("div", {
 }>(({ appBackgroundColor }) => ({
   backgroundColor: appBackgroundColor,
   gridArea: "app-content",
-  pointerEvents: "none",
   position: "relative",
 }));
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[OKTA-928189](https://oktainc.atlassian.net/browse/OKTA-928189)

## Summary

<!--
  Add a description with these talking points:
  1. Figma link if applicable.
  2. A brief description of the work and why it was done in this particular way.
-->

- Side nav auto-closes in narrow view, and it can be re-opened now. No more collapsing and staying collapsed.

## Testing & Screenshots

- [X] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->

Hard to take a picture. I verified Narrow, Wide w/ collapsed side-nav, and Wide.