### PR TITLE
fix: update style of empty state in DataView

### DIFF
--- a/packages/odyssey-react-mui/src/EmptyState.tsx
+++ b/packages/odyssey-react-mui/src/EmptyState.tsx
@@ -31,6 +31,12 @@ const EmptyContainer = styled("div", {
   alignItems: "center",
 }));
 
+const TextContainer = styled("div", {
+  shouldForwardProp: (prop) => prop !== "odysseyDesignTokens",
+})<{ odysseyDesignTokens: DesignTokens }>(({ odysseyDesignTokens }) => ({
+  maxWidth: odysseyDesignTokens.TypographyLineLengthMax,
+}));
+
 export type EmptyStateProps = {
   /**
    * Main heading of the empty state
@@ -60,8 +66,10 @@ const EmptyState = ({
 
   return (
     <EmptyContainer odysseyDesignTokens={odysseyDesignTokens}>
-      <Heading4>{heading}</Heading4>
-      <Paragraph>{description}</Paragraph>
+      <TextContainer odysseyDesignTokens={odysseyDesignTokens}>
+        <Heading4>{heading}</Heading4>
+        <Paragraph>{description}</Paragraph>
+      </TextContainer>
       {(PrimaryCallToActionComponent || SecondaryCallToActionComponent) && (
         <Box sx={{ marginBlockStart: 5 }}>
           {SecondaryCallToActionComponent}


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[OKTA-923439](https://oktainc.atlassian.net/browse/OKTA-923439)

## Summary

Update style of empty state of DataView.

## Screenshots
Before:
<img width="999" alt="image" src="https://github.com/user-attachments/assets/41c0fa19-ec8a-4200-825f-5012a12866bf" />


After:
<img width="1005" alt="image" src="https://github.com/user-attachments/assets/e5fbd235-a18a-46f7-a8dc-ba60fbdb5061" />




## Testing & Screenshots

- [ ] I have confirmed this change with my designer and the Odyssey Design Team.
<!-- Please include screenshots if it has visuals; otherwise, put "N/A". -->
