### PR TITLE
fix: row indicator issue when no result in DataView

### DIFF
--- a/packages/odyssey-react-mui/src/Pagination/Pagination.tsx
+++ b/packages/odyssey-react-mui/src/Pagination/Pagination.tsx
@@ -202,7 +202,7 @@ const Pagination = ({
   const { totalRowsLabel } = usePagination({
     pageIndex,
     pageSize,
-    currentRowsCount: currentRowsCount || pageSize,
+    currentRowsCount: currentRowsCount || 0,
     totalRows,
   });
 

--- a/packages/odyssey-react-mui/src/Pagination/usePagination.ts
+++ b/packages/odyssey-react-mui/src/Pagination/usePagination.ts
@@ -32,9 +32,12 @@ export const usePagination = ({
     const firstRow = pageSize * (pageIndex - 1) + 1;
     const lastRow = firstRow + (currentRowsCount - 1);
 
-    const totalRowsLabel = totalRows
-      ? t("pagination.rowswithtotal", { firstRow, lastRow, totalRows })
-      : t("pagination.rowswithouttotal", { firstRow, lastRow });
+    const totalRowsLabel =
+      currentRowsCount === 0
+        ? t("pagination.totalrows", { totalRows: 0 })
+        : totalRows
+          ? t("pagination.rowswithtotal", { firstRow, lastRow, totalRows })
+          : t("pagination.rowswithouttotal", { firstRow, lastRow });
 
     return {
       firstRow,

--- a/packages/odyssey-react-mui/src/properties/odyssey-react-mui.properties
+++ b/packages/odyssey-react-mui/src/properties/odyssey-react-mui.properties
@@ -127,6 +127,7 @@ pagination.page = Page
 pagination.rowsperpage = Rows per page
 pagination.rowswithtotal = {{firstRow}}-{{lastRow}} of {{totalRows}} rows
 pagination.rowswithouttotal = {{firstRow}}-{{lastRow}} rows
+pagination.totalrows = {{totalRows}} rows
 table.actions.selectall = Select all
 table.actions.selectnone = Select none
 table.actions.selectsome = {{selectedRowCount}} selected


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[OKTA-903249](https://oktainc.atlassian.net/browse/OKTA-903249)

## Summary

When there's no results, row indicator display incorrect info.

## Testing & Screenshots
Before:
<img width="1311" alt="image" src="https://github.com/user-attachments/assets/5fd61a0a-b24f-4c5e-8480-aabaf7a887da" />

After:
<img width="1322" alt="image" src="https://github.com/user-attachments/assets/125176e7-503e-47b0-8e1c-aa8f50dccf41" />


- [x] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
