### PR TITLE
feat: add initialRowSelection prop to DataTable.tsx

### DIFF
--- a/packages/odyssey-react-mui/src/DataTable/DataTable.tsx
+++ b/packages/odyssey-react-mui/src/DataTable/DataTable.tsx
@@ -92,6 +92,7 @@ export type DataTableGetDataType = {
   search?: string;
   filters?: DataFilter[];
   sort?: MRT_SortingState;
+  rowSelection?: MRT_RowSelectionState;
 };
 
 export type DataTableOnReorderRowsType = {
@@ -823,6 +824,7 @@ const DataTable = ({
           search,
           filters,
           sort: columnSorting,
+          rowSelection,
         });
         setData(incomingData);
       } catch (error) {

--- a/packages/odyssey-react-mui/src/DataTable/DataTable.tsx
+++ b/packages/odyssey-react-mui/src/DataTable/DataTable.tsx
@@ -265,6 +265,11 @@ export type DataTableProps = {
    * The highest page number allowed to be manually input in pagination
    */
   maxPages?: number;
+  /**
+   * Optional intial list of selected rows
+   * Use when row selection is enabled
+   */
+  initialRowSelection?: MRT_RowSelectionState;
 };
 
 const ScrollableTableContainer = styled("div", {
@@ -356,6 +361,7 @@ const DataTable = ({
   rowActionMenuItems,
   searchDelayTime,
   totalRows,
+  initialRowSelection,
 }: DataTableProps) => {
   const { t } = useTranslation();
 
@@ -382,7 +388,7 @@ const DataTable = ({
     useState<MRT_VisibilityState>();
   const [rowDensity, setRowDensity] =
     useState<MRT_DensityState>(initialDensity);
-  const [rowSelection, setRowSelection] = useState<MRT_RowSelectionState>({});
+  const [rowSelection, setRowSelection] = useState<MRT_RowSelectionState>(initialRowSelection || {});
   const [search, setSearch] = useState<string>(initialSearchValue);
   const [filters, setFilters] = useState<DataFilter[]>();
   const [initialFilters, setInitialFilters] = useState<DataFilter[]>();


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

[POKTA-5735](https://oktainc.atlassian.net/browse/POKTA-5735)

## Summary

Adding a new prop that allows you to configure the initially selected rows. This is useful for when you want to render a list of selected items on first render.

## Testing & Screenshots

No visual changes, just functional
