### PR TITLE
feat: external row selection control for DataTable

### DIFF
--- a/packages/odyssey-react-mui/src/DataTable/DataTable.tsx
+++ b/packages/odyssey-react-mui/src/DataTable/DataTable.tsx
@@ -238,6 +238,11 @@ export type DataTableProps = {
    */
   searchDelayTime?: number;
   /**
+   * Allows for external control of the selected row state
+   * use in tandem with onChangeRowSelection to manage your state
+   */
+  selectedRows?: DataTableRowSelectionState;
+  /**
    * Callback that fires when a row (or rows) is selected or unselected.
    */
   onChangeRowSelection?: (rowSelection: DataTableRowSelectionState) => void;
@@ -355,6 +360,7 @@ const DataTable = ({
   rowActionButtons,
   rowActionMenuItems,
   searchDelayTime,
+  selectedRows,
   totalRows,
 }: DataTableProps) => {
   const { t } = useTranslation();
@@ -382,7 +388,6 @@ const DataTable = ({
     useState<MRT_VisibilityState>();
   const [rowDensity, setRowDensity] =
     useState<MRT_DensityState>(initialDensity);
-  const [rowSelection, setRowSelection] = useState<MRT_RowSelectionState>({});
   const [search, setSearch] = useState<string>(initialSearchValue);
   const [filters, setFilters] = useState<DataFilter[]>();
   const [initialFilters, setInitialFilters] = useState<DataFilter[]>();
@@ -391,6 +396,8 @@ const DataTable = ({
   const [errorMessage, setErrorMessage] = useState<string | undefined>(
     errorMessageProp,
   );
+  const [_rowSelection, setRowSelection] = useState<MRT_RowSelectionState>({});
+  const rowSelection = selectedRows || _rowSelection;
 
   useScrollIndication({
     tableOuterContainer: tableOuterContainerRef.current,

--- a/packages/odyssey-react-mui/src/labs/DataView/DataView.tsx
+++ b/packages/odyssey-react-mui/src/labs/DataView/DataView.tsx
@@ -124,6 +124,7 @@ const DataView = <TData extends MRT_RowData>({
   noResultsPlaceholder,
   onChangeRowSelection,
   onReorderRows,
+  onRowSelectionChange,
   paginationType = "paged",
   resultsPerPage = 20,
   searchDelayTime,
@@ -164,6 +165,10 @@ const DataView = <TData extends MRT_RowData>({
   useEffect(() => {
     onChangeRowSelection?.(rowSelection);
   }, [rowSelection, onChangeRowSelection]);
+
+  useEffect(() => {
+    onRowSelectionChange?.(rowSelection);
+  }, [rowSelection, onRowSelectionChange]);
 
   const [pagination, setPagination] = useState({
     pageIndex: currentPage,


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 📓 Ensure each of your commit messages adhere to the conventional commit specification.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn start`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

<!--
Adding a new Odyssey component? Please use the New Component PR template instead.
Uncomment the link below, go to "Preview", and click the link to swap the template.
[🔄 Use new component PR template](?expand=1&template=NEW_COMPONENT_PULL_REQUEST_TEMPLATE.md)
-->

[POKTA-5804](https://oktainc.atlassian.net/browse/POKTA-5804)

## Summary

Allows users to externally control the state of row selection. One case where this is useful when you need to render a table with items pre-selected. This allows users to fully control the selected state. 

## Testing & Screenshots

No visual changes
